### PR TITLE
Replace every "-plane" to "-axis" in all comments

### DIFF
--- a/src/ansys/geometry/core/primitives/circle.py
+++ b/src/ansys/geometry/core/primitives/circle.py
@@ -22,9 +22,9 @@ class Circle:
     radius : Union[Quantity, Distance]
         Radius of the circle.
     reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-plane direction.
+        X-axis direction.
     axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Z-plane direction.
+        Z-axis direction.
     """
 
     @check_input_types

--- a/src/ansys/geometry/core/primitives/cone.py
+++ b/src/ansys/geometry/core/primitives/cone.py
@@ -26,9 +26,9 @@ class Cone:
     half_angle : Union[Quantity, Angle, Real]
         Half angle of the apex, determining the upward angle.
     reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-plane direction.
+        X-axis direction.
     axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Z-plane direction.
+        Z-axis direction.
     """
 
     @check_input_types

--- a/src/ansys/geometry/core/primitives/ellipse.py
+++ b/src/ansys/geometry/core/primitives/ellipse.py
@@ -25,9 +25,9 @@ class Ellipse:
     minor_radius : Union[Quantity, Distance]
         Minor radius of the ellipse.
     reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-plane direction.
+        X-axis direction.
     axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Z-plane direction.
+        Z-axis direction.
     """
 
     @check_input_types

--- a/src/ansys/geometry/core/primitives/sphere.py
+++ b/src/ansys/geometry/core/primitives/sphere.py
@@ -22,9 +22,9 @@ class Sphere:
     radius : Union[Quantity, Distance]
         Radius of the sphere.
     reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-plane direction.
+        X-axis direction.
     axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Z-plane direction.
+        Z-axis direction.
     """
 
     @check_input_types

--- a/src/ansys/geometry/core/primitives/torus.py
+++ b/src/ansys/geometry/core/primitives/torus.py
@@ -19,9 +19,9 @@ class Torus:
     origin : Union[~numpy.ndarray, RealSequence, Point3D],
         Centered origin of the torus.
     direction_x : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-plane direction.
+        X-axis direction.
     direction_y : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Y-plane direction.
+        Y-axis direction.
     major_radius : Real
         Major radius of the torus.
     minor_radius : Real


### PR DESCRIPTION
Updating docstrings for primitive classes that specified "axis" as "planes"