### PR TITLE
Remove staticmethod decorator

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@
 * [Alejandro Fernández](https://github.com/AlejandroFernandezLuces)
 * [Lance Lance](https://github.com/LanceX2214)
 * [Dastan Abdulla](https://github.com/dastan-ansys)
+* [Riccardo Manno](https://github.com/rmanno91)

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -242,7 +242,6 @@ def prepare_and_start_backend(
     )
 
 
-@staticmethod
 def get_available_port():
     """Return an available port to be used."""
     sock = socket.socket()


### PR DESCRIPTION
The method get_available_port is not contained in any calls and decorated with staticmethod therefore it is not callable. Removed