### PR TITLE
feat: Implements simple picker

### DIFF
--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -513,7 +513,14 @@ class PlotterHelper:
                 a.prop.show_edges = False
 
     def picker_callback(self, actor: "pv.Actor") -> None:
-        """Define callback for the element picker."""
+        """
+        Define callback for the element picker.
+
+        Parameters
+        ----------
+        actor : pv.Actor
+            Actor that we are picking.
+        """
         self.reset()
         pt = self._pl.scene.picked_point
         self._actor_object_mapping.keys


### PR DESCRIPTION
Implement the basic functionality of the picker. Still missing which things we want to do when picking, and which elements (full bodies, faces, edges..) we want to pick.

TODO:
- [x] Pick bodies.
- [x] Get body name in the callback.
- [x] Print name in the plotter.

Usage example:
![Recording 2023-08-07 at 11 24 55](https://github.com/ansys/pygeometry/assets/17165476/6a9c3757-ceca-4ea7-a3cd-501de67fbbbf)
