### PR TITLE
Add logs folder as variable to the launcher

### DIFF
--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -282,6 +282,7 @@ def launch_modeler_with_geometry_service(
     enable_trace: bool = False,
     log_level: int = 2,
     timeout: int = 60,
+    logs_folder: str = None,
 ) -> "Modeler":
     """
     Start the Geometry service locally using the ``ProductInstance`` class.
@@ -313,6 +314,8 @@ def launch_modeler_with_geometry_service(
         The default is ``2`` (Warning).
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 60.
+    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+        the backend will use its default path.
 
     Raises
     ------
@@ -354,6 +357,7 @@ def launch_modeler_with_geometry_service(
         log_level=log_level,
         api_version=ApiVersions.LATEST,
         timeout=timeout,
+        logs_folder=logs_folder,
     )
 
 
@@ -363,7 +367,8 @@ def launch_modeler_with_discovery(
     port: int = None,
     log_level: int = 2,
     api_version: ApiVersions = ApiVersions.LATEST,
-    timeout: int = 150,
+    timeout: int = 150,    
+    logs_folder: str = None,
 ):
     """
     Start Ansys Discovery locally using the ``ProductInstance`` class.
@@ -408,6 +413,8 @@ def launch_modeler_with_discovery(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
+    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+        the backend will use its default path.
 
     Raises
     ------
@@ -451,6 +458,7 @@ def launch_modeler_with_discovery(
         log_level=log_level,
         api_version=api_version,
         timeout=timeout,
+        logs_folder=logs_folder,
     )
 
 
@@ -461,6 +469,7 @@ def launch_modeler_with_spaceclaim(
     log_level: int = 2,
     api_version: ApiVersions = ApiVersions.LATEST,
     timeout: int = 150,
+    logs_folder: str = None,
 ):
     """
     Start Ansys SpaceClaim locally using the ``ProductInstance`` class.
@@ -502,6 +511,8 @@ def launch_modeler_with_spaceclaim(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
+    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+        the backend will use its default path.
 
     Raises
     ------
@@ -545,6 +556,7 @@ def launch_modeler_with_spaceclaim(
         log_level=log_level,
         api_version=api_version,
         timeout=timeout,
+        logs_folder=logs_folder,
     )
 
 

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -314,7 +314,7 @@ def launch_modeler_with_geometry_service(
         The default is ``2`` (Warning).
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 60.
-    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+    logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
 
     Raises
@@ -367,7 +367,7 @@ def launch_modeler_with_discovery(
     port: int = None,
     log_level: int = 2,
     api_version: ApiVersions = ApiVersions.LATEST,
-    timeout: int = 150,    
+    timeout: int = 150,
     logs_folder: str = None,
 ):
     """
@@ -413,7 +413,7 @@ def launch_modeler_with_discovery(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
-    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+    logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
 
     Raises
@@ -511,7 +511,7 @@ def launch_modeler_with_spaceclaim(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
-    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+    logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
 
     Raises

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -78,6 +78,9 @@ BACKEND_HOST_VARIABLE = "API_ADDRESS"
 BACKEND_PORT_VARIABLE = "API_PORT"
 """The backend's port number environment variable for local start."""
 
+BACKEND_LOGS_FOLDER_VARIABLE = "ANS_DSCO_REMOTE_LOGS_FOLDER"
+"""The backend's logs folder path to be used."""
+
 BACKEND_API_VERSION_VARIABLE = "API_VERSION"
 """
 The backend's api version environment variable for local start.
@@ -138,6 +141,7 @@ def prepare_and_start_backend(
     log_level: int = 2,
     api_version: ApiVersions = ApiVersions.LATEST,
     timeout: int = 150,
+    logs_folder: str = None,
 ) -> "Modeler":
     """
     Start the requested service locally using the ``ProductInstance`` class.
@@ -176,6 +180,8 @@ def prepare_and_start_backend(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
+    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+        the backend will use its default path.
 
     Raises
     ------
@@ -202,7 +208,8 @@ def prepare_and_start_backend(
         _check_minimal_versions(product_version)
 
     args = []
-    env_copy = _get_common_env(host=host, port=port, enable_trace=enable_trace, log_level=log_level)
+    env_copy = _get_common_env(host=host, port=port, enable_trace=enable_trace, log_level=log_level
+        , logs_folder= logs_folder)
 
     if backend_type == BackendType.DISCOVERY:
         args.append(os.path.join(installations[product_version], DISCOVERY_FOLDER, DISCOVERY_EXE))
@@ -343,7 +350,13 @@ def _check_port_or_get_one(port: int) -> int:
         return get_available_port()
 
 
-def _get_common_env(host: str, port: int, enable_trace: bool, log_level: int) -> Dict[str, str]:
+def _get_common_env(
+    host: str, 
+    port: int, 
+    enable_trace: bool, 
+    log_level: int,
+    logs_folder: str = None,
+    ) -> Dict[str, str]:
     """
     Make a copy of the actual system's environment.
 
@@ -355,5 +368,7 @@ def _get_common_env(host: str, port: int, enable_trace: bool, log_level: int) ->
     env_copy[BACKEND_PORT_VARIABLE] = f"{port}"
     env_copy[BACKEND_TRACE_VARIABLE] = f"{enable_trace:d}"
     env_copy[BACKEND_LOG_LEVEL_VARIABLE] = f"{log_level}"
+    if logs_folder is not None:
+        env_copy[BACKEND_LOGS_FOLDER_VARIABLE] = f"{logs_folder}"
 
     return env_copy

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -180,7 +180,7 @@ def prepare_and_start_backend(
         the latest. Default is ``ApiVersions.LATEST``.
     timeout : int, optional
         Timeout for starting the backend startup process. The default is 150.
-    logs_folder : sets the backend's logs folder path. If nothing is defined, 
+    logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
 
     Raises
@@ -208,8 +208,13 @@ def prepare_and_start_backend(
         _check_minimal_versions(product_version)
 
     args = []
-    env_copy = _get_common_env(host=host, port=port, enable_trace=enable_trace, log_level=log_level
-        , logs_folder= logs_folder)
+    env_copy = _get_common_env(
+        host=host,
+        port=port,
+        enable_trace=enable_trace,
+        log_level=log_level,
+        logs_folder=logs_folder,
+    )
 
     if backend_type == BackendType.DISCOVERY:
         args.append(os.path.join(installations[product_version], DISCOVERY_FOLDER, DISCOVERY_EXE))
@@ -351,12 +356,12 @@ def _check_port_or_get_one(port: int) -> int:
 
 
 def _get_common_env(
-    host: str, 
-    port: int, 
-    enable_trace: bool, 
+    host: str,
+    port: int,
+    enable_trace: bool,
     log_level: int,
     logs_folder: str = None,
-    ) -> Dict[str, str]:
+) -> Dict[str, str]:
     """
     Make a copy of the actual system's environment.
 


### PR DESCRIPTION
These changes allows to specify another logs folder for the ApiServer, different from the default one. 