### PR TITLE
Interactive pyvista scenes in examples

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto -W --color
+SPHINXOPTS    = -j auto  --color
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -20,7 +20,7 @@
 /* meilisearch.css make the code-block and the result too narrow, here we
  * override the problematic element. There might be a better way to restrict
  * this. */
-.container 
+.container
 {
   display: block !important;
   justify-content: unset !important;

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -17,3 +17,12 @@
 .sd-card .sd-card-footer .sd-card-text {
   max-width: 220px;
 }
+/* meilisearch.css make the code-block and the result too narrow, here we
+ * override the problematic element. There might be a better way to restrict
+ * this. */
+.container 
+{
+  display: block !important;
+  justify-content: unset !important;
+  align-items: unset !important;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,6 +21,8 @@ from ansys.geometry.core import __version__
 
 LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml"]
 
+# Set backend to 'html' to get interactive plots
+os.environ["PYVISTA_JUPYTER_BACKEND"] = 'html'
 
 def get_wheelhouse_assets_dictionary():
     """Auxiliary method to build the wheelhouse assets dictionary."""

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,8 @@ from ansys.geometry.core import __version__
 LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml"]
 
 # Set backend to 'html' to get interactive plots
-os.environ["PYVISTA_JUPYTER_BACKEND"] = 'html'
+os.environ["PYVISTA_JUPYTER_BACKEND"] = "html"
+
 
 def get_wheelhouse_assets_dictionary():
     """Auxiliary method to build the wheelhouse assets dictionary."""


### PR DESCRIPTION
The changes in https://github.com/pyvista/pyvista/pull/4938 may not be easily applicable to the `examples` section  of the `pyansys-geometry` documentation:

`pyvista` uses `sphinx-gallery` along with a  custom scraper for reading the source of  an example from a `.py` file and generating a `.rst`  files that embeds a custom `offlineviewer` directive.

We could convert all examples from jupyter notebooks to  `.py` files and use `pyvista` infrastructure to generate the examples gallery . 

As an alternative we can add a simple snippet after every `plot.show()`   that extracts the scene as `html` and embeds it in the documentation as an `iframe` i.e.

```python
scene = pl.export_html(filename=None)

from IPython.display import display, HTML
html_str = scene.getvalue().replace('"','&quot;')
iframe=f"""
<iframe
    srcdoc="{html_str}"
    width='100%'
    height='500'
</iframe>
"""
HTML(iframe)
```

of course we do not want to show all this code to the user  so, we can use [cell tags](https://myst-nb.readthedocs.io/en/latest/render/hiding.html#hide-cell-contents)  to hide it . See the modified `.mystnb` file.

However, these tags come with a couple of requirements. 
- Switching to the [myst_nb](https://github.com/executablebooks/myst-nb) parser from `jupytext` that is currently being used. I am not sure why. `jupytext` [should](https://jupytext.readthedocs.io/en/latest/formats-markdown.html)  support these tags but in my experiments it does not. Maybe I am missing some configuration.

- The version of `myst_nb` from pypi is incompatible with the dependencies of this project (limits `sphinx` version among others) so we need to install the latest from git. (A new release should come soon see [here](https://github.com/executablebooks/MyST-NB/issues/543) )

With the above caveats here is one example:

https://github.com/ansys/pyansys-geometry/assets/6725596/9d3132fe-f806-49cd-88f2-fa7f96a92543

(remember to start a html server if you try this pull request locally `python -m http.server --directory doc/_build/html`)

@AlejandroFernandezLuces 


