### PR TITLE
fix: backticks breaking doc build after ruff linter

### DIFF
--- a/doc/changelog.d/1275.fixed.md
+++ b/doc/changelog.d/1275.fixed.md
@@ -1,1 +1,1 @@
-fix: backticks braking doc build after ruff linter
+fix: backticks breaking doc build after ruff linter

--- a/src/ansys/geometry/core/connection/conversions.py
+++ b/src/ansys/geometry/core/connection/conversions.py
@@ -135,7 +135,7 @@ def sketch_shapes_to_grpc_geometries(
     faces: List[SketchFace],
     only_one_curve: Optional[bool] = False,
 ) -> GRPCGeometries:
-    """Convert lists of ``SketchEdge``/``SketchFace`` to a gRPC message.
+    """Convert lists of ``SketchEdge`` and ``SketchFace`` to a gRPC message.
 
     Parameters
     ----------

--- a/src/ansys/geometry/core/connection/conversions.py
+++ b/src/ansys/geometry/core/connection/conversions.py
@@ -555,7 +555,7 @@ def curve_to_grpc_curve(curve: Curve) -> GRPCCurve:
 
 
 def trimmed_curve_to_grpc_trimmed_curve(curve: "TrimmedCurve") -> GRPCTrimmedCurve:
-    """Convert a ``TrimmedCurve``to a trimmed curve gRPC message.
+    """Convert a ``TrimmedCurve`` to a trimmed curve gRPC message.
 
     Parameters
     ----------


### PR DESCRIPTION
As title says