### PR TITLE
fix: canonical links included in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,18 +72,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="docsearch:language" content="en"/>
   <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
   </head>
   
   

--- a/version/stable/index.html
+++ b/version/stable/index.html
@@ -72,18 +72,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="docsearch:language" content="en"/>
   <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
-  <link rel="canonical" href="https://geometry.docs.pyansys.com/">
   </head>
   
   


### PR DESCRIPTION
Removes additional tags for canonical pages. Still investigating where this originates. The script in the `feat/seo-improvements` branch seems to be working fine locally. The rest of the pages only have one canonical link tag. 