### PR TITLE
Change geometry service name in PIM recipe

### DIFF
--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -69,7 +69,7 @@ def launch_remote_modeler(
         )
 
     pim = pypim.connect()
-    instance = pim.create_instance(product_name="discovery-geometry", product_version=version)
+    instance = pim.create_instance(product_name="geometry", product_version=version)
     instance.wait_for_ready()
     channel = instance.build_grpc_channel(
         options=[

--- a/tests/integration/test_remote_launcher.py
+++ b/tests/integration/test_remote_launcher.py
@@ -54,9 +54,7 @@ def test_launch_remote_instance(monkeypatch, modeler: Modeler):
     # Assert: PyGeometry went through the PyPIM workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    mock_client.create_instance.assert_called_with(
-        product_name="discovery-geometry", product_version=None
-    )
+    mock_client.create_instance.assert_called_with(product_name="geometry", product_version=None)
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with(
         options=[


### PR DESCRIPTION
Change product name from `discovery geometry` to `geometry`.