### PR TITLE
fix: prepare_and_start_backend is only available on Windows

### DIFF
--- a/doc/changelog.d/1076.fixed.md
+++ b/doc/changelog.d/1076.fixed.md
@@ -1,0 +1,1 @@
+maint: prepare_and_start_backend is only available on Windows

--- a/doc/changelog.d/1076.fixed.md
+++ b/doc/changelog.d/1076.fixed.md
@@ -1,1 +1,1 @@
-maint: prepare_and_start_backend is only available on Windows
+fix: prepare_and_start_backend is only available on Windows

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -241,6 +241,9 @@ def prepare_and_start_backend(
     """
     from ansys.geometry.core.modeler import Modeler
 
+    if os.name != "nt": # pragma: no cover
+        raise RuntimeError("Method 'prepare_and_start_backend' is only available on Windows.")
+
     port = _check_port_or_get_one(port)
     installations = get_available_ansys_installations()
     if product_version != None:
@@ -419,7 +422,6 @@ def _start_program(args: List[str], local_env: Dict[str, str]) -> subprocess.Pop
     """
     return subprocess.Popen(
         args,
-        shell=os.name != "nt",
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -241,7 +241,7 @@ def prepare_and_start_backend(
     """
     from ansys.geometry.core.modeler import Modeler
 
-    if os.name != "nt": # pragma: no cover
+    if os.name != "nt":  # pragma: no cover
         raise RuntimeError("Method 'prepare_and_start_backend' is only available on Windows.")
 
     port = _check_port_or_get_one(port)


### PR DESCRIPTION
Controlling usage of subprocess (only for Windows OS) and avoid using ``shell=True``.