### PR TITLE
fix: add the baseurl in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,6 +69,7 @@ switcher_version = get_version_match(__version__)
 html_logo = pyansys_logo_black
 html_theme = "ansys_sphinx_theme"
 html_short_title = html_title = "PyAnsys Geometry"
+html_baseurl = f"https://{cname}/version/stable"
 
 # specify the location of your github repo
 html_context = {


### PR DESCRIPTION
add the baseurl in conf.py for documentation redirection wrt to multiversion documentation.
