### PR TITLE
fix: Add default dict to `run_discovery_script_file` 

### DIFF
--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -304,7 +304,7 @@ class Modeler:
 
     @protect_grpc
     def run_discovery_script_file(
-        self, file_path: str, script_args: Dict[str, str], import_design=False
+        self, file_path: str, script_args: Dict[str, str] = {}, import_design=False
     ) -> Tuple[Dict[str, str], Optional["Design"]]:
         """
         Run a Discovery script file.

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -319,13 +319,13 @@ class Modeler:
         file_path : str
             Path of the file. The extension of the file must be included.
         script_args : Optional[Dict[str, str]], optional.
-            Arguments to pass to the script. By default, ``None``
+            Arguments to pass to the script. By default, ``None``.
         import_design : bool, optional.
             Whether to refresh the current design from the service. When the script
             is expected to modify the existing design, set this to ``True`` to retrieve
             up-to-date design data. When this is set to ``False`` (default) and the
             script modifies the current design, the design may be out-of-sync. By default,
-            ``False``
+            ``False``.
 
         Returns
         -------

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -304,7 +304,7 @@ class Modeler:
 
     @protect_grpc
     def run_discovery_script_file(
-        self, file_path: str, script_args: Dict[str, str] = None, import_design=False
+        self, file_path: str, script_args: Optional[Dict[str, str]] = None, import_design=False
     ) -> Tuple[Dict[str, str], Optional["Design"]]:
         """
         Run a Discovery script file.
@@ -318,13 +318,13 @@ class Modeler:
         ----------
         file_path : str
             Path of the file. The extension of the file must be included.
-        script_args : dict[str, str]
-            Arguments to pass to the script.
-        import_design : bool, default: False
+        script_args : dict[str, str], optional.
+            Arguments to pass to the script. By default, `None`
+        import_design : bool, optional.
             Whether to refresh the current design from the service. When the script
             is expected to modify the existing design, set this to ``True`` to retrieve
             up-to-date design data. When this is set to ``False`` (default) and the
-            script modifies the current design, the design may be out-of-sync.
+            script modifies the current design, the design may be out-of-sync. By default, `False`
 
         Returns
         -------

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -324,7 +324,8 @@ class Modeler:
             Whether to refresh the current design from the service. When the script
             is expected to modify the existing design, set this to ``True`` to retrieve
             up-to-date design data. When this is set to ``False`` (default) and the
-            script modifies the current design, the design may be out-of-sync. By default, `False`
+            script modifies the current design, the design may be out-of-sync. By default,
+            ``False``
 
         Returns
         -------

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -304,7 +304,7 @@ class Modeler:
 
     @protect_grpc
     def run_discovery_script_file(
-        self, file_path: str, script_args: Dict[str, str] = {}, import_design=False
+        self, file_path: str, script_args: Dict[str, str] = None, import_design=False
     ) -> Tuple[Dict[str, str], Optional["Design"]]:
         """
         Run a Discovery script file.

--- a/tests/integration/test_runscript.py
+++ b/tests/integration/test_runscript.py
@@ -33,9 +33,8 @@ from ansys.geometry.core.sketch import Sketch
 
 # Python (.py)
 def test_python_simple_script(modeler: Modeler, skip_not_on_linux_service):
-    args = {}
     result = modeler.run_discovery_script_file(
-        "./tests/integration/files/disco_scripts/simple_script.py", args
+        "./tests/integration/files/disco_scripts/simple_script.py"
     )
     pattern_db = re.compile(r"SpaceClaim\.Api\.[A-Za-z0-9]+\.DesignBody", re.IGNORECASE)
     pattern_doc = re.compile(r"SpaceClaim\.Api\.[A-Za-z0-9]+\.Document", re.IGNORECASE)
@@ -45,10 +44,9 @@ def test_python_simple_script(modeler: Modeler, skip_not_on_linux_service):
 
 
 def test_python_failing_script(modeler: Modeler, skip_not_on_linux_service):
-    args = {}
     with pytest.raises(GeometryRuntimeError):
         modeler.run_discovery_script_file(
-            "./tests/integration/files/disco_scripts/failing_script.py", args
+            "./tests/integration/files/disco_scripts/failing_script.py"
         )
 
 
@@ -73,9 +71,8 @@ def test_python_integrated_script(modeler: Modeler, skip_not_on_linux_service):
 
 # SpaceClaim (.scscript)
 def test_scscript_simple_script(modeler: Modeler, skip_not_on_linux_service):
-    args = {}
     result = modeler.run_discovery_script_file(
-        "./tests/integration/files/disco_scripts/simple_script.scscript", args
+        "./tests/integration/files/disco_scripts/simple_script.scscript"
     )
     assert len(result) == 2
     pattern_db = re.compile(r"SpaceClaim\.Api\.[A-Za-z0-9]+\.DesignBody", re.IGNORECASE)
@@ -87,9 +84,8 @@ def test_scscript_simple_script(modeler: Modeler, skip_not_on_linux_service):
 
 # Discovery (.dscript)
 def test_dscript_simple_script(modeler: Modeler, skip_not_on_linux_service):
-    args = {}
     result = modeler.run_discovery_script_file(
-        "./tests/integration/files/disco_scripts/simple_script.dscript", args
+        "./tests/integration/files/disco_scripts/simple_script.dscript"
     )
     assert len(result) == 2
     pattern_db = re.compile(r"SpaceClaim\.Api\.[A-Za-z0-9]+\.DesignBody", re.IGNORECASE)


### PR DESCRIPTION
Defaults `script_args` to `{}`.

Closes  #870 