### PR TITLE
doc: update to sphinx-autoapi==3.1.0a2 version

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,31 +13,24 @@ help:
 
 .PHONY: help Makefile
 
-.install-deps:
-	@pip freeze | grep -q "sphinx-autoapi @ git+https://github.com/ansys/sphinx-autoapi" && is_custom_sphinx_autoapi_installed="yes" || is_custom_sphinx_autoapi_installed="no"
-	@if [ "$$is_custom_sphinx_autoapi_installed" != "yes" ]; then \
-		pip uninstall --yes sphinx-autoapi; \
-		pip install "sphinx-autoapi @ git+https://github.com/ansys/sphinx-autoapi@feat/single-page-stable"; \
-	fi
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: .install-deps Makefile
+%: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Customized clean due to examples gallery
-clean: .install-deps
+clean:
 	rm -rf $(BUILDDIR)/*
 	find . -type d -name "api" -exec rm -rf {} +
 
 # Create PDF
-pdf: .install-deps
+pdf:
 	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd $(BUILDDIR)/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
 	(test -f $(BUILDDIR)/latex/*.pdf && echo pdf exists) || exit 1
 
 # Build HTML files and generate examples as .py files
-html: .install-deps
+html:
 	@$(SPHINXBUILD) -M linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd $(BUILDDIR)/html/examples

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    = -j auto -W --color
 SPHINXBUILD   = sphinx-build
+APIDIR        = api
 SOURCEDIR     = source
 BUILDDIR      = _build
 
@@ -21,7 +22,7 @@ help:
 # Customized clean due to examples gallery
 clean:
 	rm -rf $(BUILDDIR)/*
-	find . -type d -name "api" -exec rm -rf {} +
+	find . -type d -name $(APIDIR) -exec rm -rf {} +
 
 # Create PDF
 pdf:
@@ -33,6 +34,7 @@ pdf:
 html:
 	@$(SPHINXBUILD) -M linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	# TODO: migrate this logic as a sphinx-hook declared in the conf.py file
 	cd $(BUILDDIR)/html/examples
 	for d in */ ; do
 		cd $d

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -11,6 +11,7 @@ if "%SPHINXOPTS%" == "" (
 	set SPHINXOPTS=-j auto -W --color
 )
 set SOURCEDIR=source
+set APIDIR=api
 set BUILDDIR=_build
 
 if "%1" == "" goto help
@@ -41,7 +42,7 @@ goto build-examples-py
 
 :clean
 rmdir /s /q %BUILDDIR% > /NUL 2>&1
-for /d /r %SOURCEDIR% %%d in (api) do @if exist "%%d" rmdir /s /q "%%d"
+for /d /r %SOURCEDIR% %%d in (%APIDIR) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 
 :help

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -13,13 +13,6 @@ if "%SPHINXOPTS%" == "" (
 set SOURCEDIR=source
 set BUILDDIR=_build
 
-REM TODO: these lines of code should be removed once the feature branch is merged
-for /f %%i in ('pip freeze ^| findstr /c:"sphinx-autoapi @ git+https://github.com/ansys/sphinx-autoapi"') do set is_custom_sphinx_autoapi_installed=%%i
-if NOT "%is_custom_sphinx_autoapi_installed%" == "sphinx-autoapi" (
-	pip uninstall --yes sphinx-autoapi
-	pip install "sphinx-autoapi @ git+https://github.com/ansys/sphinx-autoapi@feat/single-page-stable")
-REM TODO: these lines of code should be removed once the feature branch is merged
-
 if "%1" == "" goto help
 if "%1" == "clean" goto clean
 if "%1" == "pdf" goto pdf

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -197,7 +197,7 @@ autoapi_template_dir = get_autoapi_templates_dir_relative_path(Path(__file__))
 suppress_warnings = ["autoapi.python_import_resolution", "design.grid"]
 autoapi_python_use_implicit_namespaces = True
 autoapi_keep_files = True
-autoapi_render_in_single_page = ["class", "enum", "exception"]
+autoapi_own_page_level = "class"
 
 # Examples gallery customization
 nbsphinx_execute = "always"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ tests = [
     "vtk==9.3.0",
 ]
 doc = [
-    "ansys-sphinx-theme==0.13.4",
+    "ansys-sphinx-theme==0.14.0",
     "docker==7.0.0",
     "ipyvtklink==0.2.3",
     "jupyter_sphinx==0.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ doc = [
     "pyvista[jupyter]==0.43.3",
     "requests==2.31.0",
     "sphinx==7.2.6",
-    "sphinx-autoapi==3.0.0",            # "sphinx-autoapi @ git+https://github.com/jorgepiloto/sphinx-autoapi@feat/single-page-option", ---> Installed directly in workflow
+    "sphinx-autoapi==3.1.a2",
     "sphinx-autodoc-typehints==1.24.0",
     "sphinx-copybutton==0.5.2",
     "sphinx_design==0.5.0",


### PR DESCRIPTION
Stop using our custom sphinx-autoapi branch in favor of the official alpha release. This is blocked until https://github.com/ansys/ansys-sphinx-theme/pull/344 gets merged and a new minor release of our corporate theme is out.