### PR TITLE
feat: ``revolve_sketch`` rotation definition enhancement

### DIFF
--- a/doc/changelog.d/1336.added.md
+++ b/doc/changelog.d/1336.added.md
@@ -1,0 +1,1 @@
+feat: ``revolve_sketch`` rotation definition enhancement

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -592,12 +592,6 @@ class Component:
     ) -> Body:
         """Create a solid body by revolving a sketch profile around an axis.
 
-        Notes
-        -----
-        It is important that the sketch plane origin is not coincident with the rotation
-        origin. If the sketch plane origin is coincident with the rotation origin, the
-        distance between the two points is zero, and the revolve operation fails.
-
         Parameters
         ----------
         name : str
@@ -616,26 +610,16 @@ class Component:
         Body
             Revolved body from the given sketch.
         """
-        # Check that the sketch plane origin is not coincident with the rotation origin
-        if sketch.plane.origin == rotation_origin:
-            raise ValueError(
-                "The sketch plane origin is coincident with the rotation origin. "
-                + "The distance between the points is zero, and the revolve operation will fail."
-            )
-
-        # Compute the distance between the rotation origin and the sketch plane
-        rotation_origin_to_sketch = sketch.plane.origin - rotation_origin
-        rotation_origin_to_sketch_as_vector = Vector3D(rotation_origin_to_sketch)
-        distance = Distance(
-            rotation_origin_to_sketch_as_vector.norm,
-            unit=rotation_origin_to_sketch.base_unit,
-        )
+        # Based on the reference axis and the sketch plane's normal, retrieve the orthogonal
+        # vector (i.e. this is the reference vector for the Circle object). Assuming a distance of 1
+        # we revolve around the axis the angle given.
+        rotation_vector = sketch._plane.normal.cross(axis)
 
         # Define the revolve path
         circle = Circle(
             rotation_origin,
-            radius=distance,
-            reference=rotation_origin_to_sketch_as_vector,
+            radius=Distance(1),
+            reference=rotation_vector,
             axis=axis,
         )
         angle = angle if isinstance(angle, Angle) else Angle(angle)

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -154,15 +154,18 @@ def test_issue_1309_revolve_operation_with_coincident_origins(modeler: Modeler):
     # Create Base
     sketch = Sketch(sketch_plane)
 
-    sketch.arc(
-        start=Point2D([0, 0]),
-        end=Point2D([4.7, 4.7]),
-        center=Point2D([0, 4.7]),
-        clockwise=False,
-    ).segment_to_point(Point2D([4.7, 12])).segment_to_point(Point2D([-25.3, 12])).segment_to_point(
-        Point2D([-25.3, 0])
-    ).segment_to_point(Point2D([0, 0]))
-    sketch.plot()
+    (
+        sketch.arc(
+            start=Point2D([0, 0]),
+            end=Point2D([4.7, 4.7]),
+            center=Point2D([0, 4.7]),
+            clockwise=False,
+        )
+        .segment_to_point(Point2D([4.7, 12]))
+        .segment_to_point(Point2D([-25.3, 12]))
+        .segment_to_point(Point2D([-25.3, 0]))
+        .segment_to_point(Point2D([0, 0]))
+    )
 
     # Create Component (Revolve sketch)
     design = modeler.create_design("cylinder")

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -25,8 +25,15 @@ from pathlib import Path
 
 import numpy as np
 
-from ansys.geometry.core.math import UNITVECTOR3D_X, UNITVECTOR3D_Y, Plane, Point2D, Point3D
-from ansys.geometry.core.misc import DEFAULT_UNITS, UNITS, Distance
+from ansys.geometry.core.math import (
+    UNITVECTOR3D_X,
+    UNITVECTOR3D_Y,
+    UNITVECTOR3D_Z,
+    Plane,
+    Point2D,
+    Point3D,
+)
+from ansys.geometry.core.misc import DEFAULT_UNITS, UNITS, Angle, Distance
 from ansys.geometry.core.modeler import Modeler
 from ansys.geometry.core.sketch import Sketch
 
@@ -130,3 +137,42 @@ def test_issue_1304_arc_sketch_creation():
     finally:
         # Reverse the default units to meter
         DEFAULT_UNITS.LENGTH = UNITS.meter
+
+
+def test_issue_1309_revolve_operation_with_coincident_origins(modeler: Modeler):
+    """Test that revolving a sketch with coincident origins (sketch and rotation origin)
+    does not crash the program.
+
+    For more info see
+    https://github.com/ansys/pyansys-geometry/issues/1309
+    """
+    # Sketch Plane
+    sketch_plane = Plane(
+        origin=Point3D([0, 0, 5]), direction_x=UNITVECTOR3D_X, direction_y=UNITVECTOR3D_Z
+    )
+
+    # Create Base
+    sketch = Sketch(sketch_plane)
+
+    sketch.arc(
+        start=Point2D([0, 0]),
+        end=Point2D([4.7, 4.7]),
+        center=Point2D([0, 4.7]),
+        clockwise=False,
+    ).segment_to_point(Point2D([4.7, 12])).segment_to_point(Point2D([-25.3, 12])).segment_to_point(
+        Point2D([-25.3, 0])
+    ).segment_to_point(Point2D([0, 0]))
+    sketch.plot()
+
+    # Create Component (Revolve sketch)
+    design = modeler.create_design("cylinder")
+    component = design.add_component("cylinder_toroid")
+    revolved_body = component.revolve_sketch(
+        "toroid",
+        sketch=sketch,
+        axis=UNITVECTOR3D_X,
+        angle=Angle(360, UNITS.degrees),
+        rotation_origin=Point3D([-10.3, 0, 0]),
+    )
+
+    assert revolved_body.name == "toroid"


### PR DESCRIPTION
## Description
Rotation definition when revolving is now defined based on the axis passed: revolution axis and sketch plane normal axis. This allows to remove the "blocking condition" of coincident origins and equally aligned axis of reference in some sketches.

## Issue linked
Closes #1309 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
