### PR TITLE
MAINT: update Sphinx to 6.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ doc = [
     "numpydoc==1.5.0",
     "panel==0.14.4",
     "pyvista[trame]==0.38.5",
-    "Sphinx==5.3.0",
+    "Sphinx==6.1.3",
     "sphinx-autoapi==2.1.0",
     "sphinx-autodoc-typehints==1.22.0",
     "sphinx-copybutton==0.5.2",


### PR DESCRIPTION
Bump dependency now that the new ``ansys-sphinx-theme`` supports it