### PR TITLE
fix: Rename built in shadowing variables

### DIFF
--- a/doc/changelog.d/1257.fixed.md
+++ b/doc/changelog.d/1257.fixed.md
@@ -1,0 +1,1 @@
+fix: Rename built in shadowing variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "ansys-api-geometry==0.4.4",
     "ansys-tools-path>=0.3,<1",
-    "ansys-tools-visualization-interface>=0.2.4,<1",
+    "ansys-tools-visualization-interface>=0.2.6,<1",
     "beartype>=0.11.0,<0.19",
     "grpcio>=1.35.0,<2",
     "grpcio-health-checking>=1.45.0,<2",
@@ -50,7 +50,7 @@ all = [
 tests = [
     "ansys-platform-instancemanagement==1.1.2",
     "ansys-tools-path==0.6.0",
-    "ansys-tools-visualization-interface==0.2.4",
+    "ansys-tools-visualization-interface==0.2.6",
     "beartype==0.18.5",
     "docker==7.1.0",
     "grpcio==1.64.1",
@@ -77,7 +77,7 @@ tests-minimal = [
 ]
 doc = [
     "ansys-sphinx-theme[autoapi]==0.16.5",
-    "ansys-tools-visualization-interface==0.2.4",
+    "ansys-tools-visualization-interface==0.2.6",
     "beartype==0.18.5",
     "docker==7.1.0",
     "ipyvtklink==0.2.3",

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -330,8 +330,6 @@ class GeometryPlotter(Plotter):
 
         Parameters
         ----------
-        object : Any
-            Object to add.
         plottable_object : str, default: None
             Regular expression with the desired name or names you want to include in the plotter.
         name_filter: str, default: None

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -301,7 +301,7 @@ class GeometryPlotter(Plotter):
     def plot_iter(
         self,
         plotting_list: List[Any],
-        filter: str = None,
+        name_filter: str = None,
         **plotting_options,
     ) -> None:
         """
@@ -314,17 +314,17 @@ class GeometryPlotter(Plotter):
         ----------
         plotting_list : List[Any]
             List of objects you want to plot.
-        filter : str, default: None
+        name_filter : str, default: None
             Regular expression with the desired name or names you want to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
         """
         for object in plotting_list:
-            _ = self.plot(object, filter, **plotting_options)
+            _ = self.plot(object, name_filter, **plotting_options)
 
     # Override add function from plotter
-    def plot(self, object: Any, filter: str = None, **plotting_options) -> None:
+    def plot(self, plottable_object: Any, name_filter: str = None, **plotting_options) -> None:
         """
         Add a custom mesh to the plotter.
 
@@ -332,7 +332,9 @@ class GeometryPlotter(Plotter):
         ----------
         object : Any
             Object to add.
-        filter : str, default: None
+        plottable_object : str, default: None
+            Regular expression with the desired name or names you want to include in the plotter.
+        name_filter: str, default: None
             Regular expression with the desired name or names you want to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, depend of the backend implementation
@@ -351,24 +353,28 @@ class GeometryPlotter(Plotter):
         else:
             merge_components = None
         # Add the custom object to the plotter
-        if isinstance(object, DesignPoint):
-            self.add_design_point(object, **plotting_options)
-        elif isinstance(object, Sketch):
-            self.add_sketch(object, **plotting_options)
-        elif isinstance(object, Body) or isinstance(object, MasterBody):
-            self.add_body(object, merge_bodies, **plotting_options)
-        elif isinstance(object, Design) or isinstance(object, Component):
-            self.add_component(object, merge_components, merge_bodies, **plotting_options)
-        elif isinstance(object, List) and object != [] and isinstance(object[0], pv.PolyData):
-            self.add_sketch_polydata(object, **plotting_options)
-        elif isinstance(object, List):
-            self.plot_iter(object, filter, **plotting_options)
-        elif isinstance(object, MeshObjectPlot):
+        if isinstance(plottable_object, DesignPoint):
+            self.add_design_point(plottable_object, **plotting_options)
+        elif isinstance(plottable_object, Sketch):
+            self.add_sketch(plottable_object, **plotting_options)
+        elif isinstance(plottable_object, Body) or isinstance(object, MasterBody):
+            self.add_body(plottable_object, merge_bodies, **plotting_options)
+        elif isinstance(plottable_object, Design) or isinstance(object, Component):
+            self.add_component(plottable_object, merge_components, merge_bodies, **plotting_options)
+        elif (
+            isinstance(plottable_object, List)
+            and plottable_object != []
+            and isinstance(plottable_object[0], pv.PolyData)
+        ):
+            self.add_sketch_polydata(plottable_object, **plotting_options)
+        elif isinstance(plottable_object, List):
+            self.plot_iter(plottable_object, name_filter, **plotting_options)
+        elif isinstance(plottable_object, MeshObjectPlot):
             self._backend.pv_interface.set_add_mesh_defaults(plotting_options)
-            self._backend.pv_interface.plot(object, filter, **plotting_options)
+            self._backend.pv_interface.plot(plottable_object, name_filter, **plotting_options)
         else:
             # any left type should be a PyVista object
-            self._backend.pv_interface.plot(object, filter, **plotting_options)
+            self._backend.pv_interface.plot(plottable_object, name_filter, **plotting_options)
 
     def show(
         self,


### PR DESCRIPTION
## Description
Fixes shadowing caused by `visualization-interface`. Fixed in https://github.com/ansys/ansys-tools-visualization-interface/pull/75

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
