### PR TITLE
feat: adapting beartype typehints to +Python 3.10 standard

### DIFF
--- a/doc/changelog.d/1347.added.md
+++ b/doc/changelog.d/1347.added.md
@@ -1,0 +1,1 @@
+feat: adapting beartype typehints to +Python 3.10 standard

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -368,7 +368,6 @@ jinja_contexts = {
 nitpick_ignore_regex = [
     # Ignore typing
     (r"py:.*", r"optional"),
-    (r"py:.*", r"beartype.typing.*"),
     (r"py:.*", r"ansys.geometry.core.typing.*"),
     (r"py:.*", r"Real.*"),
     (r"py:.*", r"SketchObject"),

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -21,14 +21,16 @@
 # SOFTWARE.
 """Module providing a wrapped abstraction of the gRPC stubs."""
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 import time
+from typing import Optional
 
 from ansys.api.dbu.v0.admin_pb2 import BackendType as GRPCBackendType
 from ansys.api.dbu.v0.admin_pb2_grpc import AdminStub
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 from google.protobuf.empty_pb2 import Empty
 import grpc
 from grpc._channel import _InactiveRpcError
@@ -88,7 +90,7 @@ class GrpcClient:
     ----------
     host : str, default: DEFAULT_HOST
         Host where the server is running.
-    port : Union[str, int], default: DEFAULT_PORT
+    port : str or int, default: DEFAULT_PORT
         Port number where the server is running.
     channel : ~grpc.Channel, default: None
         gRPC channel for server communication.
@@ -124,16 +126,16 @@ class GrpcClient:
     @check_input_types
     def __init__(
         self,
-        host: Optional[str] = DEFAULT_HOST,
-        port: Union[str, int] = DEFAULT_PORT,
-        channel: Optional[grpc.Channel] = None,
+        host: str = DEFAULT_HOST,
+        port: str | int = DEFAULT_PORT,
+        channel: grpc.Channel | None = None,
         remote_instance: Optional["Instance"] = None,
-        docker_instance: Optional[LocalDockerInstance] = None,
-        product_instance: Optional[ProductInstance] = None,
-        timeout: Optional[Real] = 120,
-        logging_level: Optional[int] = logging.INFO,
-        logging_file: Optional[Union[Path, str]] = None,
-        backend_type: Optional[BackendType] = None,
+        docker_instance: LocalDockerInstance | None = None,
+        product_instance: ProductInstance | None = None,
+        timeout: Real = 120,
+        logging_level: int = logging.INFO,
+        logging_file: Path | str | None = None,
+        backend_type: BackendType | None = None,
     ):
         """Initialize the ``GrpcClient`` object."""
         self._closed = False

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -21,8 +21,6 @@
 # SOFTWARE.
 """Module providing a wrapped abstraction of the gRPC stubs."""
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 import time

--- a/src/ansys/geometry/core/connection/conversions.py
+++ b/src/ansys/geometry/core/connection/conversions.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 """Module providing for conversions."""
 
+from typing import TYPE_CHECKING
+
 from ansys.api.geometry.v0.models_pb2 import (
     Arc as GRPCArc,
     Circle as GRPCCircle,
@@ -38,7 +40,6 @@ from ansys.api.geometry.v0.models_pb2 import (
     Tessellation,
     TrimmedCurve as GRPCTrimmedCurve,
 )
-from beartype.typing import TYPE_CHECKING, List, Optional, Tuple
 
 from ansys.geometry.core.math.frame import Frame
 from ansys.geometry.core.math.matrix import Matrix44
@@ -131,9 +132,9 @@ def plane_to_grpc_plane(plane: Plane) -> GRPCPlane:
 
 def sketch_shapes_to_grpc_geometries(
     plane: Plane,
-    edges: List[SketchEdge],
-    faces: List[SketchFace],
-    only_one_curve: Optional[bool] = False,
+    edges: list[SketchEdge],
+    faces: list[SketchFace],
+    only_one_curve: bool = False,
 ) -> GRPCGeometries:
     """Convert lists of ``SketchEdge`` and ``SketchFace`` to a gRPC message.
 
@@ -141,9 +142,9 @@ def sketch_shapes_to_grpc_geometries(
     ----------
     plane : Plane
         Plane for positioning the 2D sketches.
-    edges : List[SketchEdge]
+    edges : list[SketchEdge]
         Source edge data.
-    faces : List[SketchFace]
+    faces : list[SketchFace]
         Source face data.
     only_one_curve : bool, default: False
         Whether to project one curve of the whole set of geometries to
@@ -191,21 +192,21 @@ def sketch_shapes_to_grpc_geometries(
 
 
 def sketch_edges_to_grpc_geometries(
-    edges: List[SketchEdge],
+    edges: list[SketchEdge],
     plane: Plane,
-) -> Tuple[List[GRPCLine], List[GRPCArc]]:
+) -> tuple[list[GRPCLine], list[GRPCArc]]:
     """Convert a list of ``SketchEdge`` to a gRPC message.
 
     Parameters
     ----------
-    edges : List[SketchEdge]
+    edges : list[SketchEdge]
         Source edge data.
     plane : Plane
         Plane for positioning the 2D sketches.
 
     Returns
     -------
-    Tuple[List[GRPCLine], List[GRPCArc]]
+    tuple[list[GRPCLine], list[GRPCArc]]
         Geometry service gRPC line and arc messages. The unit is meters.
     """
     arcs = []

--- a/src/ansys/geometry/core/connection/docker_instance.py
+++ b/src/ansys/geometry/core/connection/docker_instance.py
@@ -24,9 +24,9 @@
 from enum import Enum
 from functools import wraps
 import os
+from typing import Optional
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Tuple, Union
 
 try:
     from docker.client import DockerClient
@@ -90,10 +90,10 @@ class LocalDockerInstance:
     restart_if_existing_service : bool, default: False
         Whether the Geometry service (which is already running)
         should be restarted when attempting connection.
-    name : Optional[str], default: None
+    name : str or None, default: None
         Name of the Docker container to deploy. The default is ``None``,
         in which case Docker assigns it a random name.
-    image : Optional[GeometryContainers], default: None
+    image : GeometryContainers or None, default: None
         The Geometry service Docker image to deploy. The default is ``None``,
         in which case the ``LocalDockerInstance`` class identifies the OS of your
         Docker engine and deploys the latest version of the Geometry service for that
@@ -154,8 +154,8 @@ class LocalDockerInstance:
         port: int = DEFAULT_PORT,
         connect_to_existing_service: bool = True,
         restart_if_existing_service: bool = False,
-        name: Optional[str] = None,
-        image: Optional[GeometryContainers] = None,
+        name: str | None = None,
+        image: GeometryContainers | None = None,
     ) -> None:
         """``LocalDockerInstance`` constructor."""
         # Initialize instance variables
@@ -186,7 +186,7 @@ class LocalDockerInstance:
         else:
             raise RuntimeError(f"Geometry service cannot be deployed on port {port}")
 
-    def _check_port_availability(self, port: int) -> Tuple[bool, Optional["Container"]]:
+    def _check_port_availability(self, port: int) -> tuple[bool, Optional["Container"]]:
         """Check whether the requested port is available for deployment.
 
         Returns
@@ -234,19 +234,17 @@ class LocalDockerInstance:
         # If you have reached this point, the image is not a Geometry service
         return False  # pragma: no cover
 
-    def _deploy_container(
-        self, port: int, name: Union[str, None], image: Union[GeometryContainers, None]
-    ):
+    def _deploy_container(self, port: int, name: str | None, image: GeometryContainers | None):
         """Handle the deployment of a Geometry service.
 
         Parameters
         ----------
         port : int
             Port under which the service should be deployed.
-        name : Union[str, None], optional
+        name : str or None, optional
             Name given to the deployed container. If ``None``, Docker will provide
             an arbitrary name.
-        image : Union[GeometryContainers, None]
+        image : GeometryContainers or None
             Geometry service Docker container image to be used. If ``None``, the
             latest container version matching
 
@@ -326,7 +324,7 @@ class LocalDockerInstance:
         return self._existed_previously
 
 
-def get_geometry_container_type(instance: LocalDockerInstance) -> Union[GeometryContainers, None]:
+def get_geometry_container_type(instance: LocalDockerInstance) -> GeometryContainers | None:
     """Provide back the ``GeometryContainers`` value.
 
     Notes
@@ -340,7 +338,7 @@ def get_geometry_container_type(instance: LocalDockerInstance) -> Union[Geometry
 
     Returns
     -------
-    Union[GeometryContainers, None]
+    GeometryContainers or None
         The GeometryContainer value corresponding to the previous image or None
         if not match.
     """

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -23,8 +23,7 @@
 
 import logging
 import os
-
-from beartype.typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
 from ansys.geometry.core.connection.client import MAX_MESSAGE_LENGTH
@@ -50,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ansys.geometry.core.modeler import Modeler
 
 
-def launch_modeler(mode: str = None, **kwargs: Optional[Dict]) -> "Modeler":
+def launch_modeler(mode: str = None, **kwargs: dict | None) -> "Modeler":
     """Start the ``Modeler`` interface for PyAnsys Geometry.
 
     Parameters
@@ -96,7 +95,7 @@ def launch_modeler(mode: str = None, **kwargs: Optional[Dict]) -> "Modeler":
         return _launch_with_automatic_detection(**kwargs)
 
 
-def _launch_with_launchmode(mode: str, **kwargs: Optional[Dict]) -> "Modeler":
+def _launch_with_launchmode(mode: str, **kwargs: dict | None) -> "Modeler":
     """Start the ``Modeler`` interface for PyAnsys Geometry.
 
     Parameters
@@ -145,7 +144,7 @@ def _launch_with_launchmode(mode: str, **kwargs: Optional[Dict]) -> "Modeler":
         )
 
 
-def _launch_with_automatic_detection(**kwargs: Optional[Dict]) -> "Modeler":
+def _launch_with_automatic_detection(**kwargs: dict | None) -> "Modeler":
     """Start the ``Modeler`` interface based on automatic detection.
 
     Parameters
@@ -221,10 +220,10 @@ def _launch_with_automatic_detection(**kwargs: Optional[Dict]) -> "Modeler":
 
 
 def launch_remote_modeler(
-    version: Optional[str] = None,
-    client_log_level: Optional[int] = logging.INFO,
-    client_log_file: Optional[str] = None,
-    **kwargs: Optional[Dict],
+    version: str | None = None,
+    client_log_level: int = logging.INFO,
+    client_log_file: str | None = None,
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start the Geometry service remotely using the PIM API.
 
@@ -268,11 +267,11 @@ def launch_docker_modeler(
     port: int = DEFAULT_PORT,
     connect_to_existing_service: bool = True,
     restart_if_existing_service: bool = False,
-    name: Optional[str] = None,
-    image: Optional[GeometryContainers] = None,
-    client_log_level: Optional[int] = logging.INFO,
-    client_log_file: Optional[str] = None,
-    **kwargs: Optional[Dict],
+    name: str | None = None,
+    image: GeometryContainers | None = None,
+    client_log_level: int = logging.INFO,
+    client_log_file: str | None = None,
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start the Geometry service locally using Docker.
 
@@ -293,10 +292,10 @@ def launch_docker_modeler(
     restart_if_existing_service : bool, default: False
         Whether the Geometry service (which is already running)
         should be restarted when attempting connection.
-    name : Optional[str], default: None
+    name : str, default: None
         Name of the Docker container to deploy. The default is ``None``,
         in which case Docker assigns it a random name.
-    image : Optional[GeometryContainers], default: None
+    image : GeometryContainers, default: None
         The Geometry service Docker image to deploy. The default is ``None``,
         in which case the ``LocalDockerInstance`` class identifies the OS of your
         Docker engine and deploys the latest version of the Geometry service for
@@ -340,10 +339,10 @@ def launch_docker_modeler(
 
 
 def launch_modeler_with_discovery_and_pimlight(
-    version: Optional[str] = None,
-    client_log_level: Optional[int] = logging.INFO,
-    client_log_file: Optional[str] = None,
-    **kwargs: Optional[Dict],
+    version: str | None = None,
+    client_log_level: int = logging.INFO,
+    client_log_file: str | None = None,
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start Ansys Discovery remotely using the PIM API.
 
@@ -383,10 +382,10 @@ def launch_modeler_with_discovery_and_pimlight(
 
 
 def launch_modeler_with_geometry_service_and_pimlight(
-    version: Optional[str] = None,
-    client_log_level: Optional[int] = logging.INFO,
-    client_log_file: Optional[str] = None,
-    **kwargs: Optional[Dict],
+    version: str | None = None,
+    client_log_level: int = logging.INFO,
+    client_log_file: str | None = None,
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start the Geometry service remotely using the PIM API.
 
@@ -426,10 +425,10 @@ def launch_modeler_with_geometry_service_and_pimlight(
 
 
 def launch_modeler_with_spaceclaim_and_pimlight(
-    version: Optional[str] = None,
-    client_log_level: Optional[int] = logging.INFO,
-    client_log_file: Optional[str] = None,
-    **kwargs: Optional[Dict],
+    version: str | None = None,
+    client_log_level: int = logging.INFO,
+    client_log_file: str | None = None,
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start Ansys SpaceClaim remotely using the PIM API.
 
@@ -482,7 +481,7 @@ def launch_modeler_with_geometry_service(
     client_log_file: str = None,
     log_level: int = None,  # DEPRECATED
     logs_folder: str = None,  # DEPRECATED
-    **kwargs: Optional[Dict],
+    **kwargs: dict | None,
 ) -> "Modeler":
     """Start the Geometry service locally using the ``ProductInstance`` class.
 
@@ -610,7 +609,7 @@ def launch_modeler_with_discovery(
     client_log_file: str = None,
     log_level: int = None,  # DEPRECATED
     logs_folder: str = None,  # DEPRECATED
-    **kwargs: Optional[Dict],
+    **kwargs: dict | None,
 ):
     """Start Ansys Discovery locally using the ``ProductInstance`` class.
 
@@ -743,7 +742,7 @@ def launch_modeler_with_spaceclaim(
     client_log_file: str = None,
     log_level: int = None,  # DEPRECATED
     logs_folder: str = None,  # DEPRECATED
-    **kwargs: Optional[Dict],
+    **kwargs: dict | None,
 ):
     """Start Ansys SpaceClaim locally using the ``ProductInstance`` class.
 
@@ -860,10 +859,10 @@ def launch_modeler_with_spaceclaim(
 def _launch_pim_instance(
     is_pim_light: bool,
     product_name: str,
-    product_version: Optional[str] = None,
-    backend_type: Optional[BackendType] = None,
+    product_version: str | None = None,
+    backend_type: BackendType | None = None,
     client_log_level: int = logging.INFO,
-    client_log_file: Optional[str] = None,
+    client_log_file: str | None = None,
 ):
     """
     Start `PyPIM <https://github.com/ansys/pypim>`_ using the PIM API.

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -30,9 +30,9 @@ import socket
 # Subprocess is needed to start the backend. But
 # the input is controlled by the library. Excluding bandit check.
 import subprocess  # nosec B404
+from typing import TYPE_CHECKING
 
 from ansys.tools.path import get_available_ansys_installations, get_latest_ansys_installation
-from beartype.typing import TYPE_CHECKING, Dict, List
 
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
 from ansys.geometry.core.logger import LOG
@@ -397,7 +397,7 @@ def _is_port_available(port: int, host: str = "localhost") -> bool:
 
 
 def _manifest_path_provider(
-    version: int, available_installations: Dict, manifest_path: str = None
+    version: int, available_installations: dict[str, str], manifest_path: str = None
 ) -> str:
     """Return the ApiServer's add-in manifest file path."""
     if manifest_path:
@@ -425,7 +425,7 @@ def _manifest_path_provider(
         raise RuntimeError(msg)
 
 
-def __start_program(args: List[str], local_env: Dict[str, str]) -> subprocess.Popen:
+def __start_program(args: list[str], local_env: dict[str, str]) -> subprocess.Popen:
     """Start the program.
 
     Notes
@@ -434,10 +434,10 @@ def __start_program(args: List[str], local_env: Dict[str, str]) -> subprocess.Po
 
     Parameters
     ----------
-    args : List[str]
+    args : list[str]
         List of arguments to be passed to the program. The first list's item shall
         be the program path.
-    local_env : Dict[str,str]
+    local_env : dict[str,str]
         Environment variables to be passed to the program.
 
     Returns
@@ -468,7 +468,7 @@ def _check_minimal_versions(latest_installed_version: int) -> None:
         raise SystemError(msg)
 
 
-def _check_version_is_available(version: int, installations: Dict[int, str]) -> None:
+def _check_version_is_available(version: int, installations: dict[int, str]) -> None:
     """Check that the requested version for launcher is installed."""
     if version not in installations:
         msg = (
@@ -501,7 +501,7 @@ def _get_common_env(
     enable_trace: bool,
     server_log_level: int,
     server_logs_folder: str = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Make a copy of the actual system's environment.
 
     Then update or create some environment variables with the provided

--- a/src/ansys/geometry/core/designer/beam.py
+++ b/src/ansys/geometry/core/designer/beam.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Provides for creating and managing a beam."""
 
-from beartype.typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.math.vector import UnitVector3D
@@ -211,7 +211,7 @@ class Beam:
         return self._profile
 
     @property
-    def parent_component(self) -> Union["Component", None]:
+    def parent_component(self) -> "Component":
         """Component node that the beam is under."""
         return self._parent_component
 

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -24,6 +24,7 @@
 from abc import ABC, abstractmethod
 from enum import Enum, unique
 from functools import wraps
+from typing import TYPE_CHECKING, Iterable, Union
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.bodies_pb2 import (
@@ -48,7 +49,6 @@ from ansys.api.geometry.v0.commands_pb2 import (
 )
 from ansys.api.geometry.v0.commands_pb2_grpc import CommandsStub
 from beartype import beartype as check_input_types
-from beartype.typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
@@ -149,22 +149,22 @@ class IBody(ABC):
         return
 
     @abstractmethod
-    def faces(self) -> List[Face]:
+    def faces(self) -> list[Face]:
         """Get a list of all faces within the body.
 
         Returns
         -------
-        List[Face]
+        list[Face]
         """
         return
 
     @abstractmethod
-    def edges(self) -> List[Edge]:
+    def edges(self) -> list[Edge]:
         """Get a list of all edges within the body.
 
         Returns
         -------
-        List[Edge]
+        list[Edge]
         """
         return
 
@@ -179,7 +179,7 @@ class IBody(ABC):
         return
 
     @abstractmethod
-    def surface_thickness(self) -> Union[Quantity, None]:
+    def surface_thickness(self) -> Quantity | None:
         """Get the surface thickness of a surface body.
 
         Notes
@@ -250,19 +250,19 @@ class IBody(ABC):
         return
 
     @abstractmethod
-    def imprint_curves(self, faces: List[Face], sketch: Sketch) -> Tuple[List[Edge], List[Face]]:
+    def imprint_curves(self, faces: list[Face], sketch: Sketch) -> tuple[list[Edge], list[Face]]:
         """Imprint all specified geometries onto specified faces of the body.
 
         Parameters
         ----------
-        faces: List[Face]
-            List of faces to imprint the curves of the sketch onto.
+        faces: list[Face]
+            list of faces to imprint the curves of the sketch onto.
         sketch: Sketch
             All curves to imprint on the faces.
 
         Returns
         -------
-        Tuple[List[Edge], List[Face]]
+        tuple[list[Edge], list[Face]]
             All impacted edges and faces from the imprint operation.
         """
         return
@@ -273,8 +273,8 @@ class IBody(ABC):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:
+        only_one_curve: bool = False,
+    ) -> list[Face]:
         """Project all specified geometries onto the body.
 
         Parameters
@@ -297,7 +297,7 @@ class IBody(ABC):
 
         Returns
         -------
-        List[Face]
+        list[Face]
             All faces from the project curves operation.
         """
         return
@@ -308,8 +308,8 @@ class IBody(ABC):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:  # noqa: D102
+        only_one_curve: bool = False,
+    ) -> list[Face]:  # noqa: D102
         """Project and imprint specified geometries onto the body.
 
         This method combines the ``project_curves()`` and ``imprint_curves()`` method into
@@ -337,20 +337,20 @@ class IBody(ABC):
 
         Returns
         -------
-        List[Face]
+        list[Face]
             All imprinted faces from the operation.
         """
         return
 
     @abstractmethod
-    def translate(self, direction: UnitVector3D, distance: Union[Quantity, Distance, Real]) -> None:
+    def translate(self, direction: UnitVector3D, distance: Quantity | Distance | Real) -> None:
         """Translate the body in a specified direction and distance.
 
         Parameters
         ----------
         direction: UnitVector3D
             Direction of the translation.
-        distance: Union[~pint.Quantity, Distance, Real]
+        distance: ~pint.Quantity | Distance | Real
             Distance (magnitude) of the translation.
 
         Returns
@@ -364,7 +364,7 @@ class IBody(ABC):
         self,
         axis_origin: Point3D,
         axis_direction: UnitVector3D,
-        angle: Union[Quantity, Angle, Real],
+        angle: Quantity | Angle | Real,
     ) -> None:
         """Rotate the geometry body around the specified axis by a given angle.
 
@@ -374,7 +374,7 @@ class IBody(ABC):
             Origin of the rotational axis.
         axis_direction: UnitVector3D
             The axis of rotation.
-        angle: Union[~pint.Quantity, Angle, Real]
+        angle: ~pint.Quantity | Angle | Real
             Angle (magnitude) of the rotation.
 
         Returns
@@ -466,7 +466,7 @@ class IBody(ABC):
         return
 
     @abstractmethod
-    def tessellate(self, merge: Optional[bool] = False) -> Union["PolyData", "MultiBlock"]:
+    def tessellate(self, merge: bool = False) -> Union["PolyData", "MultiBlock"]:
         """Tessellate the body and return the geometry as triangles.
 
         Parameters
@@ -524,9 +524,9 @@ class IBody(ABC):
     def plot(
         self,
         merge: bool = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        **plotting_options: Optional[dict],
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        **plotting_options: dict | None,
     ) -> None:
         """Plot the body.
 
@@ -738,7 +738,7 @@ class MasterBody(IBody):
         return self._is_surface
 
     @property
-    def surface_thickness(self) -> Union[Quantity, None]:  # noqa: D102
+    def surface_thickness(self) -> Quantity | None:  # noqa: D102
         return self._surface_thickness if self.is_surface else None
 
     @property
@@ -747,7 +747,7 @@ class MasterBody(IBody):
 
     @property
     @protect_grpc
-    def faces(self) -> List[Face]:  # noqa: D102
+    def faces(self) -> list[Face]:  # noqa: D102
         self._grpc_client.log.debug(f"Retrieving faces for body {self.id} from server.")
         grpc_faces = self._bodies_stub.GetFaces(self._grpc_id)
         return [
@@ -763,7 +763,7 @@ class MasterBody(IBody):
 
     @property
     @protect_grpc
-    def edges(self) -> List[Edge]:  # noqa: D102
+    def edges(self) -> list[Edge]:  # noqa: D102
         self._grpc_client.log.debug(f"Retrieving edges for body {self.id} from server.")
         grpc_edges = self._bodies_stub.GetEdges(self._grpc_id)
         return [
@@ -834,8 +834,8 @@ class MasterBody(IBody):
     @protect_grpc
     @check_input_types
     def imprint_curves(  # noqa: D102
-        self, faces: List[Face], sketch: Sketch
-    ) -> Tuple[List[Edge], List[Face]]:
+        self, faces: list[Face], sketch: Sketch
+    ) -> tuple[list[Edge], list[Face]]:
         raise NotImplementedError(
             """
             imprint_curves is not implemented at the MasterBody level.
@@ -850,8 +850,8 @@ class MasterBody(IBody):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:
+        only_one_curve: bool = False,
+    ) -> list[Face]:
         raise NotImplementedError(
             """
             project_curves is not implemented at the MasterBody level.
@@ -866,8 +866,8 @@ class MasterBody(IBody):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:
+        only_one_curve: bool = False,
+    ) -> list[Face]:
         raise NotImplementedError(
             """
             imprint_projected_curves is not implemented at the MasterBody level.
@@ -879,7 +879,7 @@ class MasterBody(IBody):
     @check_input_types
     @reset_tessellation_cache
     def translate(  # noqa: D102
-        self, direction: UnitVector3D, distance: Union[Quantity, Distance, Real]
+        self, direction: UnitVector3D, distance: Quantity | Distance | Real
     ) -> None:
         distance = distance if isinstance(distance, Distance) else Distance(distance)
 
@@ -933,7 +933,7 @@ class MasterBody(IBody):
         self,
         axis_origin: Point3D,
         axis_direction: UnitVector3D,
-        angle: Union[Quantity, Angle, Real],
+        angle: Quantity | Angle | Real,
     ) -> None:
         angle = angle if isinstance(angle, Angle) else Angle(angle)
         rotation_magnitude = angle.value.m_as(DEFAULT_UNITS.SERVER_ANGLE)
@@ -1013,7 +1013,7 @@ class MasterBody(IBody):
 
     @protect_grpc
     def tessellate(  # noqa: D102
-        self, merge: Optional[bool] = False, transform: Matrix44 = IDENTITY_MATRIX44
+        self, merge: bool = False, transform: Matrix44 = IDENTITY_MATRIX44
     ) -> Union["PolyData", "MultiBlock"]:
         # lazy import here to improve initial module load time
         import pyvista as pv
@@ -1038,9 +1038,9 @@ class MasterBody(IBody):
     def plot(  # noqa: D102
         self,
         merge: bool = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        **plotting_options: Optional[dict],
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        **plotting_options: dict | None,
     ) -> None:
         raise NotImplementedError(
             "MasterBody does not implement plot methods. Call this method on a body instead."
@@ -1146,7 +1146,7 @@ class Body(IBody):
     @property
     @protect_grpc
     @ensure_design_is_active
-    def faces(self) -> List[Face]:  # noqa: D102
+    def faces(self) -> list[Face]:  # noqa: D102
         self._template._grpc_client.log.debug(f"Retrieving faces for body {self.id} from server.")
         grpc_faces = self._template._bodies_stub.GetFaces(EntityIdentifier(id=self.id))
         return [
@@ -1163,7 +1163,7 @@ class Body(IBody):
     @property
     @protect_grpc
     @ensure_design_is_active
-    def edges(self) -> List[Edge]:  # noqa: D102
+    def edges(self) -> list[Edge]:  # noqa: D102
         self._template._grpc_client.log.debug(f"Retrieving edges for body {self.id} from server.")
         grpc_edges = self._template._bodies_stub.GetEdges(EntityIdentifier(id=self.id))
         return [
@@ -1194,7 +1194,7 @@ class Body(IBody):
         return self._template.is_surface
 
     @property
-    def _surface_thickness(self) -> Union[Quantity, None]:  # noqa: D102
+    def _surface_thickness(self) -> Quantity | None:  # noqa: D102
         return self._template.surface_thickness
 
     @_surface_thickness.setter
@@ -1202,7 +1202,7 @@ class Body(IBody):
         self._template._surface_thickness = value
 
     @property
-    def surface_thickness(self) -> Union[Quantity, None]:  # noqa: D102
+    def surface_thickness(self) -> Quantity | None:  # noqa: D102
         return self._surface_thickness
 
     @property
@@ -1239,8 +1239,8 @@ class Body(IBody):
     @protect_grpc
     @ensure_design_is_active
     def imprint_curves(  # noqa: D102
-        self, faces: List[Face], sketch: Sketch
-    ) -> Tuple[List[Edge], List[Face]]:
+        self, faces: list[Face], sketch: Sketch
+    ) -> tuple[list[Edge], list[Face]]:
         # Verify that each of the faces provided are part of this body
         body_faces = self.faces
         for provided_face in faces:
@@ -1294,8 +1294,8 @@ class Body(IBody):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:
+        only_one_curve: bool = False,
+    ) -> list[Face]:
         curves = sketch_shapes_to_grpc_geometries(
             sketch._plane, sketch.edges, sketch.faces, only_one_curve=only_one_curve
         )
@@ -1330,8 +1330,8 @@ class Body(IBody):
         direction: UnitVector3D,
         sketch: Sketch,
         closest_face: bool,
-        only_one_curve: Optional[bool] = False,
-    ) -> List[Face]:
+        only_one_curve: bool = False,
+    ) -> list[Face]:
         curves = sketch_shapes_to_grpc_geometries(
             sketch._plane, sketch.edges, sketch.faces, only_one_curve=only_one_curve
         )
@@ -1368,7 +1368,7 @@ class Body(IBody):
 
     @ensure_design_is_active
     def translate(  # noqa: D102
-        self, direction: UnitVector3D, distance: Union[Quantity, Distance, Real]
+        self, direction: UnitVector3D, distance: Quantity | Distance | Real
     ) -> None:
         return self._template.translate(direction, distance)
 
@@ -1377,7 +1377,7 @@ class Body(IBody):
         self,
         axis_origin: Point3D,
         axis_direction: UnitVector3D,
-        angle: Union[Quantity, Angle, Real],
+        angle: Quantity | Angle | Real,
     ) -> None:
         return self._template.rotate(axis_origin, axis_direction, angle)
 
@@ -1403,17 +1403,16 @@ class Body(IBody):
 
     @ensure_design_is_active
     def tessellate(  # noqa: D102
-        self, merge: Optional[bool] = False
+        self, merge: bool = False
     ) -> Union["PolyData", "MultiBlock"]:
         return self._template.tessellate(merge, self.parent_component.get_world_transform())
 
     def plot(  # noqa: D102
         self,
         merge: bool = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        show_options: Optional[dict] = None,
-        **plotting_options: Optional[dict],
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        **plotting_options: dict | None,
     ) -> None:
         # lazy import here to improve initial module load time
         from ansys.tools.visualization_interface.types.mesh_object_plot import (

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -22,6 +22,7 @@
 """Provides for managing components."""
 
 from enum import Enum, unique
+from typing import TYPE_CHECKING, Optional, Union
 import uuid
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
@@ -47,7 +48,6 @@ from ansys.api.geometry.v0.components_pb2 import (
 from ansys.api.geometry.v0.components_pb2_grpc import ComponentsStub
 from ansys.api.geometry.v0.models_pb2 import Direction, Line, TrimmedCurveList
 from beartype import beartype as check_input_types
-from beartype.typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
@@ -147,10 +147,10 @@ class Component:
     """
 
     # Types of the class instance private attributes
-    _components: List["Component"]
-    _beams: List[Beam]
-    _coordinate_systems: List[CoordinateSystem]
-    _design_points: List[DesignPoint]
+    _components: list["Component"]
+    _beams: list[Beam]
+    _coordinate_systems: list[CoordinateSystem]
+    _design_points: list[DesignPoint]
 
     @protect_grpc
     @check_input_types
@@ -160,8 +160,8 @@ class Component:
         parent_component: Union["Component", None],
         grpc_client: GrpcClient,
         template: Optional["Component"] = None,
-        preexisting_id: Optional[str] = None,
-        master_component: Optional[MasterComponent] = None,
+        preexisting_id: str | None = None,
+        master_component: MasterComponent | None = None,
         read_existing_comp: bool = False,
     ):
         """Initialize the ``Component`` class."""
@@ -232,12 +232,12 @@ class Component:
         return self._name
 
     @property
-    def components(self) -> List["Component"]:
+    def components(self) -> list["Component"]:
         """List of ``Component`` objects inside of the component."""
         return self._components
 
     @property
-    def bodies(self) -> List[Body]:
+    def bodies(self) -> list[Body]:
         """List of ``Body`` objects inside of the component."""
         bodies = []
         for body in self._master_component.part.bodies:
@@ -247,22 +247,22 @@ class Component:
         return bodies
 
     @property
-    def beams(self) -> List[Beam]:
+    def beams(self) -> list[Beam]:
         """List of ``Beam`` objects inside of the component."""
         return self._beams
 
     @property
-    def design_points(self) -> List[DesignPoint]:
+    def design_points(self) -> list[DesignPoint]:
         """List of ``DesignPoint`` objects inside of the component."""
         return self._design_points
 
     @property
-    def coordinate_systems(self) -> List[CoordinateSystem]:
+    def coordinate_systems(self) -> list[CoordinateSystem]:
         """List of ``CoordinateSystem`` objects inside of the component."""
         return self._coordinate_systems
 
     @property
-    def parent_component(self) -> Union["Component", None]:
+    def parent_component(self) -> "Component":
         """Parent of the component."""
         return self._parent_component
 
@@ -272,7 +272,7 @@ class Component:
         return self._is_alive
 
     @property
-    def shared_topology(self) -> Union[SharedTopologyType, None]:
+    def shared_topology(self) -> SharedTopologyType | None:
         """Shared topology type of the component (if any).
 
         Notes
@@ -311,10 +311,10 @@ class Component:
     @ensure_design_is_active
     def modify_placement(
         self,
-        translation: Optional[Vector3D] = None,
-        rotation_origin: Optional[Point3D] = None,
-        rotation_direction: Optional[UnitVector3D] = None,
-        rotation_angle: Union[Quantity, Angle, Real] = 0,
+        translation: Vector3D | None = None,
+        rotation_origin: Point3D | None = None,
+        rotation_direction: UnitVector3D | None = None,
+        rotation_angle: Quantity | Angle | Real = 0,
     ):
         """Apply a translation and/or rotation to the placement matrix.
 
@@ -331,7 +331,7 @@ class Component:
             Origin that defines the axis to rotate the component about.
         rotation_direction : UnitVector3D, default: None
             Direction of the axis to rotate the component about.
-        rotation_angle : Union[~pint.Quantity, Angle, Real], default: 0
+        rotation_angle : ~pint.Quantity | Angle | Real, default: 0
             Angle to rotate the component around the axis.
         """
         t = (
@@ -433,8 +433,8 @@ class Component:
         self,
         name: str,
         sketch: Sketch,
-        distance: Union[Quantity, Distance, Real],
-        direction: Union[ExtrusionDirection, str] = ExtrusionDirection.POSITIVE,
+        distance: Quantity | Distance | Real,
+        direction: ExtrusionDirection | str = ExtrusionDirection.POSITIVE,
     ) -> Body:
         """Create a solid body by extruding the sketch profile a distance.
 
@@ -448,9 +448,9 @@ class Component:
             User-defined label for the new solid body.
         sketch : Sketch
             Two-dimensional sketch source for the extrusion.
-        distance : Union[~pint.Quantity, Distance, Real]
+        distance : ~pint.Quantity | Distance | Real
             Distance to extrude the solid body.
-        direction : Union[ExtrusionDirection, str], default: "+"
+        direction : ExtrusionDirection | str, default: "+"
             Direction for extruding the solid body.
             The default is to extrude in the positive normal direction of the sketch.
             Options are "+" and "-" as a string, or the enum values.
@@ -492,7 +492,7 @@ class Component:
         self,
         name: str,
         sketch: Sketch,
-        path: List[TrimmedCurve],
+        path: list[TrimmedCurve],
     ) -> Body:
         """Create a body by sweeping a planar profile along a path.
 
@@ -506,7 +506,7 @@ class Component:
             User-defined label for the new solid body.
         sketch : Sketch
             Two-dimensional sketch source for the extrusion.
-        path : List[TrimmedCurve]
+        path : list[TrimmedCurve]
             The path to sweep the profile along.
 
         Returns
@@ -540,8 +540,8 @@ class Component:
     def sweep_chain(
         self,
         name: str,
-        path: List[TrimmedCurve],
-        chain: List[TrimmedCurve],
+        path: list[TrimmedCurve],
+        chain: list[TrimmedCurve],
     ) -> Body:
         """Create a body by sweeping a chain of curves along a path.
 
@@ -553,9 +553,9 @@ class Component:
         ----------
         name : str
             User-defined label for the new solid body.
-        path : List[TrimmedCurve]
+        path : list[TrimmedCurve]
             The path to sweep the chain along.
-        chain : List[TrimmedCurve]
+        chain : list[TrimmedCurve]
             A chain of trimmed curves.
 
         Returns
@@ -587,7 +587,7 @@ class Component:
         name: str,
         sketch: Sketch,
         axis: Vector3D,
-        angle: Union[Quantity, Angle, Real],
+        angle: Quantity | Angle | Real,
         rotation_origin: Point3D,
     ) -> Body:
         """Create a solid body by revolving a sketch profile around an axis.
@@ -600,7 +600,7 @@ class Component:
             Two-dimensional sketch source for the revolve.
         axis : Vector3D
             Axis of rotation for the revolve.
-        angle : Union[~pint.Quantity, Angle, Real]
+        angle : ~pint.Quantity | Angle | Real
             Angle to revolve the solid body around the axis. The angle can be positive or negative.
         rotation_origin : Point3D
             Origin of the axis of rotation.
@@ -640,8 +640,8 @@ class Component:
         self,
         name: str,
         face: Face,
-        distance: Union[Quantity, Distance],
-        direction: Union[ExtrusionDirection, str] = ExtrusionDirection.POSITIVE,
+        distance: Quantity | Distance,
+        direction: ExtrusionDirection | str = ExtrusionDirection.POSITIVE,
     ) -> Body:
         """Extrude the face profile by a given distance to create a solid body.
 
@@ -659,9 +659,9 @@ class Component:
             User-defined label for the new solid body.
         face : Face
             Target face to use as the source for the new surface.
-        distance : Union[~pint.Quantity, Distance, Real]
+        distance : ~pint.Quantity | Distance | Real
             Distance to extrude the solid body.
-        direction : Union[ExtrusionDirection, str], default: "+"
+        direction : ExtrusionDirection | str, default: "+"
             Direction for extruding the solid body's face.
             The default is to extrude in the positive normal direction of the face.
             Options are "+" and "-" as a string, or the enum values.
@@ -735,7 +735,7 @@ class Component:
     def create_body_from_loft_profile(
         self,
         name: str,
-        profiles: List[List[TrimmedCurve]],
+        profiles: list[list[TrimmedCurve]],
         periodic: bool = False,
         ruled: bool = False,
     ) -> Body:
@@ -745,7 +745,7 @@ class Component:
         ----------
         name : str
             Name of the lofted body.
-        profiles : List[List[TrimmedCurve]]
+        profiles : list[list[TrimmedCurve]]
             Collection of lists of trimmed curves (profiles) defining the lofted body's shape.
         periodic : bool, default: False
             Whether the lofted body should have periodic continuity.
@@ -897,7 +897,7 @@ class Component:
     @check_input_types
     @ensure_design_is_active
     def translate_bodies(
-        self, bodies: List[Body], direction: UnitVector3D, distance: Union[Quantity, Distance, Real]
+        self, bodies: list[Body], direction: UnitVector3D, distance: Quantity | Distance | Real
     ) -> None:
         """Translate the bodies in a specified direction by a distance.
 
@@ -908,11 +908,11 @@ class Component:
 
         Parameters
         ----------
-        bodies: List[Body]
-            List of bodies to translate by the same distance.
+        bodies: list[Body]
+            list of bodies to translate by the same distance.
         direction: UnitVector3D
             Direction of the translation.
-        distance: Union[~pint.Quantity, Distance, Real]
+        distance: ~pint.Quantity | Distance | Real
             Magnitude of the translation.
 
         Returns
@@ -949,8 +949,8 @@ class Component:
     @check_input_types
     @ensure_design_is_active
     def create_beams(
-        self, segments: List[Tuple[Point3D, Point3D]], profile: BeamProfile
-    ) -> List[Beam]:
+        self, segments: list[tuple[Point3D, Point3D]], profile: BeamProfile
+    ) -> list[Beam]:
         """Create beams under the component.
 
         Notes
@@ -960,8 +960,8 @@ class Component:
 
         Parameters
         ----------
-        segments : List[Tuple[Point3D, Point3D]]
-            List of start and end pairs, each specifying a single line segment.
+        segments : list[tuple[Point3D, Point3D]]
+            list of start and end pairs, each specifying a single line segment.
         profile : BeamProfile
             Beam profile to use to create the beams.
         """
@@ -1019,7 +1019,7 @@ class Component:
 
         Parameters
         ----------
-        component : Union[Component, str]
+        component : Component | str
             ID of the component or instance to delete.
         """
         id = component if isinstance(component, str) else component.id
@@ -1044,7 +1044,7 @@ class Component:
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def delete_body(self, body: Union[Body, str]) -> None:
+    def delete_body(self, body: Body | str) -> None:
         """Delete a body belonging to this component (or its children).
 
         Notes
@@ -1054,7 +1054,7 @@ class Component:
 
         Parameters
         ----------
-        body : Union[Body, str]
+        body : Body | str
             ID of the body or instance to delete.
         """
         id = body if isinstance(body, str) else body.id
@@ -1098,16 +1098,16 @@ class Component:
     def add_design_points(
         self,
         name: str,
-        points: List[Point3D],
-    ) -> List[DesignPoint]:
+        points: list[Point3D],
+    ) -> list[DesignPoint]:
         """Create a list of design points.
 
         Parameters
         ----------
         name : str
             User-defined label for the list of design points.
-        points : List[Point3D]
-            List of the 3D points that constitute the list of design points.
+        points : list[Point3D]
+            list of the 3D points that constitute the list of design points.
         """
         # Create DesignPoint objects server-side
         self._grpc_client.log.debug(f"Creating design points on {self.id}...")
@@ -1131,7 +1131,7 @@ class Component:
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def delete_beam(self, beam: Union[Beam, str]) -> None:
+    def delete_beam(self, beam: Beam | str) -> None:
         """Delete an existing beam belonging to this component's scope.
 
         Notes
@@ -1142,7 +1142,7 @@ class Component:
 
         Parameters
         ----------
-        beam : Union[Beam, str]
+        beam : Beam | str
             ID of the beam or instance to delete.
         """
         id = beam if isinstance(beam, str) else beam.id
@@ -1197,7 +1197,7 @@ class Component:
         return None
 
     @check_input_types
-    def search_body(self, id: str) -> Union[Body, None]:
+    def search_body(self, id: str) -> Body | None:
         """Search bodies in the component's scope.
 
         Notes
@@ -1212,7 +1212,7 @@ class Component:
 
         Returns
         -------
-        Body
+        Body | None
             Body with the requested ID. If the ID is not found, ``None`` is returned.
         """
         # Search in component's bodies
@@ -1231,7 +1231,7 @@ class Component:
         return None
 
     @check_input_types
-    def search_beam(self, id: str) -> Union[Beam, None]:
+    def search_beam(self, id: str) -> Beam | None:
         """Search beams in the component's scope.
 
         Notes
@@ -1246,7 +1246,7 @@ class Component:
 
         Returns
         -------
-        Union[Beam, None]
+        Beam | None
             Beam with the requested ID. If the ID is not found, ``None`` is returned.
         """
         # Search in component's beams
@@ -1362,9 +1362,9 @@ class Component:
         self,
         merge_component: bool = False,
         merge_bodies: bool = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        **plotting_options: Optional[dict],
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        **plotting_options: dict | None,
     ) -> None:
         """Plot the component.
 

--- a/src/ansys/geometry/core/designer/coordinate_system.py
+++ b/src/ansys/geometry/core/designer/coordinate_system.py
@@ -21,9 +21,10 @@
 # SOFTWARE.
 """Provides for managing a user-defined coordinate system."""
 
+from typing import TYPE_CHECKING
+
 from ansys.api.geometry.v0.coordinatesystems_pb2 import CreateRequest
 from ansys.api.geometry.v0.coordinatesystems_pb2_grpc import CoordinateSystemsStub
-from beartype.typing import TYPE_CHECKING, Optional
 
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.conversions import frame_to_grpc_frame
@@ -62,7 +63,7 @@ class CoordinateSystem:
         frame: Frame,
         parent_component: "Component",
         grpc_client: GrpcClient,
-        preexisting_id: Optional[str] = None,
+        preexisting_id: str | None = None,
     ):
         """Initialize the ``CoordinateSystem`` class."""
         self._parent_component = parent_component

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -23,6 +23,7 @@
 
 from enum import Enum, unique
 from pathlib import Path
+from typing import Union
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier, PartExportFormat
 from ansys.api.dbu.v0.designs_pb2 import InsertRequest, NewRequest, SaveAsRequest
@@ -43,7 +44,6 @@ from ansys.api.geometry.v0.namedselections_pb2_grpc import NamedSelectionsStub
 from ansys.api.geometry.v0.parts_pb2 import ExportRequest
 from ansys.api.geometry.v0.parts_pb2_grpc import PartsStub
 from beartype import beartype as check_input_types
-from beartype.typing import Dict, List, Optional, Union
 from google.protobuf.empty_pb2 import Empty
 import numpy as np
 from pint import Quantity, UndefinedUnitError
@@ -109,9 +109,9 @@ class Design(Component):
     """
 
     # Types of the class instance private attributes
-    _materials: List[Material]
-    _named_selections: Dict[str, NamedSelection]
-    _beam_profiles: Dict[str, BeamProfile]
+    _materials: list[Material]
+    _named_selections: dict[str, NamedSelection]
+    _beam_profiles: dict[str, BeamProfile]
 
     @protect_grpc
     @check_input_types
@@ -151,17 +151,17 @@ class Design(Component):
         return self._design_id
 
     @property
-    def materials(self) -> List[Material]:
+    def materials(self) -> list[Material]:
         """List of materials available for the design."""
         return self._materials
 
     @property
-    def named_selections(self) -> List[NamedSelection]:
+    def named_selections(self) -> list[NamedSelection]:
         """List of named selections available for the design."""
         return list(self._named_selections.values())
 
     @property
-    def beam_profiles(self) -> List[BeamProfile]:
+    def beam_profiles(self) -> list[BeamProfile]:
         """List of beam profile available for the design."""
         return list(self._beam_profiles.values())
 
@@ -221,12 +221,12 @@ class Design(Component):
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def save(self, file_location: Union[Path, str]) -> None:
+    def save(self, file_location: Path | str) -> None:
         """Save a design to disk on the active Geometry server instance.
 
         Parameters
         ----------
-        file_location : Union[~pathlib.Path, str]
+        file_location : ~pathlib.Path | str
             Location on disk to save the file to.
         """
         # Sanity checks on inputs
@@ -241,16 +241,16 @@ class Design(Component):
     @ensure_design_is_active
     def download(
         self,
-        file_location: Union[Path, str],
-        format: Optional[DesignFileFormat] = DesignFileFormat.SCDOCX,
+        file_location: Path | str,
+        format: DesignFileFormat = DesignFileFormat.SCDOCX,
     ) -> None:
         """Export and download the design from the server.
 
         Parameters
         ----------
-        file_location : Union[~pathlib.Path, str]
+        file_location : ~pathlib.Path | str
             Location on disk to save the file to.
-        format :DesignFileFormat, default: DesignFileFormat.SCDOCX
+        format : DesignFileFormat, default: DesignFileFormat.SCDOCX
             Format for the file to save to.
         """
         # Sanity checks on inputs
@@ -293,12 +293,12 @@ class Design(Component):
             f"Design is successfully downloaded at location {file_location}."
         )
 
-    def __build_export_file_location(self, location: Union[Path, str, None], ext: str) -> Path:
+    def __build_export_file_location(self, location: Path | str | None, ext: str) -> Path:
         """Build the file location for export functions.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str, None]
+        location : ~pathlib.Path | str
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
         ext : str
@@ -311,12 +311,12 @@ class Design(Component):
         """
         return (Path(location) if location else Path.cwd()) / f"{self.name}.{ext}"
 
-    def export_to_scdocx(self, location: Union[Path, str] = None) -> str:
+    def export_to_scdocx(self, location: Path | str | None = None) -> str:
         """Export the design to an scdocx file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -334,12 +334,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_parasolid_text(self, location: Union[Path, str] = None) -> str:
+    def export_to_parasolid_text(self, location: Path | str | None = None) -> str:
         """Export the design to a Parasolid text file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -360,12 +360,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_parasolid_bin(self, location: Union[Path, str] = None) -> str:
+    def export_to_parasolid_bin(self, location: Path | str | None = None) -> str:
         """Export the design to a Parasolid binary file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -386,12 +386,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_fmd(self, location: Union[Path, str] = None) -> str:
+    def export_to_fmd(self, location: Path | str | None = None) -> str:
         """Export the design to an FMD file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -409,12 +409,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_step(self, location: Union[Path, str] = None) -> str:
+    def export_to_step(self, location: Path | str | None = None) -> str:
         """Export the design to a STEP file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -432,12 +432,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_iges(self, location: Union[Path, str] = None) -> str:
+    def export_to_iges(self, location: Path | str = None) -> str:
         """Export the design to an IGES file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -455,12 +455,12 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_pmdb(self, location: Union[Path, str] = None) -> str:
+    def export_to_pmdb(self, location: Path | str | None = None) -> str:
         """Export the design to a PMDB file.
 
         Parameters
         ----------
-        location : Union[~pathlib.Path, str], optional
+        location : ~pathlib.Path | str, optional
             Location on disk to save the file to. If None, the file will be saved
             in the current working directory.
 
@@ -483,11 +483,11 @@ class Design(Component):
     def create_named_selection(
         self,
         name: str,
-        bodies: Optional[List[Body]] = None,
-        faces: Optional[List[Face]] = None,
-        edges: Optional[List[Edge]] = None,
-        beams: Optional[List[Beam]] = None,
-        design_points: Optional[List[DesignPoint]] = None,
+        bodies: list[Body] | None = None,
+        faces: list[Face] | None = None,
+        edges: list[Edge] | None = None,
+        beams: list[Beam] | None = None,
+        design_points: list[DesignPoint] | None = None,
     ) -> NamedSelection:
         """Create a named selection on the active Geometry server instance.
 
@@ -495,15 +495,15 @@ class Design(Component):
         ----------
         name : str
             User-defined name for the named selection.
-        bodies : List[Body], default: None
+        bodies : list[Body], default: None
             All bodies to include in the named selection.
-        faces : List[Face], default: None
+        faces : list[Face], default: None
             All faces to include in the named selection.
-        edges : List[Edge], default: None
+        edges : list[Edge], default: None
             All edges to include in the named selection.
-        beams : List[Beam], default: None
+        beams : list[Beam], default: None
             All beams to include in the named selection.
-        design_points : List[DesignPoint], default: None
+        design_points : list[DesignPoint], default: None
             All design points to include in the named selection.
 
         Returns
@@ -531,12 +531,12 @@ class Design(Component):
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def delete_named_selection(self, named_selection: Union[NamedSelection, str]) -> None:
+    def delete_named_selection(self, named_selection: NamedSelection | str) -> None:
         """Delete a named selection on the active Geometry server instance.
 
         Parameters
         ----------
-        named_selection : Union[NamedSelection, str]
+        named_selection : NamedSelection | str
             Name of the named selection or instance.
         """
         if isinstance(named_selection, str):
@@ -607,10 +607,10 @@ class Design(Component):
     def add_beam_circular_profile(
         self,
         name: str,
-        radius: Union[Quantity, Distance],
-        center: Union[np.ndarray, RealSequence, Point3D] = ZERO_POINT3D,
-        direction_x: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        direction_y: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Y,
+        radius: Quantity | Distance,
+        center: np.ndarray | RealSequence | Point3D = ZERO_POINT3D,
+        direction_x: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        direction_y: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Y,
     ) -> BeamCircularProfile:
         """Add a new beam circular profile under the design for creating beams.
 
@@ -618,13 +618,13 @@ class Design(Component):
         ----------
         name : str
             User-defined label for the new beam circular profile.
-        radius : Real
+        radius : ~pint.Quantity | Distance
             Radius of the beam circular profile.
-        center : Union[~numpy.ndarray, RealSequence, Point3D]
+        center : ~numpy.ndarray | RealSequence | Point3D
             Center of the beam circular profile.
-        direction_x : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+        direction_x : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
             X-plane direction.
-        direction_y : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+        direction_y : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
             Y-plane direction.
         """
         dir_x = direction_x if isinstance(direction_x, UnitVector3D) else UnitVector3D(direction_x)
@@ -659,14 +659,14 @@ class Design(Component):
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def add_midsurface_thickness(self, thickness: Quantity, bodies: List[Body]) -> None:
+    def add_midsurface_thickness(self, thickness: Quantity, bodies: list[Body]) -> None:
         """Add a mid-surface thickness to a list of bodies.
 
         Parameters
         ----------
         thickness : ~pint.Quantity
             Thickness to be assigned.
-        bodies : List[Body]
+        bodies : list[Body]
             All bodies to include in the mid-surface thickness assignment.
 
         Notes
@@ -674,8 +674,8 @@ class Design(Component):
         Only surface bodies will be eligible for mid-surface thickness assignment.
         """
         # Store only assignable ids
-        ids: List[str] = []
-        ids_bodies: List[Body] = []
+        ids: list[str] = []
+        ids_bodies: list[Body] = []
         for body in bodies:
             if body.is_surface:
                 ids.append(body.id)
@@ -699,14 +699,14 @@ class Design(Component):
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def add_midsurface_offset(self, offset_type: MidSurfaceOffsetType, bodies: List[Body]) -> None:
+    def add_midsurface_offset(self, offset_type: MidSurfaceOffsetType, bodies: list[Body]) -> None:
         """Add a mid-surface offset type to a list of bodies.
 
         Parameters
         ----------
         offset_type : MidSurfaceOffsetType
             Surface offset to be assigned.
-        bodies : List[Body]
+        bodies : list[Body]
             All bodies to include in the mid-surface offset assignment.
 
         Notes
@@ -714,8 +714,8 @@ class Design(Component):
         Only surface bodies will be eligible for mid-surface offset assignment.
         """
         # Store only assignable ids
-        ids: List[str] = []
-        ids_bodies: List[Body] = []
+        ids: list[str] = []
+        ids_bodies: list[Body] = []
         for body in bodies:
             if body.is_surface:
                 ids.append(body.id)
@@ -737,12 +737,12 @@ class Design(Component):
     @protect_grpc
     @check_input_types
     @ensure_design_is_active
-    def delete_beam_profile(self, beam_profile: Union[BeamProfile, str]) -> None:
+    def delete_beam_profile(self, beam_profile: BeamProfile | str) -> None:
         """Remove a beam profile on the active geometry server instance.
 
         Parameters
         ----------
-        beam_profile : Union[BeamProfile, str]
+        beam_profile : BeamProfile | str
             A beam profile name or instance that should be deleted.
         """
         removal_name = beam_profile if isinstance(beam_profile, str) else beam_profile.name
@@ -763,12 +763,12 @@ class Design(Component):
     @check_input_types
     @ensure_design_is_active
     @min_backend_version(24, 2, 0)
-    def insert_file(self, file_location: Union[Path, str]) -> Component:
+    def insert_file(self, file_location: Path | str) -> Component:
         """Insert a file into the design.
 
         Parameters
         ----------
-        file_location : Union[~pathlib.Path, str]
+        file_location : ~pathlib.Path | str
             Location on disk where the file is located.
 
         Returns

--- a/src/ansys/geometry/core/designer/designpoint.py
+++ b/src/ansys/geometry/core/designer/designpoint.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Module for creating and managing design points."""
 
-from beartype.typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.misc.checks import check_type
@@ -78,7 +78,7 @@ class DesignPoint:
         return self._value
 
     @property
-    def parent_component(self) -> Union["Component", None]:
+    def parent_component(self) -> "Component":
         """Component node that the design point is under."""
         return self._parent_component
 

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -22,10 +22,10 @@
 """Module for managing an edge."""
 
 from enum import Enum, unique
+from typing import TYPE_CHECKING
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.edges_pb2_grpc import EdgesStub
-from beartype.typing import TYPE_CHECKING, List
 from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
@@ -159,7 +159,7 @@ class Edge:
     @property
     @protect_grpc
     @ensure_design_is_active
-    def faces(self) -> List["Face"]:
+    def faces(self) -> list["Face"]:
         """Faces that contain the edge."""
         from ansys.geometry.core.designer.face import Face, SurfaceType
 

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -22,6 +22,7 @@
 """Module for managing a face."""
 
 from enum import Enum, unique
+from typing import TYPE_CHECKING
 
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.edges_pb2_grpc import EdgesStub
@@ -32,7 +33,6 @@ from ansys.api.geometry.v0.faces_pb2 import (
 )
 from ansys.api.geometry.v0.faces_pb2_grpc import FacesStub
 from ansys.api.geometry.v0.models_pb2 import Edge as GRPCEdge
-from beartype.typing import TYPE_CHECKING, List
 from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
@@ -99,7 +99,7 @@ class FaceLoop:
         Minimum point of the bounding box containing the loop.
     max_bbox : Point3D
         Maximum point of the bounding box containing the loop.
-    edges : List[Edge]
+    edges : list[Edge]
         Edges contained in the loop.
     """
 
@@ -109,7 +109,7 @@ class FaceLoop:
         length: Quantity,
         min_bbox: Point3D,
         max_bbox: Point3D,
-        edges: List[Edge],
+        edges: list[Edge],
     ):
         """Initialize ``FaceLoop`` class."""
         self._type = type
@@ -139,7 +139,7 @@ class FaceLoop:
         return self._max_bbox
 
     @property
-    def edges(self) -> List[Edge]:
+    def edges(self) -> list[Edge]:
         """Edges contained in the loop."""
         return self._edges
 
@@ -243,7 +243,7 @@ class Face:
     @property
     @protect_grpc
     @ensure_design_is_active
-    def edges(self) -> List[Edge]:
+    def edges(self) -> list[Edge]:
         """List of all edges of the face."""
         self._grpc_client.log.debug("Requesting face edges from server.")
         edges_response = self._faces_stub.GetEdges(self._grpc_id)
@@ -252,7 +252,7 @@ class Face:
     @property
     @protect_grpc
     @ensure_design_is_active
-    def loops(self) -> List[FaceLoop]:
+    def loops(self) -> list[FaceLoop]:
         """List of all loops of the face."""
         self._grpc_client.log.debug("Requesting face loops from server.")
         grpc_loops = self._faces_stub.GetLoops(EntityIdentifier(id=self.id)).loops
@@ -404,17 +404,17 @@ class Face:
         """
         return self.point(u, v)
 
-    def __grpc_edges_to_edges(self, edges_grpc: List[GRPCEdge]) -> List[Edge]:
+    def __grpc_edges_to_edges(self, edges_grpc: list[GRPCEdge]) -> list[Edge]:
         """Transform a list of gRPC edge messages into actual ``Edge`` objects.
 
         Parameters
         ----------
-        edges_grpc : List[GRPCEdge]
-            List of gRPC messages of type ``Edge``.
+        edges_grpc : list[GRPCEdge]
+            list of gRPC messages of type ``Edge``.
 
         Returns
         -------
-        List[Edge]
+        list[Edge]
             ``Edge`` objects to obtain from gRPC messages.
         """
         from ansys.geometry.core.designer.edge import CurveType, Edge
@@ -436,7 +436,7 @@ class Face:
     @ensure_design_is_active
     def create_isoparametric_curves(
         self, use_u_param: bool, parameter: float
-    ) -> List[TrimmedCurve]:
+    ) -> list[TrimmedCurve]:
         """Create isoparametic curves at the given proportional parameter.
 
         Typically, only one curve is created, but if the face has a hole, it is possible that
@@ -452,8 +452,8 @@ class Face:
 
         Returns
         -------
-        List[TrimmedCurve]
-            List of curves that were created.
+        list[TrimmedCurve]
+            list of curves that were created.
         """
         curves = self._faces_stub.CreateIsoParamCurves(
             CreateIsoParamCurvesRequest(id=self.id, u_dir_curve=use_u_param, proportion=parameter)

--- a/src/ansys/geometry/core/designer/part.py
+++ b/src/ansys/geometry/core/designer/part.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Module providing fundamental data of an assembly."""
 
-from beartype.typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.designer.body import MasterBody
 from ansys.geometry.core.math.constants import IDENTITY_MATRIX44
@@ -43,20 +43,20 @@ class Part:
         Unique identifier for the part.
     name : str
         Name of the part.
-    components : List[MasterComponent]
-        List of ``MasterComponent`` children that the part contains.
-    bodies : List[MasterBody]
-        List of ``MasterBody`` children that the part contains. These are master bodies.
+    components : list[MasterComponent]
+        list of ``MasterComponent`` children that the part contains.
+    bodies : list[MasterBody]
+        list of ``MasterBody`` children that the part contains. These are master bodies.
     """
 
     def __init__(
-        self, id: str, name: str, components: List["MasterComponent"], bodies: List[MasterBody]
+        self, id: str, name: str, components: list["MasterComponent"], bodies: list[MasterBody]
     ) -> None:
         """Initialize the ``Part`` class."""
         self._id: str = id
         self._name: str = name
-        self._components: List["MasterComponent"] = components
-        self._bodies: List[MasterBody] = bodies
+        self._components: list["MasterComponent"] = components
+        self._bodies: list[MasterBody] = bodies
 
     @property
     def id(self) -> str:
@@ -69,16 +69,16 @@ class Part:
         return self._name
 
     @property
-    def components(self) -> List["MasterComponent"]:
+    def components(self) -> list["MasterComponent"]:
         """``MasterComponent`` children that the part contains."""
         return self._components
 
     @components.setter
-    def components(self, components: List["MasterComponent"]) -> None:
+    def components(self, components: list["MasterComponent"]) -> None:
         self._components = components
 
     @property
-    def bodies(self) -> List[MasterBody]:
+    def bodies(self) -> list[MasterBody]:
         """``MasterBody`` children that the part contains.
 
         These are master bodies.
@@ -86,7 +86,7 @@ class Part:
         return self._bodies
 
     @bodies.setter
-    def bodies(self, bodies: List["MasterBody"]) -> None:
+    def bodies(self, bodies: list["MasterBody"]) -> None:
         self._bodies = bodies
 
     def __repr__(self) -> str:
@@ -128,7 +128,7 @@ class MasterComponent:
         self._part: Part = part
         part.components.append(self)
         self._transform: Matrix44 = transform
-        self._occurrences: List["Component"] = []
+        self._occurrences: list["Component"] = []
 
     @property
     def id(self) -> str:
@@ -141,7 +141,7 @@ class MasterComponent:
         return self._name
 
     @property
-    def occurrences(self) -> List["Component"]:
+    def occurrences(self) -> list["Component"]:
         """List of all occurrences of the component."""
         return self._occurrences
 

--- a/src/ansys/geometry/core/designer/selection.py
+++ b/src/ansys/geometry/core/designer/selection.py
@@ -24,7 +24,6 @@
 from ansys.api.geometry.v0.namedselections_pb2 import CreateRequest
 from ansys.api.geometry.v0.namedselections_pb2_grpc import NamedSelectionsStub
 from beartype import beartype as check_input_types
-from beartype.typing import List, Optional
 
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.designer.beam import Beam
@@ -49,15 +48,15 @@ class NamedSelection:
         User-defined name for the named selection.
     grpc_client : GrpcClient
         Active supporting Geometry service instance for design modeling.
-    bodies : List[Body], default: None
+    bodies : list[Body], default: None
         All bodies to include in the named selection.
-    faces : List[Face], default: None
+    faces : list[Face], default: None
         All faces to include in the named selection.
-    edges : List[Edge], default: None
+    edges : list[Edge], default: None
         All edges to include in the named selection.
-    beams : List[Beam], default: None
+    beams : list[Beam], default: None
         All beams to include in the named selection.
-    design_points : List[DesignPoints], default: None
+    design_points : list[DesignPoints], default: None
         All design points to include in the named selection.
     """
 
@@ -67,12 +66,12 @@ class NamedSelection:
         self,
         name: str,
         grpc_client: GrpcClient,
-        bodies: Optional[List[Body]] = None,
-        faces: Optional[List[Face]] = None,
-        edges: Optional[List[Edge]] = None,
-        beams: Optional[List[Beam]] = None,
-        design_points: Optional[List[DesignPoint]] = None,
-        preexisting_id: Optional[str] = None,
+        bodies: list[Body] | None = None,
+        faces: list[Face] | None = None,
+        edges: list[Edge] | None = None,
+        beams: list[Beam] | None = None,
+        design_points: list[DesignPoint] | None = None,
+        preexisting_id: str | None = None,
     ):
         """Initialize the ``NamedSelection`` class."""
         self._grpc_client = grpc_client

--- a/src/ansys/geometry/core/logger.py
+++ b/src/ansys/geometry/core/logger.py
@@ -130,9 +130,8 @@ from copy import copy
 from datetime import datetime
 import logging
 import sys
+from typing import TYPE_CHECKING
 import weakref
-
-from beartype.typing import TYPE_CHECKING, Optional
 
 from ansys.geometry.core.misc.checks import check_type
 
@@ -478,7 +477,7 @@ class Logger:
         logger.propagate = True
         return logger
 
-    def add_child_logger(self, suffix: str, level: Optional[str] = None):
+    def add_child_logger(self, suffix: str, level: str | None = None):
         """Add a child logger to the main logger.
 
         This logger is more general than an instance logger, which is designed to
@@ -504,7 +503,7 @@ class Logger:
         return self._instances[name]
 
     def add_instance_logger(
-        self, name: str, client_instance: "GrpcClient", level: Optional[int] = None
+        self, name: str, client_instance: "GrpcClient", level: int | None = None
     ) -> PyGeometryCustomAdapter:
         """Add a logger for a Geometry service instance.
 

--- a/src/ansys/geometry/core/materials/material.py
+++ b/src/ansys/geometry/core/materials/material.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 """Provides the data structure for material and material properties."""
 
+from typing import Sequence
+
 from beartype import beartype as check_input_types
-from beartype.typing import Dict, Optional, Sequence
 from pint import Quantity
 
 from ansys.geometry.core.materials.property import MaterialProperty, MaterialPropertyType
@@ -46,7 +47,7 @@ class Material:
         self,
         name: str,
         density: Quantity,
-        additional_properties: Optional[Sequence[MaterialProperty]] = None,
+        additional_properties: Sequence[MaterialProperty] | None = None,
     ):
         """Initialize the ``Material`` class."""
         self._name = name
@@ -61,7 +62,7 @@ class Material:
             self._properties[property.type] = property
 
     @property
-    def properties(self) -> Dict[MaterialPropertyType, MaterialProperty]:
+    def properties(self) -> dict[MaterialPropertyType, MaterialProperty]:
         """Dictionary of the material property type and material properties."""
         return self._properties
 

--- a/src/ansys/geometry/core/materials/property.py
+++ b/src/ansys/geometry/core/materials/property.py
@@ -24,7 +24,6 @@
 from enum import Enum, unique
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 from pint import Quantity
 
 from ansys.geometry.core.typing import Real
@@ -73,13 +72,13 @@ class MaterialProperty:
 
     Parameters
     ----------
-    type : Union[MaterialPropertyType, str]
+    type : MaterialPropertyType | str
         Type of the material property. If the type is a string, it must be a valid
         material property type - though it might not be supported by the MaterialPropertyType
         enum.
     name: str
         Material property name.
-    quantity: Union[~pint.Quantity, Real]
+    quantity: ~pint.Quantity | Real
         Value and unit in case of a supported Quantity. If the type is not supported, it
         must be a Real value (float or integer).
     """
@@ -87,9 +86,9 @@ class MaterialProperty:
     @check_input_types
     def __init__(
         self,
-        type: Union[MaterialPropertyType, str],
+        type: MaterialPropertyType | str,
         name: str,
-        quantity: Union[Quantity, Real],
+        quantity: Quantity | Real,
     ):
         """Initialize ``MaterialProperty`` class."""
         self._type = type
@@ -97,7 +96,7 @@ class MaterialProperty:
         self._quantity = quantity
 
     @property
-    def type(self) -> Union[MaterialPropertyType, str]:
+    def type(self) -> MaterialPropertyType | str:
         """Material property ID.
 
         If the type is not supported, it will be a string.
@@ -110,7 +109,7 @@ class MaterialProperty:
         return self._name
 
     @property
-    def quantity(self) -> Union[Quantity, Real]:
+    def quantity(self) -> Quantity | Real:
         """Material property quantity and unit.
 
         If the type is not supported, it will be a Real value (float or

--- a/src/ansys/geometry/core/math/bbox.py
+++ b/src/ansys/geometry/core/math/bbox.py
@@ -24,7 +24,6 @@
 import sys
 
 from beartype import beartype as check_input_types
-from beartype.typing import List
 
 from ansys.geometry.core.math.point import Point2D
 from ansys.geometry.core.misc.accuracy import Accuracy
@@ -145,12 +144,12 @@ class BoundingBox2D:
         self._y_max = y if y > self._y_max else self._y_max
 
     @check_input_types
-    def add_points(self, points: List[Point2D]) -> None:
+    def add_points(self, points: list[Point2D]) -> None:
         """Extend the ranges of the bounding box to include given points.
 
         Parameters
         ----------
-        points : List[Point2D]
+        points : list[Point2D]
             List of points to include within the bounds.
         """
         for point in points:

--- a/src/ansys/geometry/core/math/frame.py
+++ b/src/ansys/geometry/core/math/frame.py
@@ -22,7 +22,6 @@
 """Provides for managing a frame."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 
 from ansys.geometry.core.math.constants import UNITVECTOR3D_X, UNITVECTOR3D_Y, ZERO_POINT3D
@@ -37,21 +36,21 @@ class Frame:
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D], default: ZERO_POINT3D
+    origin : ~numpy.ndarray | RealSequence | Point3D, default: ZERO_POINT3D
         Centered origin of the`frame. The default is ``ZERO_POINT3D``, which is the
         Cartesian origin.
-    direction_x : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D], default: UNITVECTOR3D_X
+    direction_x : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D, default: UNITVECTOR3D_X
         X-axis direction.
-    direction_y : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D], default: UNITVECTOR3D_Y
+    direction_y : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D, default: UNITVECTOR3D_Y
         Y-axis direction.
     """  # noqa : E501
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D] = ZERO_POINT3D,
-        direction_x: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        direction_y: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Y,
+        origin: np.ndarray | RealSequence | Point3D = ZERO_POINT3D,
+        direction_x: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        direction_y: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Y,
     ):
         """Initialize the ``Frame`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin

--- a/src/ansys/geometry/core/math/matrix.py
+++ b/src/ansys/geometry/core/math/matrix.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 """Provides matrix primitive representations."""
 
+from typing import Union
+
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 
 from ansys.geometry.core.misc.checks import check_ndarray_is_float_int
@@ -40,11 +41,11 @@ class Matrix(np.ndarray):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence]
+    input : ~numpy.ndarray | RealSequence
         Matrix arguments as a :class:`np.ndarray <numpy.ndarray>` class.
     """
 
-    def __new__(cls, input: Union[np.ndarray, RealSequence]):
+    def __new__(cls, input: np.ndarray | RealSequence):
         """Initialize ``Matrix`` class."""
         obj = np.asarray(input).view(cls)
         obj.setflags(write=False)
@@ -93,11 +94,11 @@ class Matrix33(Matrix):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence, Matrix], default: DEFAULT_MATRIX33
+    input : ~numpy.ndarray | RealSequence | Matrix, default: DEFAULT_MATRIX33
         Matrix arguments as a :class:`np.ndarray <numpy.ndarray>` class.
     """
 
-    def __new__(cls, input: Optional[Union[np.ndarray, RealSequence, Matrix]] = DEFAULT_MATRIX33):
+    def __new__(cls, input: np.ndarray | RealSequence | Matrix = DEFAULT_MATRIX33):
         """Initialize the ``Matrix33`` class."""
         obj = Matrix(input).view(cls)
         if input is DEFAULT_MATRIX33:
@@ -114,11 +115,11 @@ class Matrix44(Matrix):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence, Matrix], default: DEFAULT_MATRIX44
+    input : ~numpy.ndarray | RealSequence | Matrix, default: DEFAULT_MATRIX44
         Matrix arguments as a :class:`np.ndarray <numpy.ndarray>` class.
     """
 
-    def __new__(cls, input: Optional[Union[np.ndarray, RealSequence, Matrix]] = DEFAULT_MATRIX44):
+    def __new__(cls, input: np.ndarray | RealSequence | Matrix = DEFAULT_MATRIX44):
         """Initialize the ``Matrix44`` class."""
         obj = Matrix(input).view(cls)
         if input is DEFAULT_MATRIX44:

--- a/src/ansys/geometry/core/math/misc.py
+++ b/src/ansys/geometry/core/math/misc.py
@@ -22,7 +22,6 @@
 """Provides auxiliary math functions for PyAnsys Geometry."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 
 from ansys.geometry.core.typing import Real
@@ -31,7 +30,7 @@ from ansys.geometry.core.typing import Real
 @check_input_types
 def get_two_circle_intersections(
     x0: Real, y0: Real, r0: Real, x1: Real, y1: Real, r1: Real
-) -> Union[Tuple[Tuple[Real, Real], Tuple[Real, Real]], None]:
+) -> tuple[tuple[Real, Real], tuple[Real, Real]] | None:
     """Get the intersection points of two circles.
 
     Parameters
@@ -59,7 +58,7 @@ def get_two_circle_intersections(
 
     Returns
     -------
-    Union[Tuple[Tuple[Real, Real], Tuple[Real, Real]], None]
+    tuple[tuple[Real, Real], tuple[Real, Real]] | None
         Intersection points of the two circles if they intersect.
         The points are returned as ``((x3, y3), (x4, y4))``, where ``(x3, y3)`` and ``(x4, y4)``
         are the intersection points of the two circles. If the circles do not

--- a/src/ansys/geometry/core/math/plane.py
+++ b/src/ansys/geometry/core/math/plane.py
@@ -22,7 +22,6 @@
 """Provides primitive representation of a 2D plane in 3D space."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 
 from ansys.geometry.core.math.constants import UNITVECTOR3D_X, UNITVECTOR3D_Y, ZERO_POINT3D
@@ -37,20 +36,20 @@ class Plane(Frame):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D], default: ZERO_POINT3D
+    origin : ~numpy.ndarray | RealSequence | Point3D, default: ZERO_POINT3D
         Centered origin of the frame. The default is ``ZERO_POINT3D``, which is the
         Cartesian origin.
-    direction_x : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D], default: UNITVECTOR3D_X
+    direction_x : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D, default: UNITVECTOR3D_X
         X-axis direction.
-    direction_y : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D], default: UNITVECTOR3D_Y
+    direction_y : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D, default: UNITVECTOR3D_Y
         Y-axis direction.
     """  # noqa : E501
 
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D] = ZERO_POINT3D,
-        direction_x: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        direction_y: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Y,
+        origin: np.ndarray | RealSequence | Point3D = ZERO_POINT3D,
+        direction_x: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        direction_y: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Y,
     ):
         """Initialize ``Plane`` class."""
         super().__init__(origin, direction_x, direction_y)

--- a/src/ansys/geometry/core/math/point.py
+++ b/src/ansys/geometry/core/math/point.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 """Provides geometry primitive representation for 2D and 3D points."""
 
+from typing import TYPE_CHECKING, Union
+
 from beartype import beartype as check_input_types
-from beartype.typing import TYPE_CHECKING, Optional, Union
 import numpy as np
 from pint import Quantity, Unit
 
@@ -50,17 +51,18 @@ class Point2D(np.ndarray, PhysicalQuantity):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence], default: DEFAULT_POINT2D_VALUES
+    input : ~numpy.ndarray | RealSequence, default: DEFAULT_POINT2D_VALUES
         Direction arguments, either as a :class:`numpy.ndarray <numpy.ndarray>` class
         or as a ``RealSequence``.
-    unit : ~pint.Unit, default: DEFAULT_UNITS.LENGTH
-        Units for defining 2D point values.
+    unit : ~pint.Unit | None, default: DEFAULT_UNITS.LENGTH
+        Units for defining 2D point values. If not specified, the default unit is
+        ``DEFAULT_UNITS.LENGTH``.
     """
 
     def __new__(
         cls,
-        input: Optional[Union[np.ndarray, RealSequence]] = DEFAULT_POINT2D_VALUES,
-        unit: Optional[Unit] = None,
+        input: np.ndarray | RealSequence = DEFAULT_POINT2D_VALUES,
+        unit: Unit | None = None,
     ):
         """Initialize the ``Point2D`` class."""
         # Build an empty np.ndarray object
@@ -68,8 +70,8 @@ class Point2D(np.ndarray, PhysicalQuantity):
 
     def __init__(
         self,
-        input: Union[np.ndarray, RealSequence] = DEFAULT_POINT2D_VALUES,
-        unit: Optional[Unit] = None,
+        input: np.ndarray | RealSequence = DEFAULT_POINT2D_VALUES,
+        unit: Unit | None = None,
     ):
         """Initialize the ``Point2D`` class."""
         # Call the PhysicalQuantity ctor
@@ -176,17 +178,18 @@ class Point3D(np.ndarray, PhysicalQuantity):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence], default: DEFAULT_POINT3D_VALUES
+    input : ~numpy.ndarray | RealSequence, default: DEFAULT_POINT3D_VALUES
         Direction arguments, either as a :class:`numpy.ndarray <numpy.ndarray>` class
         or as a ``RealSequence``.
-    unit : ~pint.Unit, default: DEFAULT_UNITS.LENGTH
-        Units for defining 3D point values.
+    unit : ~pint.Unit | None, default: DEFAULT_UNITS.LENGTH
+        Units for defining 3D point values. If not specified, the default unit is
+        ``DEFAULT_UNITS.LENGTH``.
     """
 
     def __new__(
         cls,
-        input: Optional[Union[np.ndarray, RealSequence]] = DEFAULT_POINT3D_VALUES,
-        unit: Optional[Unit] = None,
+        input: np.ndarray | RealSequence = DEFAULT_POINT3D_VALUES,
+        unit: Unit | None = None,
     ):
         """Initialize ``Point3D`` class."""
         # Build an empty np.ndarray object
@@ -194,8 +197,8 @@ class Point3D(np.ndarray, PhysicalQuantity):
 
     def __init__(
         self,
-        input: Union[np.ndarray, RealSequence] = DEFAULT_POINT3D_VALUES,
-        unit: Optional[Unit] = None,
+        input: np.ndarray | RealSequence = DEFAULT_POINT3D_VALUES,
+        unit: Unit | None = None,
     ):
         """Initialize ``Point3D`` class."""
         # Call the PhysicalQuantity ctor

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -22,9 +22,9 @@
 """Provides for creating and managing 2D and 3D vectors."""
 
 from io import UnsupportedOperation
+from typing import Union
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 from pint import Quantity
 
@@ -41,11 +41,11 @@ class Vector3D(np.ndarray):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence]
+    input : ~numpy.ndarray | RealSequence
         3D :class:`numpy.ndarray <numpy.ndarray>` class with shape(X,).
     """
 
-    def __new__(cls, input: Union[np.ndarray, RealSequence]):
+    def __new__(cls, input: np.ndarray | RealSequence):
         """Initialize the ``Vector3D`` class."""
         obj = np.asarray(input).view(cls)
 
@@ -236,17 +236,17 @@ class Vector3D(np.ndarray):
     @check_input_types
     def from_points(
         cls,
-        point_a: Union[np.ndarray, RealSequence, Point3D],
-        point_b: Union[np.ndarray, RealSequence, Point3D],
+        point_a: np.ndarray | RealSequence | Point3D,
+        point_b: np.ndarray | RealSequence | Point3D,
     ):
         """Create a 3D vector from two distinct 3D points.
 
         Parameters
         ----------
-        point_a : Point3D
+        point_a : ~numpy.ndarray | RealSequence | Point3D
             :class:`Point3D <ansys.geometry.core.math.point.Point3D>`
             class representing the first point.
-        point_b : Point3D
+        point_b : ~numpy.ndarray | RealSequence | Point3D
             :class:`Point3D <ansys.geometry.core.math.point.Point3D>`
             class representing the second point.
 
@@ -268,11 +268,11 @@ class Vector2D(np.ndarray):
 
     Parameters
     ----------
-    input : Union[~numpy.ndarray, RealSequence]
+    input : ~numpy.ndarray | RealSequence
         2D :class:`numpy.ndarray <numpy.ndarray>` class with shape(X,).
     """
 
-    def __new__(cls, input: Union[np.ndarray, RealSequence]):
+    def __new__(cls, input: np.ndarray | RealSequence):
         """Initialize the ``Vector2D`` class."""
         obj = np.asarray(input).view(cls)
 
@@ -423,17 +423,17 @@ class Vector2D(np.ndarray):
     @check_input_types
     def from_points(
         cls,
-        point_a: Union[np.ndarray, RealSequence, Point2D],
-        point_b: Union[np.ndarray, RealSequence, Point2D],
+        point_a: np.ndarray | RealSequence | Point2D,
+        point_b: np.ndarray | RealSequence | Point2D,
     ):
         """Create a 2D vector from two distinct 2D points.
 
         Parameters
         ----------
-        point_a : Point2D
+        point_a : ~numpy.ndarray | RealSequence | Point2D
             :class:`Point2D <ansys.geometry.core.math.point.Point2D>`
             class representing the first point.
-        point_b : Point2D
+        point_b : ~numpy.ndarray | RealSequence | Point2D
             :class:`Point2D <ansys.geometry.core.math.point.Point2D>`
             class representing the second point.
 
@@ -455,12 +455,12 @@ class UnitVector3D(Vector3D):
 
     Parameters
     ----------
-    input : ~numpy.ndarray, ``Vector3D``
+    input : ~numpy.ndarray | RealSequence | Vector3D
         * 1D :class:`numpy.ndarray <numpy.ndarray>` class with shape(X,)
         * Vector3D
     """
 
-    def __new__(cls, input: Union[np.ndarray, RealSequence, Vector3D]):
+    def __new__(cls, input: np.ndarray | RealSequence | Vector3D):
         """Initialize the ``UnitVector3D`` class."""
         obj = Vector3D(input) if not isinstance(input, Vector3D) else input
         obj = obj.normalize().view(cls)
@@ -482,17 +482,17 @@ class UnitVector3D(Vector3D):
     @classmethod
     def from_points(
         cls,
-        point_a: Union[np.ndarray, RealSequence, Point3D],
-        point_b: Union[np.ndarray, RealSequence, Point3D],
+        point_a: np.ndarray | RealSequence | Point3D,
+        point_b: np.ndarray | RealSequence | Point3D,
     ):
         """Create a 3D unit vector from two distinct 3D points.
 
         Parameters
         ----------
-        point_a : Point3D
+        point_a : ~numpy.ndarray | RealSequence | Point3D
             :class:`Point3D <ansys.geometry.core.math.point.Point3D>`
             class representing the first point.
-        point_b : Point3D
+        point_b : ~numpy.ndarray | RealSequence | Point3D
             :class:`Point3D <ansys.geometry.core.math.point.Point3D>`
             class representing the second point.
 
@@ -509,12 +509,12 @@ class UnitVector2D(Vector2D):
 
     Parameters
     ----------
-    input : ~numpy.ndarray, ``Vector2D``
+    input : ~numpy.ndarray | RealSequence | Vector2D
         * 1D :class:`numpy.ndarray <numpy.ndarray>` class with shape(X,)
         * Vector2D
     """
 
-    def __new__(cls, input: Union[np.ndarray, RealSequence, Vector2D]):
+    def __new__(cls, input: np.ndarray | RealSequence | Vector2D):
         """Initialize the ``UnitVector2D`` class."""
         obj = Vector2D(input) if not isinstance(input, Vector2D) else input
         obj = obj.normalize().view(cls)
@@ -532,17 +532,17 @@ class UnitVector2D(Vector2D):
     @classmethod
     def from_points(
         cls,
-        point_a: Union[np.ndarray, RealSequence, Point2D],
-        point_b: Union[np.ndarray, RealSequence, Point2D],
+        point_a: np.ndarray | RealSequence | Point2D,
+        point_b: np.ndarray | RealSequence | Point2D,
     ):
         """Create a 2D unit vector from two distinct 2D points.
 
         Parameters
         ----------
-        point_a : Point2D
+        point_a : ~numpy.ndarray | RealSequence | Point2D
             :class:`Point2D <ansys.geometry.core.math.point.Point2D>`
             class representing the first point.
-        point_b : Point2D
+        point_b : ~numpy.ndarray | RealSequence | Point2D
             :class:`Point2D <ansys.geometry.core.math.point.Point2D>`
             class representing the second point.
 

--- a/src/ansys/geometry/core/misc/auxiliary.py
+++ b/src/ansys/geometry/core/misc/auxiliary.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Auxiliary functions for the PyAnsys Geometry library."""
 
-from beartype.typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.geometry.core.designer.body import Body
@@ -112,7 +112,7 @@ def get_design_from_edge(edge: "Edge") -> "Design":
     return get_design_from_body(body)
 
 
-def __traverse_all_bodies(comp: Union["Design", "Component"]) -> List["Body"]:
+def __traverse_all_bodies(comp: Union["Design", "Component"]) -> list["Body"]:
     """Traverse all bodies in a design and all its subcomponents.
 
     This is a private method. Do not use it directly.
@@ -129,7 +129,7 @@ def __traverse_all_bodies(comp: Union["Design", "Component"]) -> List["Body"]:
 
     Returns
     -------
-    List[Body]
+    list[Body]
         List of all bodies in the design or component.
     """
     bodies = []
@@ -140,7 +140,7 @@ def __traverse_all_bodies(comp: Union["Design", "Component"]) -> List["Body"]:
     return bodies
 
 
-def get_bodies_from_ids(design: "Design", body_ids: List[str]) -> List["Body"]:
+def get_bodies_from_ids(design: "Design", body_ids: list[str]) -> list["Body"]:
     """Find the ``Body`` objects inside a ``Design`` from its ids.
 
     Notes
@@ -151,18 +151,18 @@ def get_bodies_from_ids(design: "Design", body_ids: List[str]) -> List["Body"]:
     ----------
     design : Design
         Parent design for the faces.
-    body_ids : List[str]
+    body_ids : list[str]
         List of body ids.
 
     Returns
     -------
-    List[Body]
+    list[Body]
         List of Body objects.
     """
     return [body for body in __traverse_all_bodies(design) if body.id in body_ids]
 
 
-def get_faces_from_ids(design: "Design", face_ids: List[str]) -> List["Face"]:
+def get_faces_from_ids(design: "Design", face_ids: list[str]) -> list["Face"]:
     """Find the ``Face`` objects inside a ``Design`` from its ids.
 
     Notes
@@ -173,12 +173,12 @@ def get_faces_from_ids(design: "Design", face_ids: List[str]) -> List["Face"]:
     ----------
     design : Design
         Parent design for the faces.
-    face_ids : List[str]
+    face_ids : list[str]
         List of face ids.
 
     Returns
     -------
-    List[Face]
+    list[Face]
         List of Face objects.
     """
     return [
@@ -186,7 +186,7 @@ def get_faces_from_ids(design: "Design", face_ids: List[str]) -> List["Face"]:
     ]  # noqa: E501
 
 
-def get_edges_from_ids(design: "Design", edge_ids: List[str]) -> List["Edge"]:
+def get_edges_from_ids(design: "Design", edge_ids: list[str]) -> list["Edge"]:
     """Find the ``Edge`` objects inside a ``Design`` from its ids.
 
     Notes
@@ -197,12 +197,12 @@ def get_edges_from_ids(design: "Design", edge_ids: List[str]) -> List["Edge"]:
     ----------
     design : Design
         Parent design for the edges.
-    edge_ids : List[str]
+    edge_ids : list[str]
         List of edge ids.
 
     Returns
     -------
-    List[Edge]
+    list[Edge]
         List of Edge objects.
     """
     return [

--- a/src/ansys/geometry/core/misc/checks.py
+++ b/src/ansys/geometry/core/misc/checks.py
@@ -21,9 +21,9 @@
 # SOFTWARE.
 """Provides functions for performing common checks."""
 
+from typing import TYPE_CHECKING, Iterable
 import warnings
 
-from beartype.typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, Union
 import numpy as np
 from pint import Unit
 import semver
@@ -84,7 +84,7 @@ def ensure_design_is_active(method):
     return wrapper
 
 
-def check_is_float_int(param: object, param_name: Optional[Union[str, None]] = None) -> None:
+def check_is_float_int(param: object, param_name: str | None = None) -> None:
     """Check if a parameter has a float or integer value.
 
     Parameters
@@ -107,9 +107,7 @@ def check_is_float_int(param: object, param_name: Optional[Union[str, None]] = N
         )
 
 
-def check_ndarray_is_float_int(
-    param: np.ndarray, param_name: Optional[Union[str, None]] = None
-) -> None:
+def check_ndarray_is_float_int(param: np.ndarray, param_name: str | None = None) -> None:
     """Check if a :class:`numpy.ndarray <numpy.ndarray>` has float/integer types.
 
     Parameters
@@ -137,9 +135,7 @@ def check_ndarray_is_float_int(
         )
 
 
-def check_ndarray_is_not_none(
-    param: np.ndarray, param_name: Optional[Union[str, None]] = None
-) -> None:
+def check_ndarray_is_not_none(param: np.ndarray, param_name: str | None = None) -> None:
     """Check if a :class:`numpy.ndarray <numpy.ndarray>` is all ``None``.
 
     Parameters
@@ -164,9 +160,7 @@ def check_ndarray_is_not_none(
         )
 
 
-def check_ndarray_is_all_nan(
-    param: np.ndarray, param_name: Optional[Union[str, None]] = None
-) -> None:
+def check_ndarray_is_all_nan(param: np.ndarray, param_name: str | None = None) -> None:
     """Check if a :class:`numpy.ndarray <numpy.ndarray>` is all nan-valued.
 
     Parameters
@@ -189,9 +183,7 @@ def check_ndarray_is_all_nan(
         )
 
 
-def check_ndarray_is_non_zero(
-    param: np.ndarray, param_name: Optional[Union[str, None]] = None
-) -> None:
+def check_ndarray_is_non_zero(param: np.ndarray, param_name: str | None = None) -> None:
     """Check if a :class:`numpy.ndarray <numpy.ndarray>` is zero-valued.
 
     Parameters
@@ -257,14 +249,14 @@ def check_type_equivalence(input: object, expected: object) -> None:
         )
 
 
-def check_type(input: object, expected_type: Union[type, Tuple[type, Any]]) -> None:
+def check_type(input: object, expected_type: type | tuple[type, ...]) -> None:
     """Check if an input object is of the same type as expected types.
 
     Parameters
     ----------
     input : object
         Input object.
-    expected_type : Union[type, Tuple[type, ...]]
+    expected_type : type | tuple[type, ...]
         One or more types to compare the input object against.
 
     Raises
@@ -279,7 +271,7 @@ def check_type(input: object, expected_type: Union[type, Tuple[type, Any]]) -> N
 
 
 def check_type_all_elements_in_iterable(
-    input: Iterable, expected_type: Union[type, Tuple[type, Any]]
+    input: Iterable, expected_type: type | tuple[type, ...]
 ) -> None:
     """Check if all elements in an iterable are of the same type as expected.
 
@@ -287,7 +279,7 @@ def check_type_all_elements_in_iterable(
     ----------
     input : Iterable
         Input iterable.
-    expected_type : Union[type, Tuple[type, ...]]
+    expected_type : type | tuple[type, ...]
         One or more types to compare the input object against.
 
     Raises
@@ -356,7 +348,7 @@ def min_backend_version(major: int, minor: int, service_pack: int):
     return backend_version_decorator
 
 
-def deprecated_method(alternative: Optional[str] = None, info: Optional[str] = None):
+def deprecated_method(alternative: str | None = None, info: str | None = None):
     """Decorate a method as deprecated.
 
     Parameters
@@ -383,7 +375,7 @@ def deprecated_method(alternative: Optional[str] = None, info: Optional[str] = N
     return deprecated_decorator
 
 
-def deprecated_argument(arg: str, alternative: Optional[str] = None, info: Optional[str] = None):
+def deprecated_argument(arg: str, alternative: str | None = None, info: str | None = None):
     """Decorate a method argument as deprecated.
 
     Parameters

--- a/src/ansys/geometry/core/misc/measurements.py
+++ b/src/ansys/geometry/core/misc/measurements.py
@@ -24,7 +24,6 @@
 from threading import Lock
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 from pint import Quantity, Unit
 
 from ansys.geometry.core.misc.checks import check_is_float_int, check_pint_unit_compatibility
@@ -149,7 +148,7 @@ class Measurement(PhysicalQuantity):
 
     Parameters
     ----------
-    value : Union[Real, Quantity]
+    value : Real | ~pint.Quantity
         Value of the measurement.
     unit : ~pint.Unit
         Units for the measurement.
@@ -158,7 +157,7 @@ class Measurement(PhysicalQuantity):
         If ``~pint.Unit.meter`` is given, the dimension extracted is ``[length]``.
     """
 
-    def __init__(self, value: Union[Real, Quantity], unit: Unit, dimensions: Unit):
+    def __init__(self, value: Real | Quantity, unit: Unit, dimensions: Unit):
         """Initialize the ``Measurement`` class."""
         # Check the input
         if isinstance(value, Quantity):
@@ -196,13 +195,13 @@ class Distance(Measurement):
 
     Parameters
     ----------
-    value : Union[Real, Quantity]
+    value : Real | ~pint.Quantity
         Value of the distance.
     unit : ~pint.Unit, default: DEFAULT_UNITS.LENGTH
         Units for the distance.
     """
 
-    def __init__(self, value: Union[Real, Quantity], unit: Optional[Unit] = None):
+    def __init__(self, value: Real | Quantity, unit: Unit | None = None):
         """Initialize the ``Distance`` class."""
         # Delegates in Measurement ctor. forcing expected dimensions.
         unit = unit if unit else DEFAULT_UNITS.LENGTH
@@ -214,13 +213,13 @@ class Angle(Measurement):
 
     Parameters
     ----------
-    value : Union[Real, Quantity]
+    value : Real | ~pint.Quantity
         Value of the angle.
     unit : ~pint.Unit, default: DEFAULT_UNITS.ANGLE
         Units for the distance.
     """
 
-    def __init__(self, value: Union[Real, Quantity], unit: Optional[Unit] = None):
+    def __init__(self, value: Real | Quantity, unit: Unit | None = None):
         """Initialize the ``Angle`` class."""
         # Delegates in Measurement ctor. forcing expected dimensions.
         unit = unit if unit else DEFAULT_UNITS.ANGLE

--- a/src/ansys/geometry/core/misc/units.py
+++ b/src/ansys/geometry/core/misc/units.py
@@ -22,7 +22,6 @@
 """Provides for handling units homogeneously throughout PyAnsys Geometry."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional
 from pint import Quantity, Unit, UnitRegistry, set_application_registry
 
 from ansys.geometry.core.misc.checks import check_pint_unit_compatibility
@@ -47,7 +46,7 @@ class PhysicalQuantity:
     """
 
     @check_input_types
-    def __init__(self, unit: Unit, expected_dimensions: Optional[Unit] = None):
+    def __init__(self, unit: Unit, expected_dimensions: Unit | None = None):
         """Initialize the ``PhysicalQuantity`` class."""
         if expected_dimensions:
             check_pint_unit_compatibility(unit, expected_dimensions)

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -23,6 +23,7 @@
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 from ansys.api.dbu.v0.dbuapplication_pb2 import RunScriptFileRequest
 from ansys.api.dbu.v0.dbuapplication_pb2_grpc import DbuApplicationStub
@@ -30,7 +31,6 @@ from ansys.api.dbu.v0.designs_pb2 import OpenRequest
 from ansys.api.dbu.v0.designs_pb2_grpc import DesignsStub
 from ansys.api.geometry.v0.commands_pb2 import UploadFileRequest
 from ansys.api.geometry.v0.commands_pb2_grpc import CommandsStub
-from beartype.typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 from grpc import Channel
 
 from ansys.geometry.core.connection.backend import BackendType
@@ -93,15 +93,15 @@ class Modeler:
     def __init__(
         self,
         host: str = DEFAULT_HOST,
-        port: Union[str, int] = DEFAULT_PORT,
-        channel: Optional[Channel] = None,
+        port: str | int = DEFAULT_PORT,
+        channel: Channel | None = None,
         remote_instance: Optional["Instance"] = None,
         docker_instance: Optional["LocalDockerInstance"] = None,
         product_instance: Optional["ProductInstance"] = None,
-        timeout: Optional[Real] = 120,
-        logging_level: Optional[int] = logging.INFO,
-        logging_file: Optional[Union[Path, str]] = None,
-        backend_type: Optional[BackendType] = None,
+        timeout: Real = 120,
+        logging_level: int = logging.INFO,
+        logging_file: Path | str | None = None,
+        backend_type: BackendType | None = None,
     ):
         """Initialize the ``Modeler`` class."""
         self._grpc_client = GrpcClient(
@@ -131,7 +131,7 @@ class Modeler:
             self._measurement_tools = MeasurementTools(self._grpc_client)
 
         # Maintaining references to all designs within the modeler workspace
-        self._designs: Dict[str, "Design"] = {}
+        self._designs: dict[str, "Design"] = {}
 
         # Check if the backend allows for multiple designs and throw warning if needed
         if not self.client.multiple_designs_allowed:
@@ -334,8 +334,8 @@ class Modeler:
 
     @protect_grpc
     def run_discovery_script_file(
-        self, file_path: str, script_args: Optional[Dict[str, str]] = None, import_design=False
-    ) -> Tuple[Dict[str, str], Optional["Design"]]:
+        self, file_path: str, script_args: dict[str, str] | None = None, import_design=False
+    ) -> tuple[dict[str, str], Optional["Design"]]:
         """Run a Discovery script file.
 
         .. note::
@@ -367,7 +367,7 @@ class Modeler:
         ----------
         file_path : str
             Path of the file. The extension of the file must be included.
-        script_args : Optional[Dict[str, str]], optional.
+        script_args : dict[str, str], optional.
             Arguments to pass to the script. By default, ``None``.
         import_design : bool, optional.
             Whether to refresh the current design from the service. When the script

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 """Provides plotting for various PyAnsys Geometry objects."""
 
+from typing import Any
+
 from ansys.tools.visualization_interface import (
     Color,
     EdgePlot,
@@ -28,7 +30,6 @@ from ansys.tools.visualization_interface import (
     Plotter as PlotterInterface,
 )
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackend
-from beartype.typing import Any, Dict, List, Optional, Union
 import numpy as np
 import pyvista as pv
 from pyvista.plotting.tools import create_axes_marker
@@ -51,9 +52,9 @@ class GeometryPlotter(PlotterInterface):
 
     Parameters
     ----------
-    use_trame : Union[bool, None], optional
+    use_trame : bool, optional
         Whether to use trame visualizer or not, by default None.
-    allow_picking : Union[bool, None], optional
+    allow_picking : bool, optional
         Whether to allow picking or not, by default False.
     show_plane : bool, optional
         Whether to show the plane in the scene, by default True.
@@ -61,8 +62,8 @@ class GeometryPlotter(PlotterInterface):
 
     def __init__(
         self,
-        use_trame: Union[bool, None] = None,
-        allow_picking: Union[bool, None] = False,
+        use_trame: bool | None = None,
+        allow_picking: bool | None = False,
         show_plane: bool = True,
     ) -> None:
         """Initialize the GeometryPlotter class."""
@@ -74,7 +75,7 @@ class GeometryPlotter(PlotterInterface):
         self._backend.add_widget(ShowDesignPoints(self))
         self._backend._pl._show_plane = show_plane
 
-    def add_frame(self, frame: Frame, plotting_options: Optional[Dict] = None) -> None:
+    def add_frame(self, frame: Frame, plotting_options: dict | None = None) -> None:
         """Plot a frame in the scene.
 
         Parameters
@@ -82,7 +83,7 @@ class GeometryPlotter(PlotterInterface):
         frame : Frame
             Frame to render in the scene.
         plotting_options : dict, default: None
-            Dictionary containing parameters accepted by the
+            dictionary containing parameters accepted by the
             :func:`pyvista.create_axes_marker` class for customizing
             the frame rendering in the scene.
         """
@@ -106,8 +107,8 @@ class GeometryPlotter(PlotterInterface):
     def add_plane(
         self,
         plane: Plane,
-        plane_options: Optional[Dict] = None,
-        plotting_options: Optional[Dict] = None,
+        plane_options: dict | None = None,
+        plotting_options: dict | None = None,
     ) -> None:
         """Plot a plane in the scene.
 
@@ -116,11 +117,11 @@ class GeometryPlotter(PlotterInterface):
         plane : Plane
             Plane to render in the scene.
         plane_options : dict, default: None
-            Dictionary containing parameters accepted by the
+            dictionary containing parameters accepted by the
             :func:`pyvista.Plane  <pyvista.Plane>` function for customizing the mesh
             representing the plane.
         plotting_options : dict, default: None
-            Dictionary containing parameters accepted by the
+            dictionary containing parameters accepted by the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method for
             customizing the mesh rendering of the plane.
         """
@@ -143,7 +144,7 @@ class GeometryPlotter(PlotterInterface):
         sketch: Sketch,
         show_plane: bool = False,
         show_frame: bool = False,
-        **plotting_options: Optional[Dict],
+        **plotting_options: dict | None,
     ) -> None:
         """Plot a sketch in the scene.
 
@@ -176,7 +177,7 @@ class GeometryPlotter(PlotterInterface):
         )
         self.add_sketch_polydata(sketch.sketch_polydata_edges(), sketch, **plotting_options)
 
-    def add_body_edges(self, body_plot: MeshObjectPlot, **plotting_options: Optional[dict]) -> None:
+    def add_body_edges(self, body_plot: MeshObjectPlot, **plotting_options: dict | None) -> None:
         """Add the outer edges of a body to the plot.
 
         This method has the side effect of adding the edges to the GeomObject that
@@ -201,9 +202,7 @@ class GeometryPlotter(PlotterInterface):
             edge_plot_list.append(edge_plot)
         body_plot.edges = edge_plot_list
 
-    def add_body(
-        self, body: Body, merge: Optional[bool] = False, **plotting_options: Optional[Dict]
-    ) -> None:
+    def add_body(self, body: Body, merge: bool = False, **plotting_options: dict | None) -> None:
         """Add a body to the scene.
 
         Parameters
@@ -257,13 +256,13 @@ class GeometryPlotter(PlotterInterface):
         self.plot(component_polydata, **plotting_options)
 
     def add_sketch_polydata(
-        self, polydata_entries: List[pv.PolyData], sketch: Sketch = None, **plotting_options
+        self, polydata_entries: list[pv.PolyData], sketch: Sketch = None, **plotting_options
     ) -> None:
         """Add sketches to the scene from PyVista polydata.
 
         Parameters
         ----------
-        polydata_entries : List[pyvista.PolyData]
+        polydata_entries : list[pyvista.PolyData]
             Polydata to add.
         sketch : Sketch, default: None
             Sketch to add.
@@ -297,19 +296,19 @@ class GeometryPlotter(PlotterInterface):
 
     def plot_iter(
         self,
-        plotting_list: List[Any],
+        plotting_list: list[Any],
         name_filter: str = None,
         **plotting_options,
     ) -> None:
         """Add a list of any type of object to the scene.
 
-        These types of objects are supported: ``Body``, ``Component``, ``List[pv.PolyData]``,
+        These types of objects are supported: ``Body``, ``Component``, ``list[pv.PolyData]``,
         ``pv.MultiBlock``, and ``Sketch``.
 
         Parameters
         ----------
-        plotting_list : List[Any]
-            List of objects you want to plot.
+        plotting_list : list[Any]
+            list of objects you want to plot.
         name_filter : str, default: None
             Regular expression with the desired name or names you want to include in the plotter.
         **plotting_options : dict, default: None
@@ -355,12 +354,12 @@ class GeometryPlotter(PlotterInterface):
         elif isinstance(plottable_object, Design) or isinstance(object, Component):
             self.add_component(plottable_object, merge_components, merge_bodies, **plotting_options)
         elif (
-            isinstance(plottable_object, List)
+            isinstance(plottable_object, list)
             and plottable_object != []
             and isinstance(plottable_object[0], pv.PolyData)
         ):
             self.add_sketch_polydata(plottable_object, **plotting_options)
-        elif isinstance(plottable_object, List):
+        elif isinstance(plottable_object, list):
             self.plot_iter(plottable_object, name_filter, **plotting_options)
         elif isinstance(plottable_object, MeshObjectPlot):
             self._backend.pv_interface.set_add_mesh_defaults(plotting_options)
@@ -371,8 +370,8 @@ class GeometryPlotter(PlotterInterface):
 
     def show(
         self,
-        plotting_object: Optional[Any] = None,
-        screenshot: Optional[str] = None,
+        plotting_object: Any = None,
+        screenshot: str | None = None,
         **plotting_options,
     ) -> None:
         """Show the plotter.

--- a/src/ansys/geometry/core/shapes/curves/circle.py
+++ b/src/ansys/geometry/core/shapes/curves/circle.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 from pint import Quantity
 
@@ -50,23 +49,23 @@ class Circle(Curve):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the circle.
-    radius : Union[Quantity, Distance, Real]
+    radius : ~pint.Quantity | Distance | Real
         Radius of the circle.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        radius: Union[Quantity, Distance, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        radius: Quantity | Distance | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Circle`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin

--- a/src/ansys/geometry/core/shapes/curves/curve.py
+++ b/src/ansys/geometry/core/shapes/curves/curve.py
@@ -22,8 +22,7 @@
 """Provides the ``Curve`` class."""
 
 from abc import ABC, abstractmethod
-
-from beartype.typing import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.math.matrix import Matrix44
 from ansys.geometry.core.math.point import Point3D

--- a/src/ansys/geometry/core/shapes/curves/ellipse.py
+++ b/src/ansys/geometry/core/shapes/curves/ellipse.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 from pint import Quantity
 from scipy.integrate import quad
@@ -51,26 +50,26 @@ class Ellipse(Curve):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the ellipse.
-    major_radius : Union[Quantity, Distance, Real]
+    major_radius : ~pint.Quantity | Distance | Real
         Major radius of the ellipse.
-    minor_radius : Union[Quantity, Distance, Real]
+    minor_radius : ~pint.Quantity | Distance | Real
         Minor radius of the ellipse.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        major_radius: Union[Quantity, Distance, Real],
-        minor_radius: Union[Quantity, Distance, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        major_radius: Quantity | Distance | Real,
+        minor_radius: Quantity | Distance | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Ellipse`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin

--- a/src/ansys/geometry/core/shapes/curves/line.py
+++ b/src/ansys/geometry/core/shapes/curves/line.py
@@ -25,7 +25,6 @@ from functools import cached_property
 import math
 
 from beartype import beartype as check_input_types
-from beartype.typing import Union
 import numpy as np
 
 from ansys.geometry.core.math.matrix import Matrix44
@@ -48,17 +47,17 @@ class Line(Curve):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the line.
-    direction : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    direction : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Direction of the line.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        direction: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D],
+        origin: np.ndarray | RealSequence | Point3D,
+        direction: np.ndarray | RealSequence | UnitVector3D | Vector3D,
     ):
         """Initialize the ``Line`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin

--- a/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
+++ b/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
@@ -23,7 +23,6 @@
 
 from ansys.api.geometry.v0.commands_pb2 import IntersectCurvesRequest
 from ansys.api.geometry.v0.commands_pb2_grpc import CommandsStub
-from beartype.typing import List
 from pint import Quantity
 
 from ansys.geometry.core.connection.client import GrpcClient
@@ -122,7 +121,7 @@ class TrimmedCurve:
         bounds = self.interval
         return self.geometry.evaluate(bounds.start + bounds.get_span() * param)
 
-    def intersect_curve(self, other: "TrimmedCurve") -> List[Point3D]:
+    def intersect_curve(self, other: "TrimmedCurve") -> list[Point3D]:
         """Get the intersect points of this trimmed curve with another one.
 
         If the two trimmed curves do not intersect, an empty list is returned.
@@ -134,7 +133,7 @@ class TrimmedCurve:
 
         Returns
         -------
-        List[Point3D]
+        list[Point3D]
             All points of intersection between the curves.
         """
         if self._grpc_client is None:

--- a/src/ansys/geometry/core/shapes/surfaces/cone.py
+++ b/src/ansys/geometry/core/shapes/surfaces/cone.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 from pint import Quantity
 
@@ -51,26 +50,26 @@ class Cone(Surface):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the cone.
-    radius : Union[Quantity, Distance, Real]
+    radius : ~pint.Quantity | Distance | Real
         Radius of the cone.
-    half_angle : Union[Quantity, Angle, Real]
+    half_angle : ~pint.Quantity | Angle | Real
         Half angle of the apex, determining the upward angle.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        radius: Union[Quantity, Distance, Real],
-        half_angle: Union[Quantity, Angle, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        radius: Quantity | Distance | Real,
+        half_angle: Quantity | Angle | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Cone`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin
@@ -231,7 +230,7 @@ class Cone(Surface):
 
         return ConeEvaluation(self, ParamUV(u, v))
 
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parameterize the cone surface as a tuple (U and V respectively).
 
         The U parameter specifies the clockwise angle around the axis (right-hand
@@ -242,7 +241,7 @@ class Cone(Surface):
 
         Returns
         -------
-        Tuple[Parameterization, Parameterization]
+        tuple[Parameterization, Parameterization]
             Information about how a cone's u and v parameters are parameterized, respectively.
         """
         u = Parameterization(ParamForm.PERIODIC, ParamType.CIRCULAR, Interval(0, 2 * np.pi))

--- a/src/ansys/geometry/core/shapes/surfaces/cylinder.py
+++ b/src/ansys/geometry/core/shapes/surfaces/cylinder.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 from pint import Quantity
 
@@ -52,23 +51,23 @@ class Cylinder(Surface):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the cylinder.
-    radius : Union[Quantity, Distance, Real]
+    radius : ~pint.Quantity | Distance | Real
         Radius of the cylinder.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        radius: Union[Quantity, Distance, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        radius: Quantity | Distance | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Cylinder`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin
@@ -109,7 +108,7 @@ class Cylinder(Surface):
         """Z-direction of the cylinder."""
         return self._axis
 
-    def surface_area(self, height: Union[Quantity, Distance, Real]) -> Quantity:
+    def surface_area(self, height: Quantity | Distance | Real) -> Quantity:
         """Get the surface area of the cylinder.
 
         Notes
@@ -121,12 +120,12 @@ class Cylinder(Surface):
 
         Parameters
         ----------
-        height : Union[Quantity, Distance, Real]
+        height : ~pint.Quantity | Distance | Real
             Height to bound the cylinder at.
 
         Returns
         -------
-        Quantity
+        ~pint.Quantity
             Surface area of the temporarily bounded cylinder.
         """
         height = height if isinstance(height, Distance) else Distance(height)
@@ -135,7 +134,7 @@ class Cylinder(Surface):
 
         return 2 * np.pi * self.radius * height.value + 2 * np.pi * self.radius**2
 
-    def volume(self, height: Union[Quantity, Distance, Real]) -> Quantity:
+    def volume(self, height: Quantity | Distance | Real) -> Quantity:
         """Get the volume of the cylinder.
 
         Notes
@@ -147,12 +146,12 @@ class Cylinder(Surface):
 
         Parameters
         ----------
-        height : Union[Quantity, Distance, Real]
+        height : ~pint.Quantity | Distance | Real
             Height to bound the cylinder at.
 
         Returns
         -------
-        Quantity
+        ~pint.Quantity
             Volume of the temporarily bounded cylinder.
         """
         height = height if isinstance(height, Distance) else Distance(height)
@@ -240,7 +239,7 @@ class Cylinder(Surface):
 
         return CylinderEvaluation(self, ParamUV(u, v))
 
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parameterize the cylinder surface as a tuple (U and V respectively).
 
         The U parameter specifies the clockwise angle around the axis (right-hand
@@ -251,7 +250,7 @@ class Cylinder(Surface):
 
         Returns
         -------
-        Tuple[Parameterization, Parameterization]
+        tuple[Parameterization, Parameterization]
             Information about how a cylinder's u and v parameters are parameterized, respectively.
         """
         u = Parameterization(ParamForm.PERIODIC, ParamType.CIRCULAR, Interval(0, 2 * np.pi))

--- a/src/ansys/geometry/core/shapes/surfaces/plane.py
+++ b/src/ansys/geometry/core/shapes/surfaces/plane.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 
 from ansys.geometry.core.math.constants import UNITVECTOR3D_X, UNITVECTOR3D_Z
@@ -48,19 +47,19 @@ class PlaneSurface(Surface):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D],
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Centered origin of the plane.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
     """
 
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize an instance of a plane surface."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin
@@ -109,7 +108,7 @@ class PlaneSurface(Surface):
         """Check whether a 3D point is in the domain of the plane."""
         raise NotImplementedError("contains_point() is not implemented.")
 
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parametrize the plane."""
         u = Parameterization(ParamForm.OPEN, ParamType.LINEAR, Interval(-np.inf, np.inf))
         v = Parameterization(ParamForm.OPEN, ParamType.LINEAR, Interval(-np.inf, np.inf))

--- a/src/ansys/geometry/core/shapes/surfaces/sphere.py
+++ b/src/ansys/geometry/core/shapes/surfaces/sphere.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 from pint import Quantity
 
@@ -50,23 +49,23 @@ class Sphere(Surface):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D]
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Origin of the sphere.
-    radius : Union[Quantity, Distance, Real]
+    radius : ~pint.Quantity | Distance | Real
         Radius of the sphere.
-    reference : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         X-axis direction.
-    axis : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
         Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        radius: Union[Quantity, Distance, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        radius: Quantity | Distance | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Sphere`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin
@@ -199,7 +198,7 @@ class Sphere(Surface):
         v = np.arctan2(z, np.sqrt(x * x + y * y))
         return SphereEvaluation(self, ParamUV(u, v))
 
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parameterization of the sphere surface as a tuple (U, V).
 
         The U parameter specifies the longitude angle, increasing clockwise (east) about
@@ -211,7 +210,7 @@ class Sphere(Surface):
 
         Returns
         -------
-        Tuple[Parameterization, Parameterization]
+        tuple[Parameterization, Parameterization]
             Information about how a sphere's u and v parameters are parameterized, respectively.
         """
         u = Parameterization(ParamForm.PERIODIC, ParamType.CIRCULAR, Interval(0, 2 * np.pi))

--- a/src/ansys/geometry/core/shapes/surfaces/surface.py
+++ b/src/ansys/geometry/core/shapes/surfaces/surface.py
@@ -22,8 +22,7 @@
 """Provides the ``Surface`` class."""
 
 from abc import ABC, abstractmethod
-
-from beartype.typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from ansys.geometry.core.math.matrix import Matrix44
 from ansys.geometry.core.math.point import Point3D
@@ -39,7 +38,7 @@ class Surface(ABC):
     """Provides the abstract base class for a 3D surface."""
 
     @abstractmethod
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parameterize the surface as a tuple (U and V respectively)."""
         return
 

--- a/src/ansys/geometry/core/shapes/surfaces/torus.py
+++ b/src/ansys/geometry/core/shapes/surfaces/torus.py
@@ -24,7 +24,6 @@
 from functools import cached_property
 
 from beartype import beartype as check_input_types
-from beartype.typing import Tuple, Union
 import numpy as np
 from pint import Quantity
 
@@ -50,26 +49,26 @@ class Torus(Surface):
 
     Parameters
     ----------
-    origin : Union[~numpy.ndarray, RealSequence, Point3D],
+    origin : ~numpy.ndarray | RealSequence | Point3D
         Centered origin of the torus.
-    direction_x : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        X-axis direction.
-    direction_y : Union[~numpy.ndarray, RealSequence, UnitVector3D, Vector3D]
-        Y-axis direction.
-    major_radius : Union[Quantity, Distance, Real]
+    major_radius : ~pint.Quantity | Distance | Real
         Major radius of the torus.
-    minor_radius : Union[Quantity, Distance, Real]
+    minor_radius : ~pint.Quantity | Distance | Real
         Minor radius of the torus.
+    reference : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
+        X-axis direction.
+    axis : ~numpy.ndarray | RealSequence | UnitVector3D | Vector3D
+        Z-axis direction.
     """
 
     @check_input_types
     def __init__(
         self,
-        origin: Union[np.ndarray, RealSequence, Point3D],
-        major_radius: Union[Quantity, Distance, Real],
-        minor_radius: Union[Quantity, Distance, Real],
-        reference: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_X,
-        axis: Union[np.ndarray, RealSequence, UnitVector3D, Vector3D] = UNITVECTOR3D_Z,
+        origin: np.ndarray | RealSequence | Point3D,
+        major_radius: Quantity | Distance | Real,
+        minor_radius: Quantity | Distance | Real,
+        reference: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_X,
+        axis: np.ndarray | RealSequence | UnitVector3D | Vector3D = UNITVECTOR3D_Z,
     ):
         """Initialize the ``Torus`` class."""
         self._origin = Point3D(origin) if not isinstance(origin, Point3D) else origin
@@ -190,7 +189,7 @@ class Torus(Surface):
         """
         return TorusEvaluation(self, parameter)
 
-    def parameterization(self) -> Tuple[Parameterization, Parameterization]:
+    def parameterization(self) -> tuple[Parameterization, Parameterization]:
         """Parameterize the torus surface as a tuple (U and V respectively).
 
         The U parameter specifies the longitude angle, increasing clockwise (east) about
@@ -205,7 +204,7 @@ class Torus(Surface):
 
         Returns
         -------
-        Tuple[Parameterization, Parameterization]
+        tuple[Parameterization, Parameterization]
             Information about how a torus's u and v parameters are parameterized, respectively.
         """
         u = Parameterization(ParamForm.PERIODIC, ParamType.CIRCULAR, Interval(0, 2 * np.pi))
@@ -402,12 +401,12 @@ class TorusEvaluation(SurfaceEvaluation):
         )
 
     @cached_property
-    def curvature(self) -> Tuple[Real, Vector3D, Real, Vector3D]:
+    def curvature(self) -> tuple[Real, Vector3D, Real, Vector3D]:
         """Curvature of the torus.
 
         Returns
         -------
-        Tuple[Real, Vector3D, Real, Vector3D]
+        tuple[Real, Vector3D, Real, Vector3D]
             Minimum and maximum curvature value and direction, respectively.
         """
         min_cur = 1.0 / self._torus.minor_radius.m

--- a/src/ansys/geometry/core/sketch/arc.py
+++ b/src/ansys/geometry/core/sketch/arc.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing an arc."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -59,7 +58,7 @@ class Arc(SketchEdge):
         start: Point2D,
         end: Point2D,
         center: Point2D,
-        clockwise: Optional[bool] = False,
+        clockwise: bool = False,
     ):
         """Initialize the arc shape."""
         super().__init__()
@@ -348,9 +347,9 @@ class Arc(SketchEdge):
         cls,
         start: Point2D,
         end: Point2D,
-        radius: Union[Quantity, Distance, Real],
-        convex_arc: Optional[bool] = False,
-        clockwise: Optional[bool] = False,
+        radius: Quantity | Distance | Real,
+        convex_arc: bool = False,
+        clockwise: bool = False,
     ):
         """Create an arc from a starting point, an ending point, and a radius.
 
@@ -360,7 +359,7 @@ class Arc(SketchEdge):
             Starting point of the arc.
         end : Point2D
             Ending point of the arc.
-        radius : Union[Quantity, Distance, Real]
+        radius : ~pint.Quantity | Distance | Real
             Radius of the arc.
         convex_arc : bool, default: False
             Whether the arc is convex. The default is ``False``.
@@ -407,8 +406,8 @@ class Arc(SketchEdge):
         cls,
         start: Point2D,
         center: Point2D,
-        angle: Union[Angle, Quantity, Real],
-        clockwise: Optional[bool] = False,
+        angle: Angle | Quantity | Real,
+        clockwise: bool = False,
     ):
         """Create an arc from a starting point, a center point, and an angle.
 
@@ -418,7 +417,7 @@ class Arc(SketchEdge):
             Starting point of the arc.
         center : Point2D
             Center point of the arc.
-        angle : Union[Angle, Quantity, Real]
+        angle : Angle | ~pint.Quantity | Real
             Angle of the arc.
         clockwise : bool, default: False
             Whether the provided angle should be considered clockwise.

--- a/src/ansys/geometry/core/sketch/box.py
+++ b/src/ansys/geometry/core/sketch/box.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing a box (quadrilateral)."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 from pint import Quantity
 import pyvista as pv
 from scipy.spatial.transform import Rotation as SpatialRotation
@@ -43,11 +42,11 @@ class Box(SketchFace):
     ----------
     center: Point2D
         Center point of the box.
-    width : Union[Quantity, Distance, Real]
+    width : ~pint.Quantity | Distance | Real
         Width of the box.
-    height : Union[Quantity, Distance, Real]
+    height : ~pint.Quantity | Distance | Real
         Height of the box.
-    angle : Union[Quantity, Angle, Real], default: 0
+    angle : ~pint.Quantity | Angle | Real, default: 0
         Placement angle for orientation alignment.
     """
 
@@ -55,9 +54,9 @@ class Box(SketchFace):
     def __init__(
         self,
         center: Point2D,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
     ):
         """Initialize the box."""
         super().__init__()

--- a/src/ansys/geometry/core/sketch/circle.py
+++ b/src/ansys/geometry/core/sketch/circle.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing a circle."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 from pint import Quantity
 import pyvista as pv
 
@@ -41,7 +40,7 @@ class SketchCircle(SketchFace, Circle):
     ----------
     center: Point2D
         Center point of the circle.
-    radius : Union[Quantity, Distance, Real]
+    radius : ~pint.Quantity | Distance | Real
         Radius of the circle.
     plane : Plane, optional
         Plane containing the sketched circle, which is the global XY plane
@@ -49,9 +48,7 @@ class SketchCircle(SketchFace, Circle):
     """
 
     @check_input_types
-    def __init__(
-        self, center: Point2D, radius: Union[Quantity, Distance, Real], plane: Plane = Plane()
-    ):
+    def __init__(self, center: Point2D, radius: Quantity | Distance | Real, plane: Plane = Plane()):
         """Initialize the circle."""
         # Call SketchFace init method
         SketchFace.__init__(self)
@@ -67,7 +64,7 @@ class SketchCircle(SketchFace, Circle):
         self._init_primitive_circle_from_plane(plane, radius=radius)
 
     def _init_primitive_circle_from_plane(
-        self, plane: Plane, radius: Optional[Union[Quantity, Distance]] = None
+        self, plane: Plane, radius: Quantity | Distance | None = None
     ) -> None:
         """Initialize correctly the underlying primitive ``Circle`` class.
 
@@ -75,7 +72,7 @@ class SketchCircle(SketchFace, Circle):
         ----------
         plane : Plane
             Plane containing the sketched circle.
-        radius : [Union[Quantity, Distance]], default: None
+        radius : Quantity | Distance, default: None
             Radius of the circle (if any).
         """
         # Use the radius given (if any)

--- a/src/ansys/geometry/core/sketch/edge.py
+++ b/src/ansys/geometry/core/sketch/edge.py
@@ -21,7 +21,8 @@
 # SOFTWARE.
 """Provides for creating and managing an edge."""
 
-from beartype.typing import TYPE_CHECKING
+from typing import TYPE_CHECKING
+
 from pint import Quantity
 import pyvista as pv
 

--- a/src/ansys/geometry/core/sketch/ellipse.py
+++ b/src/ansys/geometry/core/sketch/ellipse.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing an ellipse."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -46,11 +45,11 @@ class SketchEllipse(SketchFace, Ellipse):
     ----------
     center: Point2D
         Center point of the ellipse.
-    major_radius : Union[Quantity, Distance, Real]
+    major_radius : ~pint.Quantity | Distance | Real
         Major radius of the ellipse.
-    minor_radius : Union[Quantity, Distance, Real]
+    minor_radius : ~pint.Quantity | Distance | Real
         Minor radius of the ellipse.
-    angle : Union[Quantity, Angle, Real], default: 0
+    angle : ~pint.Quantity | Angle | Real, default: 0
         Placement angle for orientation alignment.
     plane : Plane, optional
         Plane containing the sketched ellipse, which is the global XY plane
@@ -61,9 +60,9 @@ class SketchEllipse(SketchFace, Ellipse):
     def __init__(
         self,
         center: Point2D,
-        major_radius: Union[Quantity, Distance, Real],
-        minor_radius: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
+        major_radius: Quantity | Distance | Real,
+        minor_radius: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
         plane: Plane = Plane(),
     ):
         """Initialize the ellipse."""
@@ -90,9 +89,9 @@ class SketchEllipse(SketchFace, Ellipse):
     def _init_primitive_ellipse_from_plane(
         self,
         plane: Plane,
-        major_radius: Optional[Distance] = None,
-        minor_radius: Optional[Distance] = None,
-        angle: Optional[Angle] = None,
+        major_radius: Distance | None = None,
+        minor_radius: Distance | None = None,
+        angle: Angle | None = None,
     ) -> None:
         """Initialize correctly the underlying primitive ``Ellipse`` class.
 
@@ -100,11 +99,11 @@ class SketchEllipse(SketchFace, Ellipse):
         ----------
         plane : Plane
             Plane containing the sketched ellipse.
-        major_radius : [Distance], default: None
+        major_radius : Distance, default: None
             Major radius of the ellipse (if any).
-        minor_radius : [Distance], default: None
+        minor_radius : Distance, default: None
             Minor radius of the ellipse (if any).
-        angle : [Angle], default: None
+        angle : Angle, default: None
             Placement angle for orientation alignment.
         """
         major_radius = major_radius if major_radius else self.major_radius

--- a/src/ansys/geometry/core/sketch/face.py
+++ b/src/ansys/geometry/core/sketch/face.py
@@ -21,7 +21,8 @@
 # SOFTWARE.
 """Provides for creating and managing a face (closed 2D sketch)."""
 
-from beartype.typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
+
 from pint import Quantity
 import pyvista as pv
 
@@ -41,7 +42,7 @@ class SketchFace:
         self._edges = []
 
     @property
-    def edges(self) -> List[SketchEdge]:
+    def edges(self) -> list[SketchEdge]:
         """List of all component edges forming the face."""
         return self._edges
 

--- a/src/ansys/geometry/core/sketch/gears.py
+++ b/src/ansys/geometry/core/sketch/gears.py
@@ -22,7 +22,6 @@
 """Module for creating and managing gears."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import List, Tuple, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -65,9 +64,9 @@ class DummyGear(Gear):
     ----------
     origin : Point2D
         Origin of the gear.
-    outer_radius : Union[Quantity, Distance, Real]
+    outer_radius : ~pint.Quantity | Distance | Real
         Outer radius of the gear.
-    inner_radius : Union[Quantity, Distance, Real]
+    inner_radius : ~pint.Quantity | Distance | Real
         Inner radius of the gear.
     n_teeth : int
         Number of teeth of the gear.
@@ -77,8 +76,8 @@ class DummyGear(Gear):
     def __init__(
         self,
         origin: Point2D,
-        outer_radius: Union[Quantity, Distance, Real],
-        inner_radius: Union[Quantity, Distance, Real],
+        outer_radius: Quantity | Distance | Real,
+        inner_radius: Quantity | Distance | Real,
         n_teeth: int,
     ):
         """Initialize the ``DummyGear`` class."""
@@ -164,7 +163,7 @@ class SpurGear(Gear):
     module : Real
         Module of the spur gear. This is also the ratio between the pitch circle
         diameter in millimeters and the number of teeth.
-    pressure_angle : Union[Quantity, Angle, Real]
+    pressure_angle : ~pint.Quantity | Angle | Real
         Pressure angle of the spur gear.
     n_teeth : int
         Number of teeth of the spur gear.
@@ -175,7 +174,7 @@ class SpurGear(Gear):
         self,
         origin: Point2D,
         module: Real,
-        pressure_angle: Union[Quantity, Angle, Real],
+        pressure_angle: Quantity | Angle | Real,
         n_teeth: int,
     ):
         """Initialize spur gears."""
@@ -297,12 +296,12 @@ class SpurGear(Gear):
 
     def _sketch_single_tooth_spur_gear(
         self,
-    ) -> Tuple[List[Real], List[Real], List[Real], List[Real]]:
+    ) -> tuple[list[Real], list[Real], list[Real], list[Real]]:
         """Sketch a single tooth using this private method.
 
         Returns
         -------
-        Tuple[List[Real], List[Real], List[Real], List[Real]]
+        tuple[list[Real], list[Real], list[Real], list[Real]]
             X and Y values for the tooth grouped together as follows: (x_i, x_m, y_i, y_m)
         """
         # Compute the involute with the smallest of both
@@ -330,7 +329,7 @@ class SpurGear(Gear):
 
     def _involute(
         self, radius: Real, max_radius: Real, max_theta: Real, steps: int = 30
-    ) -> Tuple[List[Real], List[Real]]:
+    ) -> tuple[list[Real], list[Real]]:
         """Generate the involute points discretization of a curve.
 
         Parameters
@@ -346,7 +345,7 @@ class SpurGear(Gear):
 
         Returns
         -------
-        Tuple[List[Real], List[Real], List[Real]]
+        tuple[list[Real], list[Real], list[Real]]
             Three-element tuple containing a list of X, Y, and theta values
             defining the involute.
         """
@@ -385,22 +384,22 @@ class SpurGear(Gear):
         return (x_p, y_p, t_p)
 
     def _align_involute(
-        self, x_p: List[Real], y_p: List[Real], t_p: List[Real]
-    ) -> Tuple[List[Real], List[Real]]:
+        self, x_p: list[Real], y_p: list[Real], t_p: list[Real]
+    ) -> tuple[list[Real], list[Real]]:
         """Align the discretized values of the involute curve.
 
         Parameters
         ----------
-        x_p : List[Real]
+        x_p : list[Real]
             X-elements defining the involute curve to align.
-        y_p : List[Real]
+        y_p : list[Real]
             Y-elements defining the involute curve to align.
-        t_p : List[Real]
+        t_p : list[Real]
             Angles defining the involute curve to align.
 
         Returns
         -------
-        Tuple[List[Real], List[Real]]
+        tuple[list[Real], list[Real]]
             Set of X and Y elements that have been aligned.
 
         Raises
@@ -430,22 +429,22 @@ class SpurGear(Gear):
         return self._rotate_curve(-theta_cross, x_p, y_p)
 
     def _rotate_curve(
-        self, angle: Real, x_p: List[Real], y_p: List[Real]
-    ) -> Tuple[List[Real], List[Real]]:
+        self, angle: Real, x_p: list[Real], y_p: list[Real]
+    ) -> tuple[list[Real], list[Real]]:
         """Rotate X,Y elements defining a curve by a given angle.
 
         Parameters
         ----------
         angle : Real
             Angle (in radians) to rotate the X,Y elements.
-        x_p : List[Real]
+        x_p : list[Real]
             X-elements of the curve to rotate.
-        y_p : List[Real]
+        y_p : list[Real]
             Y-elements of the curve to rotate.
 
         Returns
         -------
-        Tuple[List[Real], List[Real]]
+        tuple[list[Real], list[Real]]
             The X and Y elements of the rotated curve.
         """
         # Compute the sin and cos values of the angle
@@ -462,22 +461,22 @@ class SpurGear(Gear):
         return (x_r, y_r)
 
     def _generate_arcs(
-        self, x_p: List[Real], y_p: List[Real], closing_involute: bool = False
-    ) -> List[Arc]:
+        self, x_p: list[Real], y_p: list[Real], closing_involute: bool = False
+    ) -> list[Arc]:
         """Generate the arcs of involute curves when sketching spur gears.
 
         Parameters
         ----------
-        x_p : List[Real]
+        x_p : list[Real]
             X-elements defining the involute curve.
-        y_p : List[Real]
+        y_p : list[Real]
             Y-elements defining the involute curve.
         closing_involute : bool, optional
             Shortcut for joining involute curves, by default False.
 
         Returns
         -------
-        List[Arc]
+        list[Arc]
             The list of arcs defining the requested curve.
         """
         # Initialize results container

--- a/src/ansys/geometry/core/sketch/polygon.py
+++ b/src/ansys/geometry/core/sketch/polygon.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing a polygon."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -43,11 +42,11 @@ class Polygon(SketchFace):
     ----------
     center: Point2D
         Center point of the circle.
-    inner_radius : Union[Quantity, Distance, Real]
+    inner_radius : ~pint.Quantity | Distance | Real
         Inner radius (apothem) of the polygon.
     sides : int
         Number of sides of the polygon.
-    angle : Union[Quantity, Angle, Real], default: 0
+    angle : ~pint.Quantity | Angle | Real, default: 0
         Placement angle for orientation alignment.
     """
 
@@ -55,9 +54,9 @@ class Polygon(SketchFace):
     def __init__(
         self,
         center: Point2D,
-        inner_radius: Union[Quantity, Distance, Real],
+        inner_radius: Quantity | Distance | Real,
         sides: int,
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
+        angle: Quantity | Angle | Real = 0,
     ):
         """Initialize the polygon."""
         super().__init__()

--- a/src/ansys/geometry/core/sketch/sketch.py
+++ b/src/ansys/geometry/core/sketch/sketch.py
@@ -21,8 +21,9 @@
 # SOFTWARE.
 """Provides for creating and managing a sketch."""
 
+from typing import TYPE_CHECKING
+
 from beartype import beartype as check_input_types
-from beartype.typing import TYPE_CHECKING, Dict, List, Optional, Union
 from pint import Quantity
 
 from ansys.geometry.core.math.constants import ZERO_POINT2D
@@ -47,7 +48,7 @@ from ansys.geometry.core.typing import Real
 if TYPE_CHECKING:  # pragma: no cover
     from pyvista import PolyData
 
-SketchObject = Union[SketchEdge, SketchFace]
+SketchObject = SketchEdge | SketchFace
 """Type to refer to both ``SketchEdge`` and ``SketchFace``."""
 
 
@@ -55,15 +56,15 @@ class Sketch:
     """Provides for building 2D sketch elements."""
 
     # Types of the class instance private attributes
-    _faces: List[SketchFace]
-    _edges: List[SketchEdge]
-    _current_sketch_context: List[SketchObject]
-    _tags: Dict[str, List[SketchObject]]
+    _faces: list[SketchFace]
+    _edges: list[SketchEdge]
+    _current_sketch_context: list[SketchObject]
+    _tags: dict[str, list[SketchObject]]
 
     @check_input_types
     def __init__(
         self,
-        plane: Optional[Plane] = Plane(),
+        plane: Plane = Plane(),
     ):
         """Initialize the ``Sketch`` class."""
         self._plane = plane
@@ -83,7 +84,7 @@ class Sketch:
         return self._plane
 
     @property
-    def edges(self) -> List[SketchEdge]:
+    def edges(self) -> list[SketchEdge]:
         """List of all independently sketched edges.
 
         Notes
@@ -94,7 +95,7 @@ class Sketch:
         return self._edges
 
     @property
-    def faces(self) -> List[SketchFace]:
+    def faces(self) -> list[SketchFace]:
         """List of all independently sketched faces."""
         return self._faces
 
@@ -134,19 +135,19 @@ class Sketch:
     @check_input_types
     def translate_sketch_plane_by_offset(
         self,
-        x: Union[Quantity, Distance] = Quantity(0, DEFAULT_UNITS.LENGTH),
-        y: Union[Quantity, Distance] = Quantity(0, DEFAULT_UNITS.LENGTH),
-        z: Union[Quantity, Distance] = Quantity(0, DEFAULT_UNITS.LENGTH),
+        x: Quantity | Distance = Quantity(0, DEFAULT_UNITS.LENGTH),
+        y: Quantity | Distance = Quantity(0, DEFAULT_UNITS.LENGTH),
+        z: Quantity | Distance = Quantity(0, DEFAULT_UNITS.LENGTH),
     ) -> "Sketch":
         """Translate the origin location of the active sketch plane by offsets.
 
         Parameters
         ----------
-        x : Union[~pint.Quantity, Distance], default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
+        x : ~pint.Quantity | Distance, default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
             Amount to translate the origin of the x-direction.
-        y : Union[~pint.Quantity, Distance], default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
+        y : ~pint.Quantity | Distance, default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
             Amount to translate the origin of the y-direction.
-        z : Union[~pint.Quantity, Distance], default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
+        z : ~pint.Quantity | Distance, default: ~pint.Quantity(0, ``DEFAULT_UNITS.LENGTH``)
             Amount to translate the origin of the z-direction.
 
         Returns
@@ -176,7 +177,7 @@ class Sketch:
 
     @check_input_types
     def translate_sketch_plane_by_distance(
-        self, direction: UnitVector3D, distance: Union[Quantity, Distance]
+        self, direction: UnitVector3D, distance: Quantity | Distance
     ) -> "Sketch":
         """Translate the origin location active sketch plane by distance.
 
@@ -184,7 +185,7 @@ class Sketch:
         ----------
         direction : UnitVector3D
             Direction to translate the origin.
-        distance : Union[~pint.Quantity, Distance]
+        distance : ~pint.Quantity | Distance
             Distance to translate the origin.
 
         Returns
@@ -203,7 +204,7 @@ class Sketch:
         return self.translate_sketch_plane(translation)
 
     @check_input_types
-    def get(self, tag: str) -> List[SketchObject]:
+    def get(self, tag: str) -> list[SketchObject]:
         """Get a list of shapes with a given tag.
 
         Parameters
@@ -214,7 +215,7 @@ class Sketch:
         return self._tags[tag]
 
     @check_input_types
-    def face(self, face: SketchFace, tag: Optional[str] = None) -> "Sketch":
+    def face(self, face: SketchFace, tag: str | None = None) -> "Sketch":
         """Add a sketch face to the sketch.
 
         Parameters
@@ -236,7 +237,7 @@ class Sketch:
         return self
 
     @check_input_types
-    def edge(self, edge: SketchEdge, tag: Optional[str] = None) -> "Sketch":
+    def edge(self, edge: SketchEdge, tag: str | None = None) -> "Sketch":
         """Add a sketch edge to the sketch.
 
         Parameters
@@ -267,7 +268,7 @@ class Sketch:
 
         return self
 
-    def segment(self, start: Point2D, end: Point2D, tag: Optional[str] = None) -> "Sketch":
+    def segment(self, start: Point2D, end: Point2D, tag: str | None = None) -> "Sketch":
         """Add a segment sketch object to the sketch plane.
 
         Parameters
@@ -287,7 +288,7 @@ class Sketch:
         segment = SketchSegment(start, end)
         return self.edge(segment, tag)
 
-    def segment_to_point(self, end: Point2D, tag: Optional[str] = None) -> "Sketch":
+    def segment_to_point(self, end: Point2D, tag: str | None = None) -> "Sketch":
         """Add a segment to the sketch plane starting from the previous end point.
 
         Parameters
@@ -312,7 +313,7 @@ class Sketch:
 
     @check_input_types
     def segment_from_point_and_vector(
-        self, start: Point2D, vector: Vector2D, tag: Optional[str] = None
+        self, start: Point2D, vector: Vector2D, tag: str | None = None
     ):
         """Add a segment to the sketch starting from a given starting point.
 
@@ -343,7 +344,7 @@ class Sketch:
         return self.segment(start, end, tag)
 
     @check_input_types
-    def segment_from_vector(self, vector: Vector2D, tag: Optional[str] = None):
+    def segment_from_vector(self, vector: Vector2D, tag: str | None = None):
         """Add a segment to the sketch starting from the previous end point.
 
         Parameters
@@ -375,8 +376,8 @@ class Sketch:
         start: Point2D,
         end: Point2D,
         center: Point2D,
-        clockwise: Optional[bool] = False,
-        tag: Optional[str] = None,
+        clockwise: bool = False,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add an arc to the sketch plane.
 
@@ -409,8 +410,8 @@ class Sketch:
         self,
         end: Point2D,
         center: Point2D,
-        clockwise: Optional[bool] = False,
-        tag: Optional[str] = None,
+        clockwise: bool = False,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add an arc to the sketch starting from the previous end point.
 
@@ -447,7 +448,7 @@ class Sketch:
         start: Point2D,
         inter: Point2D,
         end: Point2D,
-        tag: Optional[str] = None,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add an arc to the sketch plane from three given points.
 
@@ -474,10 +475,10 @@ class Sketch:
         self,
         start: Point2D,
         end: Point2D,
-        radius: Union[Quantity, Distance, Real],
-        convex_arc: Optional[bool] = False,
-        clockwise: Optional[bool] = False,
-        tag: Optional[str] = None,
+        radius: Quantity | Distance | Real,
+        convex_arc: bool = False,
+        clockwise: bool = False,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add an arc from the start, end points and a radius.
 
@@ -487,7 +488,7 @@ class Sketch:
             Starting point of the arc.
         end : Point2D
             Ending point of the arc.
-        radius : Union[~pint.Quantity, Distance, Real]
+        radius : ~pint.Quantity | Distance | Real
             Radius of the arc.
         convex_arc : bool, default: False
             Whether the arc is convex. The default is ``False``.
@@ -519,9 +520,9 @@ class Sketch:
         self,
         start: Point2D,
         center: Point2D,
-        angle: Union[Quantity, Angle, Real],
-        clockwise: Optional[bool] = False,
-        tag: Optional[str] = None,
+        angle: Quantity | Angle | Real,
+        clockwise: bool = False,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add an arc from the start, center point, and angle.
 
@@ -531,7 +532,7 @@ class Sketch:
             Starting point of the arc.
         center : Point2D
             Center point of the arc.
-        angle : Union[~pint.Quantity, Angle, Real]
+        angle : ~pint.Quantity | Angle | Real
             Angle of the arc.
         clockwise : bool, default: False
             Whether the arc spans the angle clockwise. The default is ``False``.
@@ -556,7 +557,7 @@ class Sketch:
         point1: Point2D,
         point2: Point2D,
         point3: Point2D,
-        tag: Optional[str] = None,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add a triangle to the sketch using given vertex points.
 
@@ -581,30 +582,30 @@ class Sketch:
 
     def trapezoid(
         self,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        slant_angle: Union[Quantity, Angle, Real],
-        nonsymmetrical_slant_angle: Optional[Union[Quantity, Angle, Real]] = None,
-        center: Optional[Point2D] = ZERO_POINT2D,
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
-        tag: Optional[str] = None,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        slant_angle: Quantity | Angle | Real,
+        nonsymmetrical_slant_angle: Quantity | Angle | Real | None = None,
+        center: Point2D = ZERO_POINT2D,
+        angle: Quantity | Angle | Real = 0,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add a triangle to the sketch using given vertex points.
 
         Parameters
         ----------
-        width : Union[~pint.Quantity, Distance, Real]
+        width : ~pint.Quantity | Distance | Real
             Width of the slot main body.
-        height : Union[~pint.Quantity, Distance, Real]
+        height : ~pint.Quantity | Distance | Real
             Height of the slot.
-        slant_angle : Union[~pint.Quantity, Angle, Real]
+        slant_angle : ~pint.Quantity | Distance | Real
             Angle for trapezoid generation.
-        nonsymmetrical_slant_angle : Union[~pint.Quantity, Angle, Real], default: None
+        nonsymmetrical_slant_angle : ~pint.Quantity | Angle | Real | None, default: None
             Asymmetrical slant angles on each side of the trapezoid.
             The default is ``None``, in which case the trapezoid is symmetrical.
         center : Point2D, default: (0, 0)
             Center point of the trapezoid.
-        angle : Optional[Union[~pint.Quantity, Angle, Real]], default: 0
+        angle : ~pint.Quantity | Angle | Real, default: 0
             Placement angle for orientation alignment.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -620,8 +621,8 @@ class Sketch:
     def circle(
         self,
         center: Point2D,
-        radius: Union[Quantity, Distance, Real],
-        tag: Optional[str] = None,
+        radius: Quantity | Distance | Real,
+        tag: str | None = None,
     ) -> "Sketch":
         """Add a circle to the plane at a given center.
 
@@ -629,7 +630,7 @@ class Sketch:
         ----------
         center: Point2D
             Center point of the circle.
-        radius : Union[~pint.Quantity, Distance, Real]
+        radius : ~pint.Quantity | Distance | Real
             Radius of the circle.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -645,10 +646,10 @@ class Sketch:
     def box(
         self,
         center: Point2D,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
-        tag: Optional[str] = None,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create a box on the sketch.
 
@@ -656,11 +657,11 @@ class Sketch:
         ----------
         center: Point2D
             Center point of the box.
-        width : Union[~pint.Quantity, Distance, Real]
+        width : ~pint.Quantity | Distance | Real
             Width of the box.
-        height : Union[~pint.Quantity, Distance, Real]
+        height : ~pint.Quantity | Distance | Real
             Height of the box.
-        angle : Union[~pint.Quantity, Real], default: 0
+        angle : ~pint.Quantity | Angle | Real, default: 0
             Placement angle for orientation alignment.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -676,10 +677,10 @@ class Sketch:
     def slot(
         self,
         center: Point2D,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
-        tag: Optional[str] = None,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create a slot on the sketch.
 
@@ -687,11 +688,11 @@ class Sketch:
         ----------
         center: Point2D
             Center point of the slot.
-        width : Union[~pint.Quantity, Distance, Real]
+        width : ~pint.Quantity | Distance | Real
             Width of the slot.
-        height : Union[~pint.Quantity, Distance, Real]
+        height : ~pint.Quantity | Distance | Real
             Height of the slot.
-        angle : Union[~pint.Quantity, Angle, Real], default: 0
+        angle : ~pint.Quantity | Angle | Real, default: 0
             Placement angle for orientation alignment.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -707,10 +708,10 @@ class Sketch:
     def ellipse(
         self,
         center: Point2D,
-        major_radius: Union[Quantity, Distance, Real],
-        minor_radius: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
-        tag: Optional[str] = None,
+        major_radius: Quantity | Distance | Real,
+        minor_radius: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create an ellipse on the sketch.
 
@@ -718,11 +719,11 @@ class Sketch:
         ----------
         center: Point2D
             Center point of the ellipse.
-        major_radius : Union[~pint.Quantity, Distance, Real]
+        major_radius : ~pint.Quantity | Distance | Real
             Semi-major axis of the ellipse.
-        minor_radius : Union[~pint.Quantity, Distance, Real]
+        minor_radius : ~pint.Quantity | Distance | Real
             Semi-minor axis of the ellipse.
-        angle : Union[~pint.Quantity, Angle, Real], default: 0
+        angle : ~pint.Quantity | Angle | Real, default: 0
             Placement angle for orientation alignment.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -738,10 +739,10 @@ class Sketch:
     def polygon(
         self,
         center: Point2D,
-        inner_radius: Union[Quantity, Distance, Real],
+        inner_radius: Quantity | Distance | Real,
         sides: int,
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
-        tag: Optional[str] = None,
+        angle: Quantity | Angle | Real = 0,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create a polygon on the sketch.
 
@@ -749,11 +750,11 @@ class Sketch:
         ----------
         center: Point2D
             Center point of the polygon.
-        inner_radius : Union[~pint.Quantity, Distance, Real]
+        inner_radius : ~pint.Quantity | Distance | Real
             Inner radius (apothem) of the polygon.
         sides : int
             Number of sides of the polygon.
-        angle : Union[~pint.Quantity, Angle, Real], default: 0
+        angle : ~pint.Quantity | Angle | Real, default: 0
             Placement angle for orientation alignment.
         tag : str, default: None
             User-defined label for identifying the face.
@@ -769,10 +770,10 @@ class Sketch:
     def dummy_gear(
         self,
         origin: Point2D,
-        outer_radius: Union[Quantity, Distance, Real],
-        inner_radius: Union[Quantity, Distance, Real],
+        outer_radius: Quantity | Distance | Real,
+        inner_radius: Quantity | Distance | Real,
         n_teeth: int,
-        tag: Optional[str] = None,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create a dummy gear on the sketch.
 
@@ -780,9 +781,9 @@ class Sketch:
         ----------
         origin : Point2D
             Origin of the gear.
-        outer_radius : Union[~pint.Quantity, Distance, Real]
+        outer_radius : ~pint.Quantity | Distance | Real
             Outer radius of the gear.
-        inner_radius : Union[~pint.Quantity, Distance, Real]
+        inner_radius : ~pint.Quantity | Distance | Real
             Inner radius of the gear.
         n_teeth : int
             Number of teeth of the gear.
@@ -801,9 +802,9 @@ class Sketch:
         self,
         origin: Point2D,
         module: Real,
-        pressure_angle: Union[Quantity, Angle, Real],
+        pressure_angle: Quantity | Angle | Real,
         n_teeth: int,
-        tag: Optional[str] = None,
+        tag: str | None = None,
     ) -> "Sketch":
         """Create a spur gear on the sketch.
 
@@ -814,7 +815,7 @@ class Sketch:
         module : Real
             Module of the spur gear. This is also the ratio between the pitch circle
             diameter in millimeters and the number of teeth.
-        pressure_angle : Union[~pint.Quantity, Angle, Real]
+        pressure_angle : ~pint.Quantity | Angle | Real
             Pressure angle of the spur gear.
         n_teeth : int
             Number of teeth of the spur gear.
@@ -852,12 +853,12 @@ class Sketch:
 
         return self._edges[-1].end
 
-    def _tag(self, sketch_collection: List[SketchObject], tag: str) -> None:
+    def _tag(self, sketch_collection: list[SketchObject], tag: str) -> None:
         """Add a tag for a collection of sketch objects.
 
         Parameters
         ----------
-        sketch_collection : List[SketchObject]
+        sketch_collection : list[SketchObject]
             Sketch objects to tag.
         tag : str, default: None
             Tag to assign to these sketch objects.
@@ -866,11 +867,11 @@ class Sketch:
 
     def plot(
         self,
-        view_2d: Optional[bool] = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        selected_pd_objects: List["PolyData"] = None,
-        **plotting_options: Optional[dict],
+        view_2d: bool = False,
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        selected_pd_objects: list["PolyData"] = None,
+        **plotting_options: dict | None,
     ):
         """Plot all objects of the sketch to the scene.
 
@@ -918,10 +919,10 @@ class Sketch:
 
     def plot_selection(
         self,
-        view_2d: Optional[bool] = False,
-        screenshot: Optional[str] = None,
-        use_trame: Optional[bool] = None,
-        **plotting_options: Optional[dict],
+        view_2d: bool = False,
+        screenshot: str | None = None,
+        use_trame: bool | None = None,
+        **plotting_options: dict | None,
     ):
         """Plot the current selection to the scene.
 
@@ -955,12 +956,12 @@ class Sketch:
             **plotting_options,
         )
 
-    def sketch_polydata(self) -> List["PolyData"]:
+    def sketch_polydata(self) -> list["PolyData"]:
         """Get polydata configuration for all objects of the sketch.
 
         Returns
         -------
-        List[~pyvista.PolyData]
+        list[~pyvista.PolyData]
             List of the polydata configuration for all edges and faces in the sketch.
         """
         sketches_polydata = []
@@ -968,12 +969,12 @@ class Sketch:
         sketches_polydata.extend(self.sketch_polydata_faces())
         return sketches_polydata
 
-    def sketch_polydata_faces(self) -> List["PolyData"]:
+    def sketch_polydata_faces(self) -> list["PolyData"]:
         """Get polydata configuration for all faces of the sketch to the scene.
 
         Returns
         -------
-        List[~pyvista.PolyData]
+        list[~pyvista.PolyData]
             List of the polydata configuration for faces in the sketch.
         """
         sketches_polydata_faces = [
@@ -982,12 +983,12 @@ class Sketch:
         ]
         return sketches_polydata_faces
 
-    def sketch_polydata_edges(self) -> List["PolyData"]:
+    def sketch_polydata_edges(self) -> list["PolyData"]:
         """Get polydata configuration for all edges of the sketch to the scene.
 
         Returns
         -------
-        List[~pyvista.PolyData]
+        list[~pyvista.PolyData]
             List of the polydata configuration for edges in the sketch.
         """
         sketches_polydata_edges = [

--- a/src/ansys/geometry/core/sketch/slot.py
+++ b/src/ansys/geometry/core/sketch/slot.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing a slot."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -45,11 +44,11 @@ class Slot(SketchFace):
     ----------
     center: :class:`Point2D <ansys.geometry.core.math.point.Point2D>`
         Center point of the slot.
-    width : Union[Quantity, Distance, Real]
+    width : ~pint.Quantity | Distance | Real
         Width of the slot main body.
-    height : Union[Quantity, Distance, Real]
+    height : ~pint.Quantity | Distance | Real
         Height of the slot.
-    angle : Union[Quantity, Angle, Real], default: 0
+    angle : ~pint.Quantity | Angle | Real, default: 0
         Placement angle for orientation alignment.
     """
 
@@ -57,9 +56,9 @@ class Slot(SketchFace):
     def __init__(
         self,
         center: Point2D,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        angle: Quantity | Angle | Real = 0,
     ):
         """Initialize the slot."""
         super().__init__()

--- a/src/ansys/geometry/core/sketch/trapezoid.py
+++ b/src/ansys/geometry/core/sketch/trapezoid.py
@@ -22,7 +22,6 @@
 """Provides for creating and managing a trapezoid."""
 
 from beartype import beartype as check_input_types
-from beartype.typing import Optional, Union
 import numpy as np
 from pint import Quantity
 import pyvista as pv
@@ -43,18 +42,18 @@ class Trapezoid(SketchFace):
 
     Parameters
     ----------
-    width : Union[Quantity, Distance, Real]
+    width : ~pint.Quantity | Distance | Real
         Width of the trapezoid.
-    height : Union[Quantity, Distance, Real]
+    height : ~pint.Quantity | Distance | Real
         Height of the trapezoid.
-    slant_angle : Union[Quantity, Angle, Real]
+    slant_angle : ~pint.Quantity | Angle | Real
         Angle for trapezoid generation.
-    nonsymmetrical_slant_angle : Union[Quantity, Angle, Real], default: None
+    nonsymmetrical_slant_angle : ~pint.Quantity | Angle | Real | None, default: None
         Asymmetrical slant angles on each side of the trapezoid.
         The default is ``None``, in which case the trapezoid is symmetrical.
     center: Point2D, default: ZERO_POINT2D
         Center point of the trapezoid.
-    angle : Union[Quantity, Angle, Real], default: 0
+    angle : ~pint.Quantity | Angle | Real, default: 0
         Placement angle for orientation alignment.
 
     Notes
@@ -67,12 +66,12 @@ class Trapezoid(SketchFace):
     @check_input_types
     def __init__(
         self,
-        width: Union[Quantity, Distance, Real],
-        height: Union[Quantity, Distance, Real],
-        slant_angle: Union[Quantity, Angle, Real],
-        nonsymmetrical_slant_angle: Optional[Union[Quantity, Angle, Real]] = None,
-        center: Optional[Point2D] = ZERO_POINT2D,
-        angle: Optional[Union[Quantity, Angle, Real]] = 0,
+        width: Quantity | Distance | Real,
+        height: Quantity | Distance | Real,
+        slant_angle: Quantity | Angle | Real,
+        nonsymmetrical_slant_angle: Quantity | Angle | Real | None = None,
+        center: Point2D = ZERO_POINT2D,
+        angle: Quantity | Angle | Real = 0,
     ):
         """Initialize the trapezoid."""
         super().__init__()

--- a/src/ansys/geometry/core/tools/measurement_tools.py
+++ b/src/ansys/geometry/core/tools/measurement_tools.py
@@ -21,12 +21,13 @@
 # SOFTWARE.
 """Provides tools for measurement."""
 
+from typing import TYPE_CHECKING
+
 from ansys.api.geometry.v0.measuretools_pb2 import (
     MinDistanceBetweenObjectsRequest,
     MinDistanceBetweenObjectsResponse,
 )
 from ansys.api.geometry.v0.measuretools_pb2_grpc import MeasureToolsStub
-from beartype.typing import TYPE_CHECKING
 
 from ansys.geometry.core.connection import GrpcClient
 from ansys.geometry.core.errors import protect_grpc

--- a/src/ansys/geometry/core/tools/prepare_tools.py
+++ b/src/ansys/geometry/core/tools/prepare_tools.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 """Provides tools for preparing geometry for use with simulation."""
 
+from typing import TYPE_CHECKING
+
 from ansys.api.dbu.v0.dbumodels_pb2 import EntityIdentifier
 from ansys.api.geometry.v0.models_pb2 import Body as GRPCBody
 from ansys.api.geometry.v0.preparetools_pb2 import (
@@ -30,7 +32,6 @@ from ansys.api.geometry.v0.preparetools_pb2 import (
 )
 from ansys.api.geometry.v0.preparetools_pb2_grpc import PrepareToolsStub
 from beartype import beartype as check_input_types
-from beartype.typing import TYPE_CHECKING, List
 from google.protobuf.wrappers_pb2 import BoolValue, DoubleValue
 
 from ansys.geometry.core.connection import GrpcClient
@@ -67,8 +68,8 @@ class PrepareTools:
     @check_input_types
     @min_backend_version(25, 1, 0)
     def extract_volume_from_faces(
-        self, sealing_faces: List["Face"], inside_faces: List["Face"]
-    ) -> List["Body"]:
+        self, sealing_faces: list["Face"], inside_faces: list["Face"]
+    ) -> list["Body"]:
         """Extract a volume from input faces.
 
         Creates a volume (typically a flow volume) from a list of faces that seal the volume
@@ -76,14 +77,14 @@ class PrepareTools:
 
         Parameters
         ----------
-        sealing_faces : List[Face]
+        sealing_faces : list[Face]
             List of faces that seal the volume.
-        inside_faces : List[Face]
+        inside_faces : list[Face]
             List of faces that define the interior of the solid.
 
         Returns
         -------
-        List[Body]
+        list[Body]
             List of created bodies.
         """
         if not sealing_faces or not inside_faces:
@@ -112,8 +113,8 @@ class PrepareTools:
     @check_input_types
     @min_backend_version(25, 1, 0)
     def extract_volume_from_edge_loops(
-        self, sealing_edges: List["Edge"], inside_faces: List["Face"]
-    ) -> List["Body"]:
+        self, sealing_edges: list["Edge"], inside_faces: list["Face"]
+    ) -> list["Body"]:
         """Extract a volume from input edge loops.
 
         Creates a volume (typically a flow volume) from a list of edge loops that seal the volume.
@@ -121,14 +122,14 @@ class PrepareTools:
 
         Parameters
         ----------
-        sealing_edges : List[Edge]
+        sealing_edges : list[Edge]
             List of faces that seal the volume.
-        inside_faces : List[Face]
+        inside_faces : list[Face]
             List of faces that define the interior of the solid (Not always necessary).
 
         Returns
         -------
-        List[Body]
+        list[Body]
             List of created bodies.
         """
         if not sealing_edges:
@@ -157,13 +158,13 @@ class PrepareTools:
     @check_input_types
     @min_backend_version(25, 1, 0)
     def share_topology(
-        self, bodies: List["Body"], tol: Real = 0.0, preserve_instances: bool = False
+        self, bodies: list["Body"], tol: Real = 0.0, preserve_instances: bool = False
     ) -> bool:
         """Share topology between the chosen bodies.
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies to share topology between.
         tol : Real
             Maximum distance between bodies.

--- a/src/ansys/geometry/core/tools/problem_areas.py
+++ b/src/ansys/geometry/core/tools/problem_areas.py
@@ -22,6 +22,7 @@
 """The problem area definition."""
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
 from ansys.api.geometry.v0.repairtools_pb2 import (
     FixDuplicateFacesRequest,
@@ -34,7 +35,6 @@ from ansys.api.geometry.v0.repairtools_pb2 import (
     FixStitchFacesRequest,
 )
 from ansys.api.geometry.v0.repairtools_pb2_grpc import RepairToolsStub
-from beartype.typing import TYPE_CHECKING, List
 from google.protobuf.wrappers_pb2 import Int32Value
 
 from ansys.geometry.core.connection import GrpcClient
@@ -91,11 +91,11 @@ class DuplicateFaceProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    faces : List[Face]
+    faces : list[Face]
         List of faces associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, faces: List["Face"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, faces: list["Face"]):
         """Initialize a new instance of the duplicate face problem areaclass."""
         super().__init__(id, grpc_client)
 
@@ -107,7 +107,7 @@ class DuplicateFaceProblemAreas(ProblemArea):
         self._faces = faces
 
     @property
-    def faces(self) -> List["Face"]:
+    def faces(self) -> list["Face"]:
         """The list of the edges connected to this problem area."""
         return self._faces
 
@@ -145,11 +145,11 @@ class MissingFaceProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    edges : List[Edge]
+    edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: List["Edge"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
         """Initialize a new instance of the missing face problem area class."""
         super().__init__(id, grpc_client)
 
@@ -161,7 +161,7 @@ class MissingFaceProblemAreas(ProblemArea):
         self._edges = edges
 
     @property
-    def edges(self) -> List["Edge"]:
+    def edges(self) -> list["Edge"]:
         """The list of the edges connected to this problem area."""
         return self._edges
 
@@ -198,11 +198,11 @@ class InexactEdgeProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    edges : List[Edge]
+    edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: List["Edge"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
         """Initialize a new instance of the inexact edge problem area class."""
         super().__init__(id, grpc_client)
 
@@ -214,7 +214,7 @@ class InexactEdgeProblemAreas(ProblemArea):
         self._edges = edges
 
     @property
-    def edges(self) -> List["Edge"]:
+    def edges(self) -> list["Edge"]:
         """The list of the edges connected to this problem area."""
         return self._edges
 
@@ -251,11 +251,11 @@ class ExtraEdgeProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    edges : List[Edge]
+    edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: List["Edge"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
         """Initialize a new instance of the extra edge problem area class."""
         super().__init__(id, grpc_client)
 
@@ -267,7 +267,7 @@ class ExtraEdgeProblemAreas(ProblemArea):
         self._edges = edges
 
     @property
-    def edges(self) -> List["Edge"]:
+    def edges(self) -> list["Edge"]:
         """The list of the ids of the edges connected to this problem area."""
         return self._edges
 
@@ -304,11 +304,11 @@ class ShortEdgeProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    edges : List[Edge]
+    edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: List["Edge"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
         """Initialize a new instance of the ``ShortEdgeProblemAreas`` class."""
         super().__init__(id, grpc_client)
 
@@ -320,7 +320,7 @@ class ShortEdgeProblemAreas(ProblemArea):
         self._edges = edges
 
     @property
-    def edges(self) -> List["Edge"]:
+    def edges(self) -> list["Edge"]:
         """The list of the ids of the edges connected to this problem area."""
         return self._edges
 
@@ -358,11 +358,11 @@ class SmallFaceProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    faces : List[Face]
+    faces : list[Face]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, faces: List["Face"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, faces: list["Face"]):
         """Initialize a new instance of the small face problem area class."""
         super().__init__(id, grpc_client)
 
@@ -374,7 +374,7 @@ class SmallFaceProblemAreas(ProblemArea):
         self._faces = faces
 
     @property
-    def faces(self) -> List["Face"]:
+    def faces(self) -> list["Face"]:
         """The list of the ids of the edges connected to this problem area."""
         return self._faces
 
@@ -411,11 +411,11 @@ class SplitEdgeProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    edges : List[Edge]
+    edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: List["Edge"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
         """Initialize a new instance of the split edge problem area class."""
         super().__init__(id, grpc_client)
 
@@ -427,7 +427,7 @@ class SplitEdgeProblemAreas(ProblemArea):
         self._edges = edges
 
     @property
-    def edges(self) -> List["Edge"]:
+    def edges(self) -> list["Edge"]:
         """The list of edges connected to this problem area."""
         return self._edges
 
@@ -464,11 +464,11 @@ class StitchFaceProblemAreas(ProblemArea):
         Server-defined ID for the body.
     grpc_client : GrpcClient
         Active supporting geometry service instance for design modeling.
-    bodies : List[Body]
+    bodies : list[Body]
         List of bodies associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, bodies: List["Body"]):
+    def __init__(self, id: str, grpc_client: GrpcClient, bodies: list["Body"]):
         """Initialize a new instance of the stitch face problem area class."""
         super().__init__(id, grpc_client)
 
@@ -480,7 +480,7 @@ class StitchFaceProblemAreas(ProblemArea):
         self._bodies = bodies
 
     @property
-    def bodies(self) -> List["Body"]:
+    def bodies(self) -> list["Body"]:
         """The list of the bodies connected to this problem area."""
         return self._bodies
 

--- a/src/ansys/geometry/core/tools/repair_tool_message.py
+++ b/src/ansys/geometry/core/tools/repair_tool_message.py
@@ -21,22 +21,20 @@
 # SOFTWARE.
 """Module for repair tool message."""
 
-from beartype.typing import List
-
 
 class RepairToolMessage:
     """Provides return message for the repair tool methods."""
 
-    def __init__(self, success: bool, created_bodies: List[str], modified_bodies: List[str]):
+    def __init__(self, success: bool, created_bodies: list[str], modified_bodies: list[str]):
         """Initialize a new instance of the extra edge problem area class.
 
         Parameters
         ----------
         success: bool
             True if the repair operation was effective, false if it is not.
-        created_bodies: List[str]
+        created_bodies: list[str]
             List of bodies created after the repair operation.
-        modified_bodies: List[str]
+        modified_bodies: list[str]
             List of bodies modified after the repair operation.
         """
         self._success = success
@@ -49,11 +47,11 @@ class RepairToolMessage:
         return self._success
 
     @property
-    def created_bodies(self) -> List[str]:
+    def created_bodies(self) -> list[str]:
         """The list of the created bodies after the repair operation."""
         return self._created_bodies
 
     @property
-    def modified_bodies(self) -> List[str]:
+    def modified_bodies(self) -> list[str]:
         """The list of the modified bodies after the repair operation."""
         return self._modified_bodies

--- a/src/ansys/geometry/core/tools/repair_tools.py
+++ b/src/ansys/geometry/core/tools/repair_tools.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 """Provides tools for repairing bodies."""
 
+from typing import TYPE_CHECKING
+
 from ansys.api.geometry.v0.bodies_pb2_grpc import BodiesStub
 from ansys.api.geometry.v0.repairtools_pb2 import (
     FindDuplicateFacesRequest,
@@ -33,7 +35,6 @@ from ansys.api.geometry.v0.repairtools_pb2 import (
     FindStitchFacesRequest,
 )
 from ansys.api.geometry.v0.repairtools_pb2_grpc import RepairToolsStub
-from beartype.typing import TYPE_CHECKING, List
 from google.protobuf.wrappers_pb2 import DoubleValue
 
 from ansys.geometry.core.connection import GrpcClient
@@ -69,8 +70,8 @@ class RepairTools:
         self._bodies_stub = BodiesStub(self._grpc_client.channel)
 
     def find_split_edges(
-        self, bodies: List["Body"], angle: Real = 0.0, length: Real = 0.0
-    ) -> List[SplitEdgeProblemAreas]:
+        self, bodies: list["Body"], angle: Real = 0.0, length: Real = 0.0
+    ) -> list[SplitEdgeProblemAreas]:
         """Find split edges in the given list of bodies.
 
         This method finds the split edge problem areas and returns a list of split edge
@@ -78,7 +79,7 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that split edges are investigated on.
         angle : Real
             The maximum angle between edges.
@@ -87,7 +88,7 @@ class RepairTools:
 
         Returns
         -------
-        List[SplitEdgeProblemAreas]
+        list[SplitEdgeProblemAreas]
             List of objects representing split edge problem areas.
         """
         if not bodies:
@@ -112,7 +113,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_extra_edges(self, bodies: List["Body"]) -> List[ExtraEdgeProblemAreas]:
+    def find_extra_edges(self, bodies: list["Body"]) -> list[ExtraEdgeProblemAreas]:
         """Find the extra edges in the given list of bodies.
 
         This method find the extra edge problem areas and returns a list of extra edge
@@ -120,12 +121,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that extra edges are investigated on.
 
         Returns
         -------
-        List[ExtraEdgeProblemArea]
+        list[ExtraEdgeProblemArea]
             List of objects representing extra edge problem areas.
         """
         if not bodies:
@@ -146,7 +147,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_inexact_edges(self, bodies: List["Body"]) -> List[InexactEdgeProblemAreas]:
+    def find_inexact_edges(self, bodies: list["Body"]) -> list[InexactEdgeProblemAreas]:
         """Find inexact edges in the given list of bodies.
 
         This method find the inexact edge problem areas and returns a list of inexact
@@ -154,12 +155,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that inexact edges are investigated on.
 
         Returns
         -------
-        List[InExactEdgeProblemArea]
+        list[InExactEdgeProblemArea]
             List of objects representing inexact edge problem areas.
         """
         if not bodies:
@@ -182,8 +183,8 @@ class RepairTools:
         ]
 
     def find_short_edges(
-        self, bodies: List["Body"], length: Real = 0.0
-    ) -> List[ShortEdgeProblemAreas]:
+        self, bodies: list["Body"], length: Real = 0.0
+    ) -> list[ShortEdgeProblemAreas]:
         """Find the short edge problem areas.
 
         This method finds the short edge problem areas and returns a list of
@@ -191,12 +192,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that short edges are investigated on.
 
         Returns
         -------
-        List[ShortEdgeProblemAreas]
+        list[ShortEdgeProblemAreas]
             List of objects representing short edge problem areas.
         """
         if not bodies:
@@ -219,7 +220,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_duplicate_faces(self, bodies: List["Body"]) -> List[DuplicateFaceProblemAreas]:
+    def find_duplicate_faces(self, bodies: list["Body"]) -> list[DuplicateFaceProblemAreas]:
         """Find the duplicate face problem areas.
 
         This method finds the duplicate face problem areas and returns a list of
@@ -227,12 +228,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that duplicate faces are investigated on.
 
         Returns
         -------
-        List[DuplicateFaceProblemAreas]
+        list[DuplicateFaceProblemAreas]
             List of objects representing duplicate face problem areas.
         """
         if not bodies:
@@ -253,7 +254,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_missing_faces(self, bodies: List["Body"]) -> List[MissingFaceProblemAreas]:
+    def find_missing_faces(self, bodies: list["Body"]) -> list[MissingFaceProblemAreas]:
         """Find the missing faces.
 
         This method find the missing face problem areas and returns a list of missing
@@ -261,12 +262,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that missing faces are investigated on.
 
         Returns
         -------
-        List[MissingFaceProblemAreas]
+        list[MissingFaceProblemAreas]
             List of objects representing missing face problem areas.
         """
         if not bodies:
@@ -286,7 +287,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_small_faces(self, bodies: List["Body"]) -> List[SmallFaceProblemAreas]:
+    def find_small_faces(self, bodies: list["Body"]) -> list[SmallFaceProblemAreas]:
         """Find the small face problem areas.
 
         This method finds and returns a list of ids of small face problem areas
@@ -294,12 +295,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that small faces are investigated on.
 
         Returns
         -------
-        List[SmallFaceProblemAreas]
+        list[SmallFaceProblemAreas]
             List of objects representing small face problem areas.
         """
         if not bodies:
@@ -320,7 +321,7 @@ class RepairTools:
             for res in problem_areas_response.result
         ]
 
-    def find_stitch_faces(self, bodies: List["Body"]) -> List[StitchFaceProblemAreas]:
+    def find_stitch_faces(self, bodies: list["Body"]) -> list[StitchFaceProblemAreas]:
         """Return the list of stitch face problem areas.
 
         This method find the stitch face problem areas and returns a list of ids of stitch face
@@ -328,12 +329,12 @@ class RepairTools:
 
         Parameters
         ----------
-        bodies : List[Body]
+        bodies : list[Body]
             List of bodies that stitchable faces are investigated on.
 
         Returns
         -------
-        List[StitchFaceProblemAreas]
+        list[StitchFaceProblemAreas]
             List of objects representing stitch face problem areas.
         """
         body_ids = [body.id for body in bodies]

--- a/src/ansys/geometry/core/typing.py
+++ b/src/ansys/geometry/core/typing.py
@@ -21,13 +21,14 @@
 # SOFTWARE.
 """Provides typing of values for PyAnsys Geometry."""
 
-from beartype.typing import Sequence, Union
+from typing import Sequence
+
 import numpy as np
 
-Real = Union[int, float, np.integer, np.floating]
+Real = int | float | np.integer | np.floating
 """Type used to refer to both integers and floats as possible values."""
 
-RealSequence = Union[np.ndarray, Sequence[Real]]
+RealSequence = np.ndarray | Sequence[Real]
 """Type used to refer to ``Real`` types as a ``Sequence`` type.
 
 Notes

--- a/tests/integration/test_logging_client.py
+++ b/tests/integration/test_logging_client.py
@@ -24,8 +24,8 @@
 import logging as deflogging  # Default logging
 from pathlib import Path
 import re
+from typing import Callable
 
-from beartype.typing import Callable
 import pytest
 
 from ansys.geometry.core import LOG, Modeler  # Global logger

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -23,8 +23,8 @@
 
 import logging as deflogging  # Default logging
 import re
+from typing import Callable
 
-from beartype.typing import Callable
 import pytest
 
 from ansys.geometry.core import LOG  # Global logger


### PR DESCRIPTION
## Description
As title says - adapting typehints to +3.10

## Issue linked
Closes #1346 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
