### PR TITLE
docs: single column on phone docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@ PyAnsys Geometry documentation |version|
 
 PyAnsys Geometry is a Python client library for the Ansys Geometry service.
 
-.. grid:: 2
+.. grid:: 1 2 2 2
 
 
     .. grid-item-card:: Getting started :fa:`person-running`


### PR DESCRIPTION
On phone docs for the landing page look off. This should fix it.