### PR TITLE
feat: adding requests library limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tests = [
     "six==1.16.0",
     "ansys-platform-instancemanagement==1.1.1",
     "docker==6.0.1",
+    "requests==2.29.0",
     "pytest==7.3.1",
     "pytest-cov==4.0.0",
     "pytest-pyvista==0.1.8",
@@ -67,6 +68,7 @@ tests = [
 doc = [
     "ansys-sphinx-theme==0.9.8",
     "docker==6.0.1",
+    "requests==2.29.0",
     "ipyvtklink==0.2.3",
     "jupyter_sphinx==0.4.0",
     "jupytext==1.14.5",


### PR DESCRIPTION
``requests`` library made a new release 2 days ago. Seems like it is being injected in some of our dependencies now, due to flexible resolution. Pinning it down until issues are resolved