### PR TITLE
fix: start and end points for edge

### DIFF
--- a/doc/changelog.d/1176.fixed.md
+++ b/doc/changelog.d/1176.fixed.md
@@ -1,0 +1,1 @@
+fix: start and end points for edge

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -200,6 +200,8 @@ class Face:
         return self._body
 
     @property
+    @protect_grpc
+    @ensure_design_is_active
     @min_backend_version(24, 2, 0)
     def shape(self) -> TrimmedSurface:
         """
@@ -284,6 +286,7 @@ class Face:
         return loops
 
     @protect_grpc
+    @ensure_design_is_active
     def normal(self, u: float = 0.5, v: float = 0.5) -> UnitVector3D:
         """
         Get the normal direction to the face at certain proportional UV coordinates.
@@ -319,6 +322,7 @@ class Face:
             return UnitVector3D([response.x, response.y, response.z])
 
     @protect_grpc
+    @ensure_design_is_active
     def point(self, u: float = 0.5, v: float = 0.5) -> Point3D:
         """
         Get a point of the face evaluated at certain proportional UV coordinates.
@@ -381,6 +385,8 @@ class Face:
             )
         return edges
 
+    @protect_grpc
+    @ensure_design_is_active
     def create_isoparametric_curves(
         self, use_u_param: bool, parameter: float
     ) -> List[TrimmedCurve]:

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -256,7 +256,7 @@ class Plotter:
         """
         edge_plot_list = []
         for edge in body_plot.object.edges:
-            line = pv.Line(edge.shape.start, edge.shape.start)
+            line = pv.Line(edge.start, edge.end)
             edge_actor = self.scene.add_mesh(
                 line, line_width=10, color=EDGE_COLOR, **plotting_options
             )


### PR DESCRIPTION
New ``shape`` property is not available in 24R1... causing plotter to fail as well since the edges can't be plotted. This should fix the issues coming from it (delegating it to the previous API).