### PR TITLE
fix: manifest path should render as posix rather than uri

### DIFF
--- a/doc/changelog.d/1289.fixed.md
+++ b/doc/changelog.d/1289.fixed.md
@@ -1,0 +1,1 @@
+fix: manifest path should render as posix rather than uri

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -413,7 +413,7 @@ def _manifest_path_provider(
     )
 
     if def_manifest_path.exists():
-        return def_manifest_path.as_uri()
+        return def_manifest_path.as_posix()
     else:
         msg = (
             "Default manifest file's path does not exist."


### PR DESCRIPTION
As title says - this was causing the impossibility to launch SpaceClaim or Discovery with PyAnsys Geometry. Coming from #1274 ...