### PR TITLE
fix: unnecessary Point3D comparison

### DIFF
--- a/doc/changelog.d/1264.fixed.md
+++ b/doc/changelog.d/1264.fixed.md
@@ -1,0 +1,1 @@
+fix: unnecessary Point3D comparison

--- a/src/ansys/geometry/core/shapes/surfaces/sphere.py
+++ b/src/ansys/geometry/core/shapes/surfaces/sphere.py
@@ -197,7 +197,7 @@ class Sphere(Surface):
         x = origin_to_point.dot(self.dir_x)
         y = origin_to_point.dot(self.dir_y)
         z = origin_to_point.dot(self.dir_z)
-        if np.allclose((x * x + y * y + z * z), 0):
+        if np.allclose(x * x + y * y + z * z, 0):
             return SphereEvaluation(self, ParamUV(0, np.pi / 2))
 
         u = np.arctan2(y, x)

--- a/src/ansys/geometry/core/shapes/surfaces/sphere.py
+++ b/src/ansys/geometry/core/shapes/surfaces/sphere.py
@@ -197,7 +197,7 @@ class Sphere(Surface):
         x = origin_to_point.dot(self.dir_x)
         y = origin_to_point.dot(self.dir_y)
         z = origin_to_point.dot(self.dir_z)
-        if np.allclose((x * x + y * y + z * z), Point3D([0, 0, 0])):
+        if np.allclose((x * x + y * y + z * z), 0):
             return SphereEvaluation(self, ParamUV(0, np.pi / 2))
 
         u = np.arctan2(y, x)


### PR DESCRIPTION
Potential bug... array comparison shouldn't be happening. You just want to verify whether the value is 0, to perform a 90º projection.