### PR TITLE
ci: use Trusted Publisher for releasing package

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -736,13 +736,17 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [package, build-windows-container, build-linux-container, update-changelog]
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Release to the public PyPI repository
         uses: ansys/actions/release-pypi-public@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - name: Release to GitHub
         uses: ansys/actions/release-github@v6

--- a/doc/changelog.d/1216.changed.md
+++ b/doc/changelog.d/1216.changed.md
@@ -1,0 +1,1 @@
+cicd: use Trusted Publisher for releasing package

--- a/doc/changelog.d/1216.changed.md
+++ b/doc/changelog.d/1216.changed.md
@@ -1,1 +1,1 @@
-cicd: use Trusted Publisher for releasing package
+ci: use Trusted Publisher for releasing package


### PR DESCRIPTION
As title says - implementing https://actions.docs.ansys.com/version/stable/migrations/release-pypi-trusted-publisher.html#release-pypi-trusted-publisher