### PR TITLE
Refactoring repair tools

### DIFF
--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -37,48 +37,49 @@ def skip_if_linux(modeler: Modeler):
 def test_find_split_edges(modeler: Modeler):
     """Test if split edge problem areas are detectable."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
-    problem_areas = modeler.repair_tools.find_split_edges(["0:39"], 25, 150)
+    design = modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
+    problem_areas = modeler.repair_tools.find_split_edges(design.bodies, 25, 150)
     assert len(problem_areas) == 3
 
 
 def test_find_split_edge_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
-    problem_areas = modeler.repair_tools.find_split_edges(["0:39"], 25, 150)
+    design = modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
+    problem_areas = modeler.repair_tools.find_split_edges(design.bodies, 25, 150)
     assert problem_areas[0].id > 0
 
 
 def test_find_split_edge_edges(modeler: Modeler):
     """Test to find split edge problem areas with the connected edges."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
-    problem_areas = modeler.repair_tools.find_split_edges(["0:39"], 25, 150)
+    design = modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
+    problem_areas = modeler.repair_tools.find_split_edges(design.bodies, 25, 150)
     assert len(problem_areas[0].edges) > 0
 
 
 def test_fix_split_edge(modeler: Modeler):
     """Test to find and fix split edge problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
-    problem_areas = modeler.repair_tools.find_split_edges(["0:39"], 25, 150)
+    design = modeler.open_file("./tests/integration/files/SplitEdgeDesignTest.scdocx")
+    problem_areas = modeler.repair_tools.find_split_edges(design.bodies, 25, 150)
     assert problem_areas[0].fix().success
 
 
 def test_find_extra_edges(modeler: Modeler):
     """Test to read geometry and find it's extra edge problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_extra_edges(["0:22"])
+    design = modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
+
+    problem_areas = modeler.repair_tools.find_extra_edges(design.bodies)
     assert len(problem_areas) == 1
 
 
 def test_find_extra_edge_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_extra_edges(["0:22"])
+    design = modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_extra_edges(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -86,24 +87,24 @@ def test_find_extra_edge_edges(modeler: Modeler):
     """Test to read geometry and find it's extra edge problem area with connected
     edges."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_extra_edges(["0:22"])
+    design = modeler.open_file("./tests/integration/files/ExtraEdgesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_extra_edges(design.bodies)
     assert len(problem_areas[0].edges) > 0
 
 
 def test_find_inexact_edges(modeler: Modeler):
     """Test to read geometry and find it's inexact edge problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_inexact_edges(["0:38"])
-    assert len(problem_areas) == 12
+    design = modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_inexact_edges(design.bodies)
+    assert len(problem_areas) == 6
 
 
 def test_find_inexact_edge_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_inexact_edges(["0:38"])
+    design = modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_inexact_edges(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -111,32 +112,32 @@ def test_find_inexact_edge_edges(modeler: Modeler):
     """Test to read geometry and find it's inexact edge problem areas with connected
     edges."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_inexact_edges(["0:38"])
+    design = modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_inexact_edges(design.bodies)
     assert len(problem_areas[0].edges) > 0
 
 
 def test_fix_inexact_edge(modeler: Modeler):
     """Test to read geometry and find and fix it's inexact edge problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_inexact_edges(["0:38"])
+    design = modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_inexact_edges(design.bodies)
     assert problem_areas[0].fix().success
 
 
 def test_find_missing_faces(modeler: Modeler):
     """Test to read geometry and find it's missing face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_missing_faces(["1:40"])
+    design = modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_missing_faces(design.bodies)
     assert len(problem_areas) == 1
 
 
 def test_find_missing_face_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_missing_faces(["1:40"])
+    design = modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_missing_faces(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -144,32 +145,32 @@ def test_find_missing_face_faces(modeler: Modeler):
     """Test to read geometry and find it's missing face problem area with connected
     edges."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_missing_faces(["1:40"])
+    design = modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_missing_faces(design.bodies)
     assert len(problem_areas[0].edges) > 0
 
 
 def test_fix_missing_face(modeler: Modeler):
     """Test to read geometry and find and fix it's missing face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_missing_faces(["1:40"])
+    design = modeler.open_file("./tests/integration/files/MissingFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_missing_faces(design.bodies)
     assert problem_areas[0].fix().success
 
 
 def test_find_duplicate_faces(modeler: Modeler):
     """Test to read geometry and find it's duplicate face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_duplicate_faces(["0:22", "0:85"])
+    design = modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_duplicate_faces(design.bodies)
     assert len(problem_areas) == 1
 
 
 def test_duplicate_face_id(modeler: Modeler):
     """Test whether duplicate face problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_duplicate_faces(["0:22", "0:85"])
+    design = modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_duplicate_faces(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -177,32 +178,32 @@ def test_duplicate_face_faces(modeler: Modeler):
     """Test to read geometry and find it's duplicate face problem area and its connected
     faces."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_duplicate_faces(["0:22", "0:85"])
+    design = modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_duplicate_faces(design.bodies)
     assert len(problem_areas[0].faces) > 0
 
 
 def test_fix_duplicate_face(modeler: Modeler):
     """Test to read geometry and find and fix it's duplicate face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_duplicate_faces(["0:22", "0:85"])
+    design = modeler.open_file("./tests/integration/files/DuplicateFacesDesignBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_duplicate_faces(design.bodies)
     assert problem_areas[0].fix().success
 
 
 def test_find_small_faces(modeler: Modeler):
     """Test to read geometry and find it's small face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_small_faces(["0:38"])
+    design = modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert len(problem_areas) == 4
 
 
 def test_find_small_face_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_small_faces(["0:38"])
+    design = modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -210,40 +211,38 @@ def test_find_small_face_faces(modeler: Modeler):
     """Test to read geometry, find it's small face problem area and return connected
     faces."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_small_faces(["0:38"])
+    design = modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert len(problem_areas[0].faces) > 0
 
 
 def test_fix_small_face(modeler: Modeler):
     """Test to read geometry and find and fix it's small face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
-    problem_areas = modeler.repair_tools.find_small_faces(["0:38"])
+    design = modeler.open_file("./tests/integration/files/SmallFacesBefore.scdocx")
+    problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert problem_areas[0].fix().success > 0
 
 
 def test_find_stitch_faces(modeler: Modeler):
     """Test to read geometry and find it's stitch face problem areas."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/stitch_before.scdocx")
-    design = modeler.read_existing_design()
+    design = modeler.open_file("./tests/integration/files/stitch_before.scdocx")
     face_ids = []
     for body in design.bodies:
         face_ids.append(body.id)
-    problem_areas = modeler.repair_tools.find_stitch_faces(face_ids)
+    problem_areas = modeler.repair_tools.find_stitch_faces(design.bodies)
     assert len(problem_areas) == 1
 
 
 def test_find_stitch_face_id(modeler: Modeler):
     """Test whether problem area has the id."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/stitch_before.scdocx")
-    design = modeler.read_existing_design()
+    design = modeler.open_file("./tests/integration/files/stitch_before.scdocx")
     face_ids = []
     for body in design.bodies:
         face_ids.append(body.id)
-    problem_areas = modeler.repair_tools.find_stitch_faces(face_ids)
+    problem_areas = modeler.repair_tools.find_stitch_faces(design.bodies)
     assert problem_areas[0].id > 0
 
 
@@ -251,24 +250,19 @@ def test_find_stitch_face_faces(modeler: Modeler):
     """Test to read geometry and find it's stitch face problem area and return the
     connected faces."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/stitch_before.scdocx")
-    design = modeler.read_existing_design()
+    design = modeler.open_file("./tests/integration/files/stitch_before.scdocx")
     face_ids = []
     for body in design.bodies:
         face_ids.append(body.id)
-    problem_areas = modeler.repair_tools.find_stitch_faces(face_ids)
+    problem_areas = modeler.repair_tools.find_stitch_faces(design.bodies)
     assert len(problem_areas[0].faces) > 0
 
 
 def test_fix_stitch_face(modeler: Modeler):
     """Test to read geometry, find the split edge problem areas and to fix them."""
     skip_if_linux(modeler)  # Skip test on Linux
-    modeler.open_file("./tests/integration/files/stitch_before.scdocx")
-    design = modeler.read_existing_design()
-    face_ids = []
-    for body in design.bodies:
-        face_ids.append(body.id)
-    problem_areas = modeler.repair_tools.find_stitch_faces(face_ids)
+    design = modeler.open_file("./tests/integration/files/stitch_before.scdocx")
+    problem_areas = modeler.repair_tools.find_stitch_faces(design.bodies)
     message = problem_areas[0].fix()
     assert message.success == True
     assert len(message.created_bodies) == 0

--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -97,7 +97,7 @@ def test_find_inexact_edges(modeler: Modeler):
     skip_if_linux(modeler)  # Skip test on Linux
     design = modeler.open_file("./tests/integration/files/InExactEdgesBefore.scdocx")
     problem_areas = modeler.repair_tools.find_inexact_edges(design.bodies)
-    assert len(problem_areas) == 6
+    assert len(problem_areas) == 12
 
 
 def test_find_inexact_edge_id(modeler: Modeler):


### PR DESCRIPTION
instead of exposing body id strings, repair tool methods are working with body objects directly.. 