### PR TITLE
feat: also test against built images

### DIFF
--- a/.github/workflows/docker_test_build.yml
+++ b/.github/workflows/docker_test_build.yml
@@ -145,14 +145,15 @@ jobs:
           key: pyvista-image-cache-${{ runner.os }}-v-${{ env.RESET_IMAGE_CACHE }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: pyvista-image-cache-${{ runner.os }}-v-${{ env.RESET_IMAGE_CACHE }}
 
-      - name: Install X Virtual Frame Buffer
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xvfb
-
-      - name: Testing
-        run: |
-          xvfb-run pytest -v --service-os=linux --use-existing-service=yes
+      - name: Run pytest
+        uses: ansys/actions/tests-pytest@v4
+        env:
+          ALLOW_PLOTTING: true
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          pytest-extra-args: "--service-os=linux --use-existing-service=yes"
+          checkout: false
+          requires-xvfb: true
 
       - name: Stop the Geometry service
         if: always()


### PR DESCRIPTION
As title says. We should also run our tests against the hand-build docker images