### PR TITLE
fix: Pass sketch to plot instead of polydata

### DIFF
--- a/src/ansys/geometry/core/sketch/sketch.py
+++ b/src/ansys/geometry/core/sketch/sketch.py
@@ -854,7 +854,7 @@ class Sketch:
             )
         else:
             pl_helper = PlotterHelper(use_trame=use_trame).plot(
-                self.sketch_polydata(),
+                self,
                 screenshot=screenshot,
                 view_2d=view_2d_dict,
                 **plotting_options,


### PR DESCRIPTION
Pass sketch to plot instead of polydata, to allow drawing the faces of the sketch with a bit of transparency.