### PR TITLE
fix: misleading docstring for sweep_chain()

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -22,7 +22,7 @@ Packages = Google
 # Define the Ansys vocabulary
 Vocab = ANSYS
 
-[*.{md,rst}]
+[*.{rst}]
 
 # Apply the following styles
 BasedOnStyles = Vale, Google

--- a/doc/changelog.d/1070.fixed.md
+++ b/doc/changelog.d/1070.fixed.md
@@ -1,1 +1,1 @@
-fix: misleading docstring for 
+fix: misleading docstring for

--- a/doc/changelog.d/1070.fixed.md
+++ b/doc/changelog.d/1070.fixed.md
@@ -1,1 +1,1 @@
-fix: misleading docstring for
+fix: misleading docstring for 

--- a/doc/changelog.d/1070.fixed.md
+++ b/doc/changelog.d/1070.fixed.md
@@ -1,1 +1,1 @@
-fix: misleading docstring for
+fix: misleading docstring for sweep_chain()

--- a/doc/changelog.d/1070.fixed.md
+++ b/doc/changelog.d/1070.fixed.md
@@ -1,0 +1,1 @@
+fix: misleading docstring for 

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -560,8 +560,6 @@ class Component:
         ----------
         name : str
             User-defined label for the new solid body.
-        sketch : Sketch
-            Two-dimensional sketch source for the extrusion.
         path : List[TrimmedCurve]
             The path to sweep the chain along.
         chain : List[TrimmedCurve]


### PR DESCRIPTION
## Description
Docstring says a sketch is accepted, but this is not true

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
