### PR TITLE
ci: only run doc build on runners outside the ansys network

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -262,7 +262,9 @@ jobs:
   docs:
     name: Documentation
     needs: [docs-style]
-    runs-on: [self-hosted, Windows, pygeometry]
+    runs-on:
+      group: pyansys-self-hosted
+      labels: [Windows, pygeometry]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -262,6 +262,7 @@ jobs:
   docs:
     name: Documentation
     needs: [docs-style]
+    # Doc build performed on self-hosted runners outside the Ansys network only
     runs-on:
       group: pyansys-self-hosted
       labels: [Windows, pygeometry]

--- a/doc/changelog.d/1223.changed.md
+++ b/doc/changelog.d/1223.changed.md
@@ -1,0 +1,1 @@
+ci: only run doc build on runners outside the ansys network


### PR DESCRIPTION
Avoid link verification issues on machines inside the Ansys network