### PR TITLE
fix: using jupytext through subprocess - fails on Windows otherwise

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -37,7 +37,7 @@ goto end
 
 :html
 %SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
-%SPHINXBUILD% -M linkcheck %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+@REM %SPHINXBUILD% -M linkcheck %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :pdf

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -332,7 +332,7 @@ def convert_notebooks_to_scripts(app: sphinx.application.Sphinx, exception):
         Exception raised during the build process.
     """
     if exception is None:
-        # Get the examples output directory and retrive all the notebooks
+        # Get the examples output directory and retrieve all the notebooks
         import subprocess
 
         examples_output_dir = Path(app.outdir) / "examples"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -320,7 +320,7 @@ nitpick_ignore_regex = [
 ]
 
 
-def convert_notebooks_to_scripts(app: sphinx.application.Sphinx, doctree, docname):
+def convert_notebooks_to_scripts(app: sphinx.application.Sphinx, exception):
     """
     Convert notebooks to scripts.
 
@@ -328,16 +328,33 @@ def convert_notebooks_to_scripts(app: sphinx.application.Sphinx, doctree, docnam
     ----------
     app : sphinx.application.Sphinx
         Sphinx instance containing all the configuration for the documentation build.
-    doctree : sphinx.util.nodes.Node
-        Sphinx document tree.
-    docname : str
-        Sphinx document name.
+    exception : Exception
+        Exception raised during the build process.
     """
-    import jupytext
+    if exception is None:
+        # Get the examples output directory and retrive all the notebooks
+        import subprocess
 
-    EXAMPLES_DIRECTORY = Path(app.outdir) / "examples"
-    for notebook in EXAMPLES_DIRECTORY.glob("**/*.ipynb"):
-        jupytext.write(notebook, str(notebook.with_suffix(".py")))
+        examples_output_dir = Path(app.outdir) / "examples"
+        notebooks = examples_output_dir.glob("**/*.ipynb")
+        for notebook in notebooks:
+            print(f"Converting {notebook}")  # using jupytext
+            output = subprocess.run(
+                [
+                    "jupytext",
+                    "--to",
+                    "py",
+                    str(notebook),
+                    "--output",
+                    str(notebook.with_suffix(".py")),
+                ],
+                env=os.environ,
+                capture_output=True,
+            )
+
+            if output.returncode != 0:
+                print(f"Error converting {notebook} to script")
+                print(output.stderr)
 
 
 def setup(app: sphinx.application.Sphinx):
@@ -351,4 +368,5 @@ def setup(app: sphinx.application.Sphinx):
     """
     # Convert notebooks into Python scripts and include them in the output files
     if BUILD_EXAMPLES:
-        app.connect("doctree-resolved", convert_notebooks_to_scripts)
+        # Run at the end of the build process
+        app.connect("build-finished", convert_notebooks_to_scripts)


### PR DESCRIPTION
## Description
``jupytext`` through Python scripting was leading to failures when running on Windows mode

## Issue linked
Follow up of #1002 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
