### PR TITLE
chore: bump pre-commit-hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.3.1
+  rev: v0.3.2
   hooks:
     - id: add-license-headers
       files: '(src|examples|tests|docker)/.*\.(py)|\.(proto)'

--- a/doc/changelog.d/1276.changed.md
+++ b/doc/changelog.d/1276.changed.md
@@ -1,0 +1,1 @@
+chore: bump pre-commit-hook version


### PR DESCRIPTION
Bumping the ansys/pre-commit-hooks to increase speed