### PR TITLE
Reorder docs tabs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -102,6 +102,6 @@ PyGeometry is a Python client library for the Ansys Geometry service.
 
    getting_started/index
    user_guide/index
-   examples
    autoapi/index
+   examples
    contributing


### PR DESCRIPTION
As title says. Examples should go after API