### PR TITLE
fix: update pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.2.6
+  rev: v0.2.8
   hooks:
     - id: add-license-headers
 


### PR DESCRIPTION
As title says - current version is broken due to Reuse release