### PR TITLE
fix: default length units not being used properly on arc creation

### DIFF
--- a/doc/changelog.d/1310.fixed.md
+++ b/doc/changelog.d/1310.fixed.md
@@ -1,0 +1,1 @@
+fix: default length units not being used properly on arc creation

--- a/src/ansys/geometry/core/sketch/arc.py
+++ b/src/ansys/geometry/core/sketch/arc.py
@@ -326,7 +326,8 @@ class Arc(SketchEdge):
         k2 = (x_s**2 + y_s**2) - (x_e**2 + y_e**2)
 
         x_c, y_c = np.linalg.solve([[k11, k12], [k21, k22]], [k1, k2])
-        center = Point2D([x_c, y_c], unit=DEFAULT_UNITS.LENGTH)
+        center = Point2D([x_c, y_c], unit=UNITS.meter)
+        center.unit = DEFAULT_UNITS.LENGTH
 
         # Now, you should try to figure out if the rotation has to be clockwise or
         # counter-clockwise...
@@ -384,9 +385,9 @@ class Arc(SketchEdge):
             raise ValueError("Radius must be a real positive value.")
 
         # Unpack the points into its coordinates (in DEFAULT_UNITS.LENGTH)
-        x_s, y_s = start.tolist()
-        x_e, y_e = end.tolist()
-        r0 = r1 = radius.value.m_as(DEFAULT_UNITS.LENGTH)
+        x_s, y_s = start.tolist() # Always in meters
+        x_e, y_e = end.tolist() # Always in meters
+        r0 = r1 = radius.value.m_as(UNITS.meter) # Convert to meters as well
 
         # Compute the potential centers of the circle
         centers = get_two_circle_intersections(x0=x_s, y0=y_s, r0=r0, x1=x_e, y1=y_e, r1=r1)
@@ -394,7 +395,8 @@ class Arc(SketchEdge):
             raise ValueError("The provided points and radius do not yield a valid arc.")
 
         # Choose the center depending on if the arc is convex
-        center = Point2D(centers[1] if convex_arc else centers[0])
+        center = Point2D(centers[1] if convex_arc else centers[0], unit=UNITS.meter)
+        center.unit = DEFAULT_UNITS.LENGTH
 
         # Create the arc
         return Arc(start=start, end=end, center=center, clockwise=clockwise)

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -113,7 +113,12 @@ def test_issue_1304_arc_sketch_creation():
         # Draw the sketch
         sketch = Sketch()
         p_start, p_end, p_radius = Point2D([0, 0]), Point2D([4.7, 4.7]), Distance(4.7)
-        sketch.arc_from_start_end_and_radius(start=p_start, end=p_end, radius=p_radius, clockwise=False)
+        sketch.arc_from_start_end_and_radius(
+            start=p_start,
+            end=p_end,
+            radius=p_radius,
+            clockwise=False,
+        )
 
         # Perform some assertions
         assert len(sketch.edges) == 1


### PR DESCRIPTION
## Description
Problem related to the way default units are consumed inside the arc creation based on points.

## Issue linked
Closes #1304 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
