### PR TITLE
feat: keep "other" bodies when performing bool operations

### DIFF
--- a/doc/changelog.d/1311.added.md
+++ b/doc/changelog.d/1311.added.md
@@ -1,0 +1,1 @@
+feat: keep "other" bodies when performing bool operations

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -550,19 +550,22 @@ class IBody(ABC):
         """
         return
 
-    def intersect(self, other: Union["Body", Iterable["Body"]]) -> None:
+    def intersect(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:
         """Intersect two (or more) bodies.
 
         Notes
         -----
         The ``self`` parameter is directly modified with the result, and
         the ``other`` parameter is consumed. Thus, it is important to make
-        copies if needed.
+        copies if needed. If the ``keep_other`` parameter is set to ``True``,
+        the intersected body is retained.
 
         Parameters
         ----------
         other : Body
             Body to intersect with.
+        keep_other : bool, default: False
+            Whether to retain the intersected body or not.
 
         Raises
         ------
@@ -572,19 +575,22 @@ class IBody(ABC):
         return
 
     @protect_grpc
-    def subtract(self, other: Union["Body", Iterable["Body"]]) -> None:
+    def subtract(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:
         """Subtract two (or more) bodies.
 
         Notes
         -----
         The ``self`` parameter is directly modified with the result, and
         the ``other`` parameter is consumed. Thus, it is important to make
-        copies if needed.
+        copies if needed. If the ``keep_other`` parameter is set to ``True``,
+        the subtracted body is retained.
 
         Parameters
         ----------
         other : Body
             Body to subtract from the ``self`` parameter.
+        keep_other : bool, default: False
+            Whether to retain the subtracted body or not.
 
         Raises
         ------
@@ -594,19 +600,22 @@ class IBody(ABC):
         return
 
     @protect_grpc
-    def unite(self, other: Union["Body", Iterable["Body"]]) -> None:
+    def unite(self, other: Union["Body", Iterable["Body"]], keep_other : bool = False) -> None:
         """Unite two (or more) bodies.
 
         Notes
         -----
         The ``self`` parameter is directly modified with the result, and
         the ``other`` parameter is consumed. Thus, it is important to make
-        copies if needed.
+        copies if needed. If the ``keep_other`` parameter is set to ``True``,
+        the united body is retained.
 
         Parameters
         ----------
         other : Body
             Body to unite with the ``self`` parameter.
+        keep_other : bool, default: False
+            Whether to retain the united body or not.
         """
         return
 
@@ -983,17 +992,17 @@ class MasterBody(IBody):
             "MasterBody does not implement plot methods. Call this method on a body instead."
         )
 
-    def intersect(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
+    def intersect(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
         raise NotImplementedError(
             "MasterBody does not implement Boolean methods. Call this method on a body instead."
         )
 
-    def subtract(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
+    def subtract(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
         raise NotImplementedError(
             "MasterBody does not implement Boolean methods. Call this method on a body instead."
         )
 
-    def unite(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
+    def unite(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
         raise NotImplementedError(
             "MasterBody does not implement Boolean methods. Call this method on a body instead."
         )
@@ -1360,14 +1369,14 @@ class Body(IBody):
         pl.plot(meshobject, **plotting_options)
         pl.show(screenshot=screenshot, **plotting_options)
 
-    def intersect(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
-        self.__generic_boolean_op(other, "intersect", "bodies do not intersect")
+    def intersect(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
+        self.__generic_boolean_op(other, keep_other, "intersect", "bodies do not intersect")
 
-    def subtract(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
-        self.__generic_boolean_op(other, "subtract", "empty (complete) subtraction")
+    def subtract(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
+        self.__generic_boolean_op(other, keep_other,"subtract", "empty (complete) subtraction")
 
-    def unite(self, other: Union["Body", Iterable["Body"]]) -> None:  # noqa: D102
-        self.__generic_boolean_op(other, "unite", "union operation failed")
+    def unite(self, other: Union["Body", Iterable["Body"]], keep_other: bool = False) -> None:  # noqa: D102
+        self.__generic_boolean_op(other, keep_other, "unite", "union operation failed")
 
     @protect_grpc
     @reset_tessellation_cache
@@ -1376,10 +1385,16 @@ class Body(IBody):
     def __generic_boolean_op(
         self,
         other: Union["Body", Iterable["Body"]],
+        keep_other: bool,
         type_bool_op: str,
         err_bool_op: str,
     ) -> None:
         grpc_other = other if isinstance(other, Iterable) else [other]
+        if keep_other:
+            # Make a copy of the other body to keep it...
+            # stored temporarily in the parent component - since it will be deleted
+            grpc_other = [b.copy(self.parent_component, f"BoolOpCopy_{b.name}") for b in grpc_other]
+
         try:
             response = self._template._bodies_stub.Boolean(
                 BooleanRequest(

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1817,7 +1817,7 @@ def test_bool_operations_with_keep_other(modeler: Modeler):
     body1 = comp1.extrude_sketch("Body1", Sketch().box(Point2D([0, 0]), 1, 1), 1)
     body2 = comp2.extrude_sketch("Body2", Sketch().box(Point2D([0.5, 0]), 1, 1), 1)
     body3 = comp3.extrude_sketch("Body3", Sketch().box(Point2D([5, 0]), 1, 1), 1)
-    
+
     # ---- Verify subtract operation ----
     body1.subtract([body2, body3], keep_other=True)
 

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1805,6 +1805,44 @@ def test_multiple_bodies_boolean_operations(modeler: Modeler):
     assert len(comp1.bodies) == 1
     assert len(comp3.bodies) == 1
 
+def test_bool_operations_with_keep_other(modeler: Modeler):
+    """Test boolean operations with keep other option."""
+    # Create the design and bodies
+    design = modeler.create_design("TestBooleanOperationsWithKeepOther")
+
+    comp1 = design.add_component("Comp1")
+    comp2 = design.add_component("Comp2")
+    comp3 = design.add_component("Comp3")
+
+    body1 = comp1.extrude_sketch("Body1", Sketch().box(Point2D([0, 0]), 1, 1), 1)
+    body2 = comp2.extrude_sketch("Body2", Sketch().box(Point2D([0.5, 0]), 1, 1), 1)
+    body3 = comp3.extrude_sketch("Body3", Sketch().box(Point2D([5, 0]), 1, 1), 1)
+    
+    # ---- Verify subtract operation ----
+    body1.subtract([body2, body3], keep_other=True)
+
+    assert body2.is_alive
+    assert body3.is_alive
+    assert len(comp1.bodies) == 1
+    assert len(comp2.bodies) == 1
+    assert len(comp3.bodies) == 1
+
+    # ---- Verify unite operation ----
+    body1.unite([body2, body3], keep_other=True)
+
+    assert body2.is_alive
+    assert body3.is_alive
+    assert len(comp1.bodies) == 1
+    assert len(comp2.bodies) == 1
+    assert len(comp3.bodies) == 1
+
+    # ---- Verify intersect operation ----
+    body1.intersect(body2, keep_other=True)
+
+    assert body2.is_alive
+    assert len(comp1.bodies) == 1
+    assert len(comp2.bodies) == 1
+    assert len(comp3.bodies) == 1
 
 def test_child_component_instances(modeler: Modeler):
     """Test creation of child ``Component`` instances and check the data model


### PR DESCRIPTION
## Description
Provide the option to keep the "other" bodies passed when performing a bool operation. By default it will be false to support backward compatibility.

## Issue linked
Closes #1302

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
