### PR TITLE
FEAT: implement ellipse and circle geometries 

### DIFF
--- a/src/ansys/geometry/core/sketch/circle.py
+++ b/src/ansys/geometry/core/sketch/circle.py
@@ -1,4 +1,5 @@
 """``CircleSketch`` class module."""
+from typing import Optional, Union
 
 import numpy as np
 
@@ -9,19 +10,44 @@ from ansys.geometry.core.sketch.curve import SketchCurve
 class CircleSketch(SketchCurve):
     """Provides circle representation within a sketch environment."""
 
-    def __init__(self, points, origin):
-        """Constructor method for ``CircleSketch``."""
+    def __init__(self, points: list[Point2D], origin: Point2D):
+        """Initialize an instance of ``CircleSketch``.
+
+        Parameters
+        ----------
+        points : list[Point2D]
+            A list defining the ellipse.
+        origin : Point2D
+            A ``Point2D`` representing the origin of the ellipse.
+
+        """
         super().__init__(points, origin)
         self._radius = np.linalg.norm(origin - points[0])
 
     @classmethod
-    def from_radius(cls, radius, origin=None, resolution=150):
-        """Create a circle from its radius and center."""
+    def from_radius(
+        cls,
+        radius: Union[int, float],
+        origin: Optional[Point2D] = Point2D([0, 0]),
+        resolution: Optional[int] = 150,
+    ):
+        """Create a circle from its radius and center.
 
-        # Unpack the x and y coordinates for the center point
-        if origin is None:
-            origin = Point2D([0, 0])
+        Parameters
+        ----------
+        radius : int, float
+            The radius of the circle.
+        origin : Point2D
+            A ``Point2D`` representing the origin of the ellipse.
+        resolution : int
+            Number of points to be used when generating points for the ellipse.
 
+        Returns
+        -------
+        CircleSketch
+            An object for modelling circle sketches.
+
+        """
         # Collect the coordinates of the points for the point
         theta = np.linspace(0, 2 * np.pi, resolution)
         x_coords = origin.x + radius * np.cos(theta)

--- a/src/ansys/geometry/core/sketch/curve.py
+++ b/src/ansys/geometry/core/sketch/curve.py
@@ -6,38 +6,62 @@ from ansys.geometry.core.primitives.point import Point2D
 class SketchCurve:
     """Provides base sketch object class all sketch objects."""
 
-    def __init__(self, points: list[Point2D], origin):
+    def __init__(self, points: list[Point2D], origin: Point2D):
         """Initializes the sketch curve from its points.
 
         Parameters
         ----------
         points : list[Point2D]
             A list of points defining the sketch curve.
+        origin : Point2D
+            A ``Point2D`` representing the origin of the ellipse.
 
         """
         self._points = points
         self._origin = origin
 
     @property
-    def points(self):
+    def points(self) -> list[Point2D]:
         """Return a list of ``Point2D`` instances defining the sketch.
 
         Returns
         -------
-        points : list[Point2D]
+        list[Point2D]
             A list of points defining the sketch curve.
 
         """
         return self._points
 
     @property
-    def origin(self):
+    def origin(self) -> Point2D:
+        """Return the origin of the sketch.
+
+        Returns
+        -------
+        Point2D
+            A ``Point2D`` instance representing the center of the sketch curve
+
+        """
         return self._origin
 
     @property
-    def x_coords(self):
+    def x_coords(self) -> list[float]:
+        """Returns the x-coordinates of the sketch curve.
+
+        Returns
+        -------
+        list[float]
+
+        """
         return [point.x for point in self.points]
 
     @property
-    def y_coords(self):
+    def y_coords(self) -> list[float]:
+        """Returns the y-coordinates of the sketch curve.
+
+        Returns
+        -------
+        list[float]
+
+        """
         return [point.y for point in self.points]

--- a/src/ansys/geometry/core/sketch/ellipse.py
+++ b/src/ansys/geometry/core/sketch/ellipse.py
@@ -1,4 +1,5 @@
 """A module containing a class for modeling ellipses."""
+from typing import Optional, Union
 
 import numpy as np
 
@@ -9,20 +10,50 @@ from ansys.geometry.core.sketch.curve import SketchCurve
 class EllipseSketch(SketchCurve):
     """A class for modelling ellipses."""
 
-    def __init__(self, points, origin):
+    def __init__(self, points: list[Point2D], origin: Point2D):
+        """Initialize an instance of ``EllipseSketch``.
+
+        Parameters
+        ----------
+        points : list[Point2D]
+            A list defining the ellipse.
+        origin : Point2D
+            A ``Point2D`` representing the origin of the ellipse.
+
+        """
         super().__init__(points, origin)
 
     @classmethod
-    def from_axes(cls, a, b, origin=None, resolution=150):
-        """Create an ellipse from its semi-major and semi-minor axes."""
+    def from_axes(
+        cls,
+        a: Union[int, float],
+        b: Union[int, float],
+        origin: Optional[Point2D] = Point2D([0, 0]),
+        resolution: Optional[int] = 150,
+    ):
+        """Create an ellipse from its semi-major and semi-minor axes.
+
+        Parameters
+        ----------
+        a : int, float
+            The semi-major axis of the ellipse.
+        b : int, float
+            The semi-minor axis of the ellipse.
+        origin : Point2D
+            A ``Point2D`` representing the origin of the ellipse.
+        resolution : int
+            Number of points to be used when generating points for the ellipse.
+
+        Returns
+        -------
+        EllipseSketch
+            An object for modelling ellipse sketches.
+
+        """
         # Assert that the curve is an ellipse and not a parabola or hyperbola
         ecc = (a**2 - b**2) ** 0.5 / a
         if ecc >= 1:
             raise ValueError("The curve defined is not an ellipse.")
-
-        # Unpack the x and y coordinates for the origin point
-        if origin is None:
-            origin = Point2D([0, 0])
 
         # Generate the points on the ellipse
         theta = np.linspace(0, 2 * np.pi, resolution)
@@ -32,8 +63,3 @@ class EllipseSketch(SketchCurve):
         # Generate all the point instances
         points = [Point2D([x, y]) for x, y in zip(x_coords, y_coords)]
         return cls(points, origin)
-
-    @classmethod
-    def from_focii_and_point(f1, f2, point, origin=None, resolution=100):
-        """Create an ellipse from its focci and a point."""
-        raise NotImplementedError


### PR DESCRIPTION
This branch can be merged once #16 is complete.

Example:

```python
import matplotlib.pyplot as plt

from ansys.geometry.core.sketch.ellipse import EllipseSketch
from ansys.geometry.core.sketch.circle import CircleSketch


ellipse = EllipseSketch.from_axes(5, 2)
circle = CircleSketch.from_radius(2)

fig, ax = plt.subplots()
for sketch, color in zip([ellipse, circle], "rb"):
    ax.plot(sketch.x_coords, sketch.y_coords, "k")
    ax.plot(sketch.x_coords, sketch.y_coords, f"{color}o")
ax.set_aspect("equal")
plt.show()
```

![Figure_2](https://user-images.githubusercontent.com/28702884/187731668-fde8fc0a-07ba-4dc4-ac6e-1b233b58a34b.png)
