### PR TITLE
fix: GetSurface and GetCurve not available prior to 24R2

### DIFF
--- a/doc/changelog.d/1171.fixed.md
+++ b/doc/changelog.d/1171.fixed.md
@@ -1,0 +1,1 @@
+fix: GetSurface not available prior to 24R2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ Issues = "https://github.com/ansys/pyansys-geometry/issues"
 Discussions = "https://github.com/ansys/pyansys-geometry/discussions"
 Documentation = "https://geometry.docs.pyansys.com"
 Releases = "https://github.com/ansys/pyansys-geometry/releases"
+Changelog =  "https://github.com/ansys/pyansys-geometry/blob/main/doc/source/changelog.rst"
 
 [tool.flit.module]
 name = "ansys.geometry.core"

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -33,6 +33,7 @@ from google.protobuf.empty_pb2 import Empty
 import grpc
 from grpc._channel import _InactiveRpcError
 from grpc_health.v1 import health_pb2, health_pb2_grpc
+import semver
 
 from ansys.geometry.core.connection.backend import BackendType
 from ansys.geometry.core.connection.defaults import DEFAULT_HOST, DEFAULT_PORT, MAX_MESSAGE_LENGTH
@@ -193,10 +194,12 @@ class GrpcClient:
         # retrieve the backend version
         if hasattr(grpc_backend_response, "version"):
             ver = grpc_backend_response.version
-            self._backend_version = f"{ver.major_release}.{ver.minor_release}.{ver.service_pack}"
+            self._backend_version = semver.Version(
+                ver.major_release, ver.minor_release, ver.service_pack
+            )
         else:
             logger.warning("The backend version is only available after 24.1 version.")
-            self._backend_version = "24.1.0"
+            self._backend_version = semver.Version(24, 1, 0)
 
     @property
     def backend_type(self) -> BackendType:
@@ -214,15 +217,14 @@ class GrpcClient:
         return self._backend_type
 
     @property
-    def backend_version(self) -> str:
+    def backend_version(self) -> semver.Version:
         """
         Get the current backend version.
 
         Returns
         -------
-        str
-            Backend version in semantic versioning format (that is, Ansys 24R1 SP2
-            would be ``24.1.2``).
+        semver.Version
+            Backend version.
         """
         return self._backend_version
 

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -107,7 +107,7 @@ class Edge:
         return self._is_reversed
 
     @property
-    @min_backend_version(24,2,0)
+    @min_backend_version(24, 2, 0)
     def shape(self) -> TrimmedCurve:
         """
         Underlying trimmed curve of the edge.
@@ -145,7 +145,7 @@ class Edge:
         """Calculated length of the edge."""
         try:
             return self.shape.length
-        except GeometryRuntimeError: # pragma: no cover
+        except GeometryRuntimeError:  # pragma: no cover
             # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
             self._grpc_client.log.debug("Requesting edge length from server.")
             length_response = self._edges_stub.GetLength(self._grpc_id)

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -146,7 +146,7 @@ class Edge:
         try:
             return self.shape.length
         except GeometryRuntimeError:  # pragma: no cover
-            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            # Only for versions earlier than 24.2.0 (before the introduction of the shape property)
             self._grpc_client.log.debug("Requesting edge length from server.")
             length_response = self._edges_stub.GetLength(self._grpc_id)
             return Quantity(length_response.length, DEFAULT_UNITS.SERVER_LENGTH)

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -30,9 +30,9 @@ from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.conversions import grpc_curve_to_curve
-from ansys.geometry.core.errors import protect_grpc
+from ansys.geometry.core.errors import GeometryRuntimeError, protect_grpc
 from ansys.geometry.core.math.point import Point3D
-from ansys.geometry.core.misc.checks import ensure_design_is_active
+from ansys.geometry.core.misc.checks import ensure_design_is_active, min_backend_version
 from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
 from ansys.geometry.core.shapes.curves.trimmed_curve import ReversedTrimmedCurve, TrimmedCurve
 from ansys.geometry.core.shapes.parameterization import Interval
@@ -107,6 +107,7 @@ class Edge:
         return self._is_reversed
 
     @property
+    @min_backend_version(24,2,0)
     def shape(self) -> TrimmedCurve:
         """
         Underlying trimmed curve of the edge.
@@ -142,7 +143,13 @@ class Edge:
     @ensure_design_is_active
     def length(self) -> Quantity:
         """Calculated length of the edge."""
-        return self.shape.length
+        try:
+            return self.shape.length
+        except GeometryRuntimeError: # pragma: no cover
+            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            self._grpc_client.log.debug("Requesting edge length from server.")
+            length_response = self._edges_stub.GetLength(self._grpc_id)
+            return Quantity(length_response.length, DEFAULT_UNITS.SERVER_LENGTH)
 
     @property
     def curve_type(self) -> CurveType:

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -25,7 +25,11 @@ from enum import Enum, unique
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.edges_pb2_grpc import EdgesStub
-from ansys.api.geometry.v0.faces_pb2 import CreateIsoParamCurvesRequest
+from ansys.api.geometry.v0.faces_pb2 import (
+    CreateIsoParamCurvesRequest,
+    GetNormalRequest,
+    EvaluateRequest,
+)
 from ansys.api.geometry.v0.faces_pb2_grpc import FacesStub
 from ansys.api.geometry.v0.models_pb2 import Edge as GRPCEdge
 from beartype.typing import TYPE_CHECKING, List
@@ -34,10 +38,10 @@ from pint import Quantity
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.conversions import grpc_curve_to_curve, grpc_surface_to_surface
 from ansys.geometry.core.designer.edge import Edge
-from ansys.geometry.core.errors import protect_grpc
+from ansys.geometry.core.errors import GeometryRuntimeError, protect_grpc
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.math.vector import UnitVector3D
-from ansys.geometry.core.misc.checks import ensure_design_is_active
+from ansys.geometry.core.misc.checks import ensure_design_is_active, min_backend_version
 from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
 from ansys.geometry.core.shapes.box_uv import BoxUV
 from ansys.geometry.core.shapes.curves.trimmed_curve import TrimmedCurve
@@ -196,6 +200,7 @@ class Face:
         return self._body
 
     @property
+    @min_backend_version(24, 2, 0)
     def shape(self) -> TrimmedSurface:
         """
         Underlying trimmed surface of the face.
@@ -305,7 +310,13 @@ class Face:
             This :class:`UnitVector3D` object is perpendicular to the surface at the
             given UV coordinates.
         """
-        return self.shape.normal(u, v)
+        try:
+            return self.shape.normal(u, v)
+        except GeometryRuntimeError: # pragma: no cover
+            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            self._grpc_client.log.debug(f"Requesting face normal from server with (u,v)=({u},{v}).")
+            response = self._faces_stub.GetNormal(GetNormalRequest(id=self.id, u=u, v=v)).direction
+            return UnitVector3D([response.x, response.y, response.z])
 
     @protect_grpc
     def point(self, u: float = 0.5, v: float = 0.5) -> Point3D:
@@ -333,7 +344,13 @@ class Face:
             :class:`Point3D`
             object evaluated at the given UV coordinates.
         """
-        return self.shape.evaluate_proportion(u, v).position
+        try:
+            return self.shape.evaluate_proportion(u, v).position
+        except GeometryRuntimeError: # pragma: no cover
+            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            self._grpc_client.log.debug(f"Requesting face point from server with (u,v)=({u},{v}).")
+            response = self._faces_stub.Evaluate(EvaluateRequest(id=self.id, u=u, v=v)).point
+            return Point3D([response.x, response.y, response.z], DEFAULT_UNITS.SERVER_LENGTH)
 
     def __grpc_edges_to_edges(self, edges_grpc: List[GRPCEdge]) -> List[Edge]:
         """

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -313,7 +313,7 @@ class Face:
         try:
             return self.shape.normal(u, v)
         except GeometryRuntimeError:  # pragma: no cover
-            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            # Only for versions earlier than 24.2.0 (before the introduction of the shape property)
             self._grpc_client.log.debug(f"Requesting face normal from server with (u,v)=({u},{v}).")
             response = self._faces_stub.GetNormal(GetNormalRequest(id=self.id, u=u, v=v)).direction
             return UnitVector3D([response.x, response.y, response.z])
@@ -347,7 +347,7 @@ class Face:
         try:
             return self.shape.evaluate_proportion(u, v).position
         except GeometryRuntimeError:  # pragma: no cover
-            # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
+            # Only for versions earlier than 24.2.0 (before the introduction of the shape property)
             self._grpc_client.log.debug(f"Requesting face point from server with (u,v)=({u},{v}).")
             response = self._faces_stub.Evaluate(EvaluateRequest(id=self.id, u=u, v=v)).point
             return Point3D([response.x, response.y, response.z], DEFAULT_UNITS.SERVER_LENGTH)

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -27,8 +27,8 @@ from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.edges_pb2_grpc import EdgesStub
 from ansys.api.geometry.v0.faces_pb2 import (
     CreateIsoParamCurvesRequest,
-    GetNormalRequest,
     EvaluateRequest,
+    GetNormalRequest,
 )
 from ansys.api.geometry.v0.faces_pb2_grpc import FacesStub
 from ansys.api.geometry.v0.models_pb2 import Edge as GRPCEdge
@@ -312,7 +312,7 @@ class Face:
         """
         try:
             return self.shape.normal(u, v)
-        except GeometryRuntimeError: # pragma: no cover
+        except GeometryRuntimeError:  # pragma: no cover
             # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
             self._grpc_client.log.debug(f"Requesting face normal from server with (u,v)=({u},{v}).")
             response = self._faces_stub.GetNormal(GetNormalRequest(id=self.id, u=u, v=v)).direction
@@ -346,7 +346,7 @@ class Face:
         """
         try:
             return self.shape.evaluate_proportion(u, v).position
-        except GeometryRuntimeError: # pragma: no cover
+        except GeometryRuntimeError:  # pragma: no cover
             # Only for versions < 24.2.0 (i.e. before the introduction of the shape property)
             self._grpc_client.log.debug(f"Requesting face point from server with (u,v)=({u},{v}).")
             response = self._faces_stub.Evaluate(EvaluateRequest(id=self.id, u=u, v=v)).point

--- a/src/ansys/geometry/core/misc/checks.py
+++ b/src/ansys/geometry/core/misc/checks.py
@@ -338,7 +338,7 @@ def min_backend_version(major: int, minor: int, service_pack: int):
                         "The client is not available. You must initialize the client first."
                     )
                 elif self._grpc_client.backend_version is not None:
-                    comp = semver.compare(method_version, self._grpc_client.backend_version)
+                    comp = semver.Version.compare(method_version, self._grpc_client.backend_version)
                     # if comp is 1, method version is higher than backend version.
                     if comp == 1:
 

--- a/src/ansys/geometry/core/misc/checks.py
+++ b/src/ansys/geometry/core/misc/checks.py
@@ -331,19 +331,19 @@ def min_backend_version(major: int, minor: int, service_pack: int):
 
     def backend_version_decorator(method):
         def wrapper(self, *args, **kwargs):
-            method_version = f"{major}.{minor}.{service_pack}"
+            method_version = semver.Version(major, minor, service_pack)
             if hasattr(self, "_grpc_client"):
                 if self._grpc_client is None:
                     raise GeometryRuntimeError(
                         "The client is not available. You must initialize the client first."
                     )
                 elif self._grpc_client.backend_version is not None:
-                    comp = semver.Version.compare(method_version, self._grpc_client.backend_version)
+                    comp = method_version.compare(self._grpc_client.backend_version)
                     # if comp is 1, method version is higher than backend version.
                     if comp == 1:
 
                         # Check if the version is "0.0.0" (i.e., the version is not available)
-                        if self._grpc_client.backend_version == "0.0.0":
+                        if str(self._grpc_client.backend_version) == "0.0.0":
                             raise GeometryRuntimeError(
                                 f"The method '{method.__name__}' requires a minimum Ansys release version of "  # noqa: E501
                                 + f"{method_version}, but the current version used is 24.1.0 or lower."  # noqa: E501


### PR DESCRIPTION
## Description
Fixing 24R1 related issue due to GetSurface and GetCurve APIs

## Issue linked
Closes #1170 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
