### PR TITLE
Major bug when building geometries

### DIFF
--- a/src/ansys/geometry/core/connection/conversions.py
+++ b/src/ansys/geometry/core/connection/conversions.py
@@ -93,15 +93,15 @@ def sketch_shapes_to_grpc_geometries(shapes: List[BaseShape]) -> Geometries:
     geometries = Geometries()
     for shape in shapes:
         for component_shape in shape.components:
-            if isinstance(shape, Circle):
+            if isinstance(component_shape, Circle):
                 geometries.circles.append(circle_to_grpc_circle(component_shape))
-            elif isinstance(shape, Segment):
+            elif isinstance(component_shape, Segment):
                 geometries.lines.append(segment_to_grpc_line(component_shape))
-            elif isinstance(shape, Arc):
+            elif isinstance(component_shape, Arc):
                 geometries.arcs.append(arc_to_grpc_arc(component_shape))
-            elif isinstance(shape, Ellipse):
+            elif isinstance(component_shape, Ellipse):
                 geometries.ellipses.append(ellipse_to_grpc_ellipse(component_shape))
-            elif isinstance(shape, Polygon):
+            elif isinstance(component_shape, Polygon):
                 geometries.polygons.append(polygon_to_grpc_polygon(component_shape))
 
     return geometries


### PR DESCRIPTION
When building the ``Geometries`` gRPC message a major bug was identified since we were not checking the correct ``Shape`` objects. This leads to the incorrect instantiation of ``Box`` and ``Slot`` objects.

Fix is required to continue with Seattle script.