### PR TITLE
fix: avoid uploading docs assets(wheelhouse) and minor updates to workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -257,6 +257,12 @@ jobs:
           cd doc
           .\make.bat pdf
 
+      - name: Add assets to HTML docs
+        run: |
+          zip -r documentation-html.zip .\doc\_build\html
+          mv documentation-html.zip .\doc\_build\html\_static\assets\download\
+          cp doc/_build/latex/ansys-geometry-core.pdf .\doc\_build\html\_static\assets\download\
+
       - name: Upload HTML documentation
         uses: actions/upload-artifact@v3
         with:
@@ -380,42 +386,6 @@ jobs:
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-  add-assets-to-docs:
-    name: Add downloadable assets to docs
-    needs: [testing-windows, testing-linux, docs]
-    runs-on: ubuntu-latest
-    steps:
-    - name: "Download all artifacts"
-      uses: actions/download-artifact@v3
-      with:
-        path: /tmp/artifacts
-
-    - name: "Compressing HTML docs to ZIP file"
-      run: |
-        zip -r /tmp/artifacts/documentation-html.zip /tmp/artifacts/documentation-html
-
-    - name: "Download HTML documentation"
-      uses: actions/download-artifact@v3
-      with:
-        name: documentation-html
-        path: /tmp/documentation-html
-
-    - name: "Fill the HTML docs with assets"
-      run: |
-        # Move the docs in HTML format
-        mv /tmp/artifacts/documentation-html.zip /tmp/documentation-html/_static/assets/download/
-        # Move the docs in PDF format
-        mv /tmp/artifacts/documentation-pdf/* /tmp/documentation-html/_static/assets/download/
-        # Move the wheelhouses
-        mv /tmp/artifacts/**/*-wheelhouse-*.zip /tmp/documentation-html/_static/assets/download/
-
-    - name: "Upload HTML documentation"
-      uses: actions/upload-artifact@v3
-      with:
-        name: documentation-html
-        path: /tmp/documentation-html
-        retention-days: 7
 
 # =================================================================================================
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -615,7 +585,7 @@ jobs:
   release:
     name: Release project
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [package, add-assets-to-docs, build-windows-container, build-linux-container]
+    needs: [package, build-windows-container, build-linux-container]
     runs-on: ubuntu-latest
     steps:
       - name: Release to the public PyPI repository
@@ -635,7 +605,7 @@ jobs:
     name: Upload dev documentation
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [package, add-assets-to-docs]
+    needs: [package]
     steps:
       - name: Deploy the latest documentation
         uses: ansys/actions/doc-deploy-dev@v4

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -21,6 +21,7 @@ env:
   IS_WORKFLOW_RUNNING: True
   ARTIFACTORY_VERSION: v241
   MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}
+  MEILISEARCH_HOST_URL: ${{ vars.MEILISEARCH_HOST_URL }}
   MEILISEARCH_PUBLIC_API_KEY: ${{ secrets.MEILISEARCH_PUBLIC_API_KEY }}
 
 concurrency:
@@ -653,7 +654,7 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
           index-name: pyansys-geometry-vdev
-          host-url: ${{ vars.MEILISEARCH_HOST_URL }}
+          host-url: ${{ env.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}
 
   upload_docs_release:
@@ -693,5 +694,5 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pyansys-geometry-v${{ env.VERSION_MEILI }}
-          host-url: ${{ vars.MEILISEARCH_HOST_URL }}
+          host-url: ${{ env.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -37,6 +37,7 @@ The following wheelhouse files are available for download:
 .. jinja:: wheelhouse-assets
 
     {%- for os_name, download_links in assets.items() %}
+
     {{ os_name }}
     {{ "^" * os_name|length }}
 

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -34,7 +34,7 @@ Consider installing using a `virtual environment <https://docs.python.org/3/libr
 
 The following wheelhouse files are available for download:
 
-.. jinja:: download-assets
+.. jinja:: wheelhouse-assets
 
     {%- for os_name, download_links in assets.items() %}
     {{ os_name }}

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -34,26 +34,39 @@ Consider installing using a `virtual environment <https://docs.python.org/3/libr
 
 The following wheelhouse files are available for download:
 
-Linux
-^^^^^
+.. jinja:: download-assets
 
-* `Linux wheelhouse for Python 3.8 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-ubuntu-latest-3.8.zip>`_
-* `Linux wheelhouse for Python 3.9 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-ubuntu-latest-3.9.zip>`_
-* `Linux wheelhouse for Python 3.10 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-ubuntu-latest-3.10.zip>`_
-* `Linux wheelhouse for Python 3.11 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-ubuntu-latest-3.11.zip>`_
+    {%- for os_name, download_links in assets.items() %}
+    {{ os_name }}
+    {{ "^" * os_name|length }}
 
-Windows
-^^^^^^^
+    {%- for link in download_links %}
+    * `{{ link.os }} wheelhouse for Python {{ link.python_versions }} <{{ link.prefix_url }}/ansys-geometry-core-{{ link.latest_released_version }}-wheelhouse-{{ link.runner }}-{{ link.python_versions }}.zip>`_
+    {%- endfor %}
 
-* `Windows wheelhouse for Python 3.8 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-windows-latest-3.8.zip>`_
-* `Windows wheelhouse for Python 3.9 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-windows-latest-3.9.zip>`_
-* `Windows wheelhouse for Python 3.10 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-windows-latest-3.10.zip>`_
-* `Windows wheelhouse for Python 3.11 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-windows-latest-3.11.zip>`_
+    {% endfor %}
 
-MacOS
-^^^^^
+Geometry service Docker container assets
+----------------------------------------
 
-* `MacOS wheelhouse for Python 3.8 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-macos-latest-3.8.zip>`_
-* `MacOS wheelhouse for Python 3.9 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-macos-latest-3.9.zip>`_
-* `MacOS wheelhouse for Python 3.10 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-macos-latest-3.10.zip>`_
-* `MacOS wheelhouse for Python 3.11 <_static/assets/download/ansys-geometry-core-v0.4.dev0-wheelhouse-macos-latest-3.11.zip>`_
+Build the latest Geometry service Docker container using the following assets. Instructions
+on how to build the containers are found at `Docker containers <getting_started/docker/index.html>`_.
+
+Currently, the Geometry service backend is mainly delivered as a **Windows** Docker container.
+However, these containers require a Windows machine to run them.
+
+A Linux version of the Geometry service is also available but with limited capabilities,
+meaning that certain operations are not available or fail.
+
+
+Windows container
+^^^^^^^^^^^^^^^^^
+
+* `Latest Geometry service binaries for Windows containers <https://github.com/ansys/pyansys-geometry/releases/latest/download/windows-binaries.zip>`_
+* `Latest Geometry service Dockerfile for Windows containers <https://github.com/ansys/pyansys-geometry/releases/latest/download/windows-dockerfile.zip>`_
+
+Linux container
+^^^^^^^^^^^^^^^
+
+* `Latest Geometry service binaries for Linux containers <https://github.com/ansys/pyansys-geometry/releases/latest/download/linux-binaries.zip>`_
+* `Latest Geometry service Dockerfile for Linux containers <https://github.com/ansys/pyansys-geometry/releases/latest/download/linux-dockerfile.zip>`_

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -44,7 +44,7 @@ The following wheelhouse files are available for download:
     * `{{ link.os }} wheelhouse for Python {{ link.python_versions }} <{{ link.prefix_url }}/ansys-geometry-core-{{ link.latest_released_version }}-wheelhouse-{{ link.runner }}-{{ link.python_versions }}.zip>`_
     {%- endfor %}
 
-    {% endfor %}
+    {%- endfor %}
 
 Geometry service Docker container assets
 ----------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -272,7 +272,7 @@ jinja_contexts = {
     "windows_containers": {
         "add_windows_warnings": True,
     },
-    "download-assets": {"assets": get_wheelhouse_assets_dictionary()},
+    "wheelhouse-assets": {"assets": get_wheelhouse_assets_dictionary()},
 }
 
 


### PR DESCRIPTION
Closes #768

* Avoid uploading wheelhouses to gh-pages branch (hits GitHub storage limit) - related to #764
* Change vars call throughout the workflow to env var (by means of the redefinition of the var to env) - related to #765 