### PR TITLE
Fixing breadcrumbs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,7 @@ release = version = "0.1.dev0"
 # Select desired logo, theme, and declare the html title
 html_logo = logo
 html_theme = "ansys_sphinx_theme"
-html_short_title = html_title = "pygeometry"
+html_short_title = html_title = "PyGeometry"
 
 
 # specify the location of your github repo


### PR DESCRIPTION
From

![image](https://user-images.githubusercontent.com/37798125/188611959-fd0ef981-7295-49dc-ba85-04c4152af351.png)


To

![image](https://user-images.githubusercontent.com/37798125/188612605-cfd6f1c9-ee78-42ab-85d9-bf66ab8874dc.png)

Local image based on local packages. Disregard style. Important thing is the breadcrumb for ``PyGeometry``