### PR TITLE
Workflow for Python 3.11 not dependent on more stages

### DIFF
--- a/.github/workflows/py311.yml
+++ b/.github/workflows/py311.yml
@@ -16,7 +16,6 @@ jobs:
   py311-smoke-tests:
     name: Python 3.11 compatibility
     runs-on: ${{ matrix.os }}
-    needs: [smoke-tests]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As title says. Workflow failed to run because of this reason