### PR TITLE
fix: download on nested directories not working

### DIFF
--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -231,6 +231,11 @@ class Design(Component):
         if isinstance(file_location, Path):
             file_location = str(file_location)
 
+        # Check if the folder for the file location exists
+        if not Path(file_location).parent.exists():
+            # Create the parent directory
+            Path(file_location).parent.mkdir(parents=True, exist_ok=True)
+
         # Process response
         self._grpc_client.log.debug(f"Requesting design download in {format.value[0]} format.")
         received_bytes = bytes()

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -791,7 +791,7 @@ def test_download_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactor
     design.extrude_sketch(name="MyCylinder", sketch=sketch, distance=Quantity(50, UNITS.mm))
 
     # Download the design
-    file = tmp_path_factory.mktemp("scdoc_files_download") / "cylinder.scdocx"
+    file = tmp_path_factory.mktemp("scdoc_files_download") / "dummy_folder" / "cylinder.scdocx"
     design.download(file)
 
     # Check that the file exists


### PR DESCRIPTION
As reported by @b-matteo and @ansJBoly - when download is requested in an unexisting directory, process failed. This will make sure that the parent directory exists.