### PR TITLE
Get active design

### DIFF
--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -179,6 +179,8 @@ class Modeler:
             if self._designs[key]._is_active:
                 return self._designs[key]
 
+        return None
+
     def read_existing_design(self) -> "Design":
         """
         Read the existing design on the service with the connected client.

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -166,6 +166,19 @@ class Modeler:
             )
         return self._designs[design.design_id]
 
+    def get_active_design(self) -> "Design":
+        """
+        Get the active design on the modeler object.
+
+        Returns
+        -------
+        Design
+            Design object already existing on the modeler.
+        """
+        for key, _ in self._designs.items():
+            if self._designs[key]._is_active:
+                return self._designs[key]
+
     def read_existing_design(self) -> "Design":
         """
         Read the existing design on the service with the connected client.


### PR DESCRIPTION
Currently there is no method the get active design other than read_existing_design() which creates a new design object and returns it. With this method we can get the active design on the modeler.