### PR TITLE
changed name according to unified installer

### DIFF
--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ansys.geometry.core.modeler import Modeler
 
 
-WINDOWS_GEOMETRY_SERVICE_FOLDER = "GeometryService"
+WINDOWS_GEOMETRY_SERVICE_FOLDER = "GeometryServices"
 """Default Geometry Service's folder name into the unified installer."""
 
 DISCOVERY_FOLDER = "Discovery"


### PR DESCRIPTION
The folder name was correct as per the unified installer

![Screenshot 2023-09-21 142831](https://github.com/ansys/pyansys-geometry/assets/82146655/10c48ffe-7e94-4d93-96a9-11ec7c98d884)