### PR TITLE
ci: main Python version update to 3.12

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,8 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
-  MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED: '3.9'
+  MAIN_PYTHON_VERSION: '3.12'
   PACKAGE_NAME: 'ansys-geometry-core'
   DOCUMENTATION_CNAME: 'geometry.docs.pyansys.com'
   ANSRV_GEO_IMAGE: 'ghcr.io/ansys/geometry'
@@ -139,7 +138,7 @@ jobs:
         if: env.SKIP_UNSTABLE == 'false'
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED }} # self-hosted has an issue with 3.11
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Set up headless display
         if: env.SKIP_UNSTABLE == 'false'
@@ -258,7 +257,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED }} # self-hosted has an issue with 3.11
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v2
@@ -500,7 +499,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED }} # self-hosted has an issue with 3.11
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Download Windows binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -5,8 +5,7 @@ on:
     - cron: "0 3 * * *"
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
-  MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED: '3.9'
+  MAIN_PYTHON_VERSION: '3.12'
   ANSRV_GEO_IMAGE_WINDOWS_TAG: ghcr.io/ansys/geometry:windows-latest-unstable
   ANSRV_GEO_IMAGE_LINUX_TAG: ghcr.io/ansys/geometry:linux-latest-unstable
   ANSRV_GEO_PORT: 710
@@ -34,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED }} # self-hosted has an issue with 3.11
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
 

--- a/doc/changelog.d/1112.changed.md
+++ b/doc/changelog.d/1112.changed.md
@@ -1,0 +1,1 @@
+cicd: main Python version update to 3.12

--- a/doc/changelog.d/1112.changed.md
+++ b/doc/changelog.d/1112.changed.md
@@ -1,1 +1,1 @@
-cicd: main Python version update to 3.12
+ci: main Python version update to 3.12


### PR DESCRIPTION
As title says - upgrading to Python 3.12 (for self-hosted runners as well)