### PR TITLE
fix: add `index.html` pages for the sub directories of sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -30,4 +30,28 @@
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://geometry.docs.pyansys.com/version/stable/index.html</loc>
+    <lastmod>2024-02-02</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://geometry.docs.pyansys.com/version/stable/getting_started/index.html</loc>
+    <lastmod>2024-02-02</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://geometry.docs.pyansys.com/version/stable/user_guide/index.html</loc>
+    <lastmod>2024-02-02</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://geometry.docs.pyansys.com/version/stable/api/index.html</loc>
+    <lastmod>2024-02-02</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Adding index.html pages to the subdirectories listed in our sitemap to enhance user experience and SEO. This is a PR to ``gh-pages`` branch.