### PR TITLE
Use add_composite plotting API

### DIFF
--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -224,7 +224,7 @@ class Plotter:
         # Use the default PyGeometry add_mesh arguments
         self.__set_add_mesh_defaults(plotting_options)
         dataset = body.tessellate(merge=merge)
-        if isinstance(dataset, pv.MuliBlock):
+        if isinstance(dataset, pv.MultiBlock):
             self.scene.add_composite(dataset, **plotting_options)
         else:
             self.scene.add_mesh(dataset, **plotting_options)


### PR DESCRIPTION
The `tessellate()` method can sometimes return `pyvista.MultiBlock` datasets with thousands of blocks. The internal plotting API here calls that method, often adding each returned element to the plotter with its own actors, mappers, lookup tables, etc -- this has significant performance implications when leveraging the Trame-based client rendering viewer as the scene graph then has tens of thousands of elements which have to be synchronized anytime something changes (e.g., edge visibility).

It is far more performant to use a single actor via PyVista's `add_composite()` plotting API to reduce the scene graph size. See https://docs.pyvista.org/api/plotting/_autosummary/pyvista.Plotter.add_composite.html#add-composite

I made further optimizations upstream in PyVista also to improve the responsiveness of camera controls: https://github.com/pyvista/pyvista/pull/4223

https://github.com/pyvista/pyvista/pull/4223 and this PR should resolve the performance issue seen with Trame that @RobPasMue brought to my attention