### PR TITLE
feat: add ``modeler.exit()`` method

### DIFF
--- a/doc/changelog.d/1375.added.md
+++ b/doc/changelog.d/1375.added.md
@@ -1,0 +1,1 @@
+add ``modeler.exit()`` method

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -221,7 +221,7 @@ class Modeler:
 
     def exit(self) -> None:
         """Access the client's close method.
-        
+
         Notes
         -----
         This method is calling the same method as

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -217,7 +217,7 @@ class Modeler:
 
     def close(self) -> None:
         """Access the client's close method."""
-        return self.client.close()
+        self.client.close()
 
     def exit(self) -> None:
         """Access the client's close method.
@@ -227,7 +227,7 @@ class Modeler:
         This method is calling the same method as
         :func:`close() <ansys.geometry.core.modeler.Modeler.close>`.
         """
-        return self.close()
+        self.close()
 
     def _upload_file(
         self,

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -219,6 +219,16 @@ class Modeler:
         """Access the client's close method."""
         return self.client.close()
 
+    def exit(self) -> None:
+        """Access the client's close method.
+        
+        Notes
+        -----
+        This method is calling the same method as
+        :func:`close() <ansys.geometry.core.modeler.Modeler.close>`.
+        """
+        return self.close()
+
     def _upload_file(
         self,
         file_path: str,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -132,7 +132,7 @@ def modeler(docker_instance):
     yield modeler
 
     # Cleanup on exit
-    modeler.close()
+    modeler.exit()
     assert modeler.client.is_closed
 
 


### PR DESCRIPTION
## Description
We have the ``modeler.close()`` method but in order to be in line with the other PyAnsys libraries, we are also including ``modeler.exit()`` now. They will effectively perform the same calls.

## Issue linked
Related to https://github.com/ansys/pyansys-geometry/discussions/1374

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
