### PR TITLE
Feat/launcher hidden mode

### DIFF
--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -370,6 +370,7 @@ def launch_modeler_with_discovery(
     timeout: int = 150,
     manifest_path: str = None,
     logs_folder: str = None,
+    hidden: bool = False,
 ):
     """
     Start Ansys Discovery locally using the ``ProductInstance`` class.
@@ -420,6 +421,7 @@ def launch_modeler_with_discovery(
         version.
     logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
+    hidden : starts the product hiding its UI. Default is ``False``.
 
     Raises
     ------
@@ -465,6 +467,7 @@ def launch_modeler_with_discovery(
         timeout=timeout,
         manifest_path=manifest_path,
         logs_folder=logs_folder,
+        hidden = hidden,
     )
 
 
@@ -477,6 +480,7 @@ def launch_modeler_with_spaceclaim(
     timeout: int = 150,
     manifest_path: str = None,
     logs_folder: str = None,
+    hidden: bool = False,
 ):
     """
     Start Ansys SpaceClaim locally using the ``ProductInstance`` class.
@@ -524,6 +528,7 @@ def launch_modeler_with_spaceclaim(
         version.
     logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
+    hidden : starts the product hiding its UI. Default is ``False``.
 
     Raises
     ------
@@ -569,6 +574,7 @@ def launch_modeler_with_spaceclaim(
         timeout=timeout,
         manifest_path=manifest_path,
         logs_folder=logs_folder,
+        hidden = hidden,
     )
 
 

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -467,7 +467,7 @@ def launch_modeler_with_discovery(
         timeout=timeout,
         manifest_path=manifest_path,
         logs_folder=logs_folder,
-        hidden = hidden,
+        hidden=hidden,
     )
 
 
@@ -574,7 +574,7 @@ def launch_modeler_with_spaceclaim(
         timeout=timeout,
         manifest_path=manifest_path,
         logs_folder=logs_folder,
-        hidden = hidden,
+        hidden=hidden,
     )
 
 

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -116,12 +116,13 @@ The argument to hide Discovery's UI on the backend.
 To be used only with Ansys Discovery.
 """
 
-BACKEND_SPLASH_OFF = '/Splash=False'
+BACKEND_SPLASH_OFF = "/Splash=False"
 """
 The argument to specify the backend's addin manifest file's path.
 
 To be used only with Ansys Discovery and Ansys SpaceClaim.
 """
+
 
 class ProductInstance:
     """

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -102,6 +102,26 @@ The argument to specify the backend's addin manifest file's path.
 To be used only with Ansys Discovery and Ansys SpaceClaim.
 """
 
+BACKEND_SPACECLAIM_HIDDEN = "/Headless=True"
+"""
+The argument to hide SpaceClaim's UI on the backend.
+
+To be used only with Ansys SpaceClaim.
+"""
+
+BACKEND_DISCOVERY_HIDDEN = "--hidden"
+"""
+The argument to hide Discovery's UI on the backend.
+
+To be used only with Ansys Discovery.
+"""
+
+BACKEND_SPLASH_OFF = '/Splash=False'
+"""
+The argument to specify the backend's addin manifest file's path.
+
+To be used only with Ansys Discovery and Ansys SpaceClaim.
+"""
 
 class ProductInstance:
     """
@@ -143,6 +163,7 @@ def prepare_and_start_backend(
     timeout: int = 150,
     manifest_path: str = None,
     logs_folder: str = None,
+    hidden: bool = False,
 ) -> "Modeler":
     """
     Start the requested service locally using the ``ProductInstance`` class.
@@ -187,6 +208,7 @@ def prepare_and_start_backend(
         version. Only applicable for Ansys Discovery and Ansys SpaceClaim.
     logs_folder : sets the backend's logs folder path. If nothing is defined,
         the backend will use its default path.
+    hidden : starts the product hiding its UI. Default is ``False``.
 
     Raises
     ------
@@ -223,6 +245,10 @@ def prepare_and_start_backend(
 
     if backend_type == BackendType.DISCOVERY:
         args.append(os.path.join(installations[product_version], DISCOVERY_FOLDER, DISCOVERY_EXE))
+        if hidden is True:
+            args.append(BACKEND_DISCOVERY_HIDDEN)
+
+        # Here begins the spaceclaim arguments.
         args.append(BACKEND_SPACECLAIM_OPTIONS)
         args.append(
             BACKEND_ADDIN_MANIFEST_ARGUMENT
@@ -231,6 +257,9 @@ def prepare_and_start_backend(
         env_copy[BACKEND_API_VERSION_VARIABLE] = str(api_version)
     elif backend_type == BackendType.SPACECLAIM:
         args.append(os.path.join(installations[product_version], SPACECLAIM_FOLDER, SPACECLAIM_EXE))
+        if hidden is True:
+            args.append(BACKEND_SPACECLAIM_HIDDEN)
+            args.append(BACKEND_SPLASH_OFF)
         args.append(
             BACKEND_ADDIN_MANIFEST_ARGUMENT
             + _manifest_path_provider(product_version, installations, manifest_path)

--- a/tests/integration/test_launcher_product.py
+++ b/tests/integration/test_launcher_product.py
@@ -91,6 +91,7 @@ def test_product_launch_with_parameters():
         log_level=random.randint(0, 3),
         api_version=apiVersions[random.randint(0, len(apiVersions) - 1)].value,
         timeout=180,
+        hidden=True,
     )
 
     modeler_spaceclaim = launch_modeler_with_spaceclaim(
@@ -99,6 +100,7 @@ def test_product_launch_with_parameters():
         log_level=random.randint(0, 3),
         api_version=apiVersions[random.randint(0, len(apiVersions) - 1)].value,
         timeout=180,
+        hidden=True,
     )
 
     assert modeler_geo_service != None


### PR DESCRIPTION
The goal here is to be able to use PyAnsys-Geometry to start local Ansys Discovery or Ansys SpaceClaim session in hidden mode.
Meaning that the backend's UI will be hidden.