### PR TITLE
FEAT: Dropping support for Python 3.7

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         should-release: 
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:

--- a/README.rst
+++ b/README.rst
@@ -244,14 +244,14 @@ archive from the `Releases Page <https://github.com/pyansys/pygeometry/releases>
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PyGeometry from scratch on Windows,
-Linux, and MacOS from Python 3.7 to 3.11. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.8 to 3.11. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.7, unzip the wheelhouse archive and install it with:
+For example, on Linux with Python 3.8, unzip the wheelhouse archive and install it with:
 
 .. code:: bash
 
-    unzip ansys-geometry-core-v0.3.dev0-wheelhouse-Linux-3.7.zip wheelhouse
+    unzip ansys-geometry-core-v0.3.dev0-wheelhouse-Linux-3.8.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you're on Windows with Python 3.9, unzip to a wheelhouse directory and install using the preceding command.

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -8,7 +8,7 @@ or from the `PyGeometry`_ repository on GitHub.
 Package dependencies
 --------------------
 
-PyGeometry is supported on Python version 3.7 and later. As indicated in
+PyGeometry is supported on Python version 3.8 and later. As indicated in
 `Moving to require Python 3 <https://python3statement.org/>`_, previous
 versions of Python are no longer supported. 
 
@@ -79,14 +79,14 @@ archive from the `Releases Page <https://github.com/pyansys/pygeometry/releases>
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PyGeometry from scratch on Windows,
-Linux, and MacOS from Python 3.7 to 3.11. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.8 to 3.11. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.7, unzip the wheelhouse archive and install it with:
+For example, on Linux with Python 3.8, unzip the wheelhouse archive and install it with:
 
 .. code:: bash
 
-    unzip ansys-geometry-core-v0.3.dev0-wheelhouse-Linux-3.7.zip wheelhouse
+    unzip ansys-geometry-core-v0.3.dev0-wheelhouse-Linux-3.8.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you're on Windows with Python 3.9, unzip to a wheelhouse directory and install using the same command as preceding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-geometry-core"
 version = "0.3.dev0"
 description = "A python wrapper for Ansys Geometry service"
 readme = "README.rst"
-requires-python = ">=3.7,<4"
+requires-python = ">=3.8,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 maintainers = [{name = "PyGeometry developers", email = "PyGeometry@ansys.com"}]
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ isolated_build_env = build
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10


### PR DESCRIPTION
No longer needed plus EOL is coming soon. Pinging devs for visibility @chris-hawkins-usa @jonahrb @b-matteo @jorgepiloto @MaxJPRey @Revathyvenugopal162 @LanceX2214 