### PR TITLE
build: beartype upper limit on v0.18

### DIFF
--- a/doc/changelog.d/1095.fixed.md
+++ b/doc/changelog.d/1095.fixed.md
@@ -1,1 +1,1 @@
-fix: beartype complaint
+build: beartype upper limit on v0.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "ansys-api-geometry==0.4.1",
     "ansys-tools-path>=0.3,<1",
-    "beartype>=0.11.0,<1",
+    "beartype>=0.11.0,<0.18",
     "google-api-python-client>=1.7.11,<3",
     "googleapis-common-protos>=1.52.0,<2",
     "grpcio>=1.35.0,<2",
@@ -72,6 +72,7 @@ tests = [
 ]
 doc = [
     "ansys-sphinx-theme==0.15.0",
+    "beartype==0.17.2",
     "docker==7.0.0",
     "ipyvtklink==0.2.3",
     "jupyter_sphinx==0.5.3",

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -43,7 +43,7 @@ from ansys.geometry.core.logger import PyGeometryCustomAdapter
 from ansys.geometry.core.typing import Real
 
 try:
-    import ansys.platform.instancemanagement as pim
+    from ansys.platform.instancemanagement import Instance
 except ModuleNotFoundError:  # pragma: no cover
     pass
 
@@ -129,7 +129,7 @@ class GrpcClient:
         host: Optional[str] = DEFAULT_HOST,
         port: Union[str, int] = DEFAULT_PORT,
         channel: Optional[grpc.Channel] = None,
-        remote_instance: Optional["pim.Instance"] = None,
+        remote_instance: Optional["Instance"] = None,
         docker_instance: Optional[LocalDockerInstance] = None,
         product_instance: Optional[ProductInstance] = None,
         timeout: Optional[Real] = 120,

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -43,7 +43,7 @@ from ansys.geometry.core.logger import PyGeometryCustomAdapter
 from ansys.geometry.core.typing import Real
 
 try:
-    from ansys.platform.instancemanagement import Instance
+    import ansys.platform.instancemanagement as pim
 except ModuleNotFoundError:  # pragma: no cover
     pass
 
@@ -129,7 +129,7 @@ class GrpcClient:
         host: Optional[str] = DEFAULT_HOST,
         port: Union[str, int] = DEFAULT_PORT,
         channel: Optional[grpc.Channel] = None,
-        remote_instance: Optional["Instance"] = None,
+        remote_instance: Optional["pim.Instance"] = None,
         docker_instance: Optional[LocalDockerInstance] = None,
         product_instance: Optional[ProductInstance] = None,
         timeout: Optional[Real] = 120,


### PR DESCRIPTION
## Description
Limiting to older versions of beartype (temporarily).

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
