### PR TITLE
fix: removing @PipKat from *.md files - changelog fragments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,4 @@
 
 # Documentation review required from Docs team (as well) on the following set of files:
 *.rst      @PipKat @ansys/pyansys-geometry-maintainers
-*.md       @PipKat @ansys/pyansys-geometry-maintainers
 *.mystnb   @PipKat @ansys/pyansys-geometry-maintainers

--- a/doc/changelog.d/1098.changed.md
+++ b/doc/changelog.d/1098.changed.md
@@ -1,0 +1,1 @@
+fix: removing @PipKat from *.md files - changelog fragments


### PR DESCRIPTION
I believe you were being tagged EVERYWHERE  unnecessarily as reviewer @PipKat - sorry for that!