### PR TITLE
chore: use default vale version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -90,7 +90,6 @@ jobs:
         uses: ansys/actions/doc-style@v6
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
-         vale-version: '3.4.1'
 
   smoke-tests:
     name: Build and Smoke tests

--- a/doc/changelog.d/1140.changed.md
+++ b/doc/changelog.d/1140.changed.md
@@ -1,0 +1,1 @@
+chore: use default vale version


### PR DESCRIPTION
As title says. Use default ``vale`` version