### PR TITLE
fix: return type should be dict and not ``ScalarMapContainer`` (grpc type)

### DIFF
--- a/doc/changelog.d/1103.fixed.md
+++ b/doc/changelog.d/1103.fixed.md
@@ -1,0 +1,1 @@
+fix: return type should be dict and not ``ScalarMapContainer`` (grpc type)

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -407,9 +407,9 @@ class Modeler:
         self.client.log.debug(f"Script result message: {response.message}")
 
         if import_design:
-            return (response.values, self.read_existing_design())
+            return (dict(response.values), self.read_existing_design())
         else:
-            return response.values
+            return dict(response.values)
 
     @property
     def repair_tools(self) -> RepairTools:


### PR DESCRIPTION
## Description
Return type coming from ``run_discovery_script_file`` was ``ScalarMapContainer`` instead of ``dict``. Though they effectively behave in the same way, it is true that the type should be a dictionary since we should avoid returning gRPC objects to the end user.

## Issue linked
Closes #1102 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
