### PR TITLE
Adapting targets to pyansys/actions calls

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -184,7 +184,7 @@ jobs:
           .\.venv\Scripts\Activate.ps1
           python -m pip install --upgrade pip
           pip install --upgrade build wheel
-          pip install .[docs]
+          pip install .[doc]
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           .\.venv\Scripts\Activate.ps1
           pip install --upgrade build
-          pip install .[test]
+          pip install .[tests]
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "pytest==7.2.0",
     "pytest-cov==4.0.0",
 ]
-docs = [
+doc = [
     "ansys-sphinx-theme==0.7.1",
     "ipyvtklink==0.2.3",
     "jupyter_sphinx==0.4.0",

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ basepython =
 setenv =
     PYTHONUNBUFFERED = yes
     coverage: PYTEST_EXTRA_ARGS = --cov=ansys.geometry --cov-report=term --cov-report=xml:.cov/xml --cov-report=html:.cov/html
-extras = test
+extras = tests
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
 
@@ -32,6 +32,6 @@ commands =
 
 [testenv:doc]
 description = Check if documentation generates properly
-extras = docs
+extras = doc
 commands =
     sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml


### PR DESCRIPTION
As title says. Align repository targets to default pyansys/actions calls: ``doc`` and ``tests``. Some of the calls were not being performed correctly.