### PR TITLE
feat: accept pathlib.Path as input in missing methods

### DIFF
--- a/doc/changelog.d/1385.added.md
+++ b/doc/changelog.d/1385.added.md
@@ -1,0 +1,1 @@
+accept pathlib.Path as input in missing methods

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -162,7 +162,7 @@ class GrpcClient:
         )
         if logging_file:
             if isinstance(logging_file, Path):
-                logging_file = str(logging_file)
+                logging_file = logging_file.as_posix()
             self._log.log_to_file(filename=logging_file, level=logging_level)
 
         self._admin_stub = AdminStub(self._channel)

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -162,7 +162,7 @@ class GrpcClient:
         )
         if logging_file:
             if isinstance(logging_file, Path):
-                logging_file = logging_file.as_posix()
+                logging_file = str(logging_file)
             self._log.log_to_file(filename=logging_file, level=logging_level)
 
         self._admin_stub = AdminStub(self._channel)

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -231,7 +231,7 @@ class Design(Component):
         """
         # Sanity checks on inputs
         if isinstance(file_location, Path):
-            file_location = str(file_location)
+            file_location = file_location.as_posix()
 
         self._design_stub.SaveAs(SaveAsRequest(filepath=file_location))
         self._grpc_client.log.debug(f"Design successfully saved at location {file_location}.")
@@ -311,7 +311,7 @@ class Design(Component):
         """
         return (Path(location) if location else Path.cwd()) / f"{self.name}.{ext}"
 
-    def export_to_scdocx(self, location: Path | str | None = None) -> str:
+    def export_to_scdocx(self, location: Path | str | None = None) -> Path:
         """Export the design to an scdocx file.
 
         Parameters
@@ -322,7 +322,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Define the file location
@@ -334,7 +334,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_parasolid_text(self, location: Path | str | None = None) -> str:
+    def export_to_parasolid_text(self, location: Path | str | None = None) -> Path:
         """Export the design to a Parasolid text file.
 
         Parameters
@@ -345,7 +345,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Determine the extension based on the backend type
@@ -360,7 +360,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_parasolid_bin(self, location: Path | str | None = None) -> str:
+    def export_to_parasolid_bin(self, location: Path | str | None = None) -> Path:
         """Export the design to a Parasolid binary file.
 
         Parameters
@@ -371,7 +371,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Determine the extension based on the backend type
@@ -386,7 +386,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_fmd(self, location: Path | str | None = None) -> str:
+    def export_to_fmd(self, location: Path | str | None = None) -> Path:
         """Export the design to an FMD file.
 
         Parameters
@@ -397,7 +397,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Define the file location
@@ -409,7 +409,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_step(self, location: Path | str | None = None) -> str:
+    def export_to_step(self, location: Path | str | None = None) -> Path:
         """Export the design to a STEP file.
 
         Parameters
@@ -420,7 +420,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Define the file location
@@ -432,7 +432,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_iges(self, location: Path | str = None) -> str:
+    def export_to_iges(self, location: Path | str = None) -> Path:
         """Export the design to an IGES file.
 
         Parameters
@@ -443,7 +443,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Define the file location
@@ -455,7 +455,7 @@ class Design(Component):
         # Return the file location
         return file_location
 
-    def export_to_pmdb(self, location: Path | str | None = None) -> str:
+    def export_to_pmdb(self, location: Path | str | None = None) -> Path:
         """Export the design to a PMDB file.
 
         Parameters
@@ -466,7 +466,7 @@ class Design(Component):
 
         Returns
         -------
-        str
+        ~pathlib.Path
             The path to the saved file.
         """
         # Define the file location

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -231,7 +231,7 @@ class Design(Component):
         """
         # Sanity checks on inputs
         if isinstance(file_location, Path):
-            file_location = file_location.as_posix()
+            file_location = str(file_location)
 
         self._design_stub.SaveAs(SaveAsRequest(filepath=file_location))
         self._grpc_client.log.debug(f"Design successfully saved at location {file_location}.")

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -316,7 +316,7 @@ class Modeler:
         """
         # Use POSIX format of Path object here
         if isinstance(file_path, Path):
-            file_path = file_path.as_posix()
+            file_path = str(file_path)
 
         # Format-specific logic - upload the whole containing folder for assemblies
         if upload_to_server:
@@ -404,7 +404,7 @@ class Modeler:
         """
         # Use POSIX format of Path object here
         if isinstance(file_path, Path):
-            file_path = file_path.as_posix()
+            file_path = str(file_path)
 
         serv_path = self._upload_file(file_path)
         ga_stub = DbuApplicationStub(self._grpc_client.channel)

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -314,9 +314,8 @@ class Modeler:
         Design
             Newly imported design.
         """
-        # Use POSIX format of Path object here
-        if isinstance(file_path, Path):
-            file_path = str(file_path)
+        # Use str format of Path object here
+        file_path = str(file_path) if isinstance(file_path, Path) else file_path
 
         # Format-specific logic - upload the whole containing folder for assemblies
         if upload_to_server:
@@ -402,9 +401,8 @@ class Modeler:
             If the Discovery script fails to run. Otherwise, assume that the script
             ran successfully.
         """
-        # Use POSIX format of Path object here
-        if isinstance(file_path, Path):
-            file_path = str(file_path)
+        # Use str format of Path object here
+        file_path = str(file_path) if isinstance(file_path, Path) else file_path
 
         serv_path = self._upload_file(file_path)
         ga_stub = DbuApplicationStub(self._grpc_client.channel)

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -285,7 +285,7 @@ class Modeler:
     @protect_grpc
     def open_file(
         self,
-        file_path: str,
+        file_path: str | Path,
         upload_to_server: bool = True,
         import_options: ImportOptions = ImportOptions(),
     ) -> "Design":
@@ -301,7 +301,7 @@ class Modeler:
 
         Parameters
         ----------
-        file_path : str
+        file_path : str, ~pathlib.Path
             Path of the file to open. The extension of the file must be included.
         upload_to_server : bool
             True if the service is running on a remote machine. If service is running on the local
@@ -314,6 +314,10 @@ class Modeler:
         Design
             Newly imported design.
         """
+        # Use POSIX format of Path object here
+        if isinstance(file_path, Path):
+            file_path = file_path.as_posix()
+
         # Format-specific logic - upload the whole containing folder for assemblies
         if upload_to_server:
             if any(
@@ -343,7 +347,7 @@ class Modeler:
 
     @protect_grpc
     def run_discovery_script_file(
-        self, file_path: str, script_args: dict[str, str] | None = None, import_design=False
+        self, file_path: str | Path, script_args: dict[str, str] | None = None, import_design=False
     ) -> tuple[dict[str, str], Optional["Design"]]:
         """Run a Discovery script file.
 
@@ -374,7 +378,7 @@ class Modeler:
 
         Parameters
         ----------
-        file_path : str
+        file_path : str, ~pathlib.Path
             Path of the file. The extension of the file must be included.
         script_args : dict[str, str], optional.
             Arguments to pass to the script. By default, ``None``.
@@ -398,6 +402,10 @@ class Modeler:
             If the Discovery script fails to run. Otherwise, assume that the script
             ran successfully.
         """
+        # Use POSIX format of Path object here
+        if isinstance(file_path, Path):
+            file_path = file_path.as_posix()
+
         serv_path = self._upload_file(file_path)
         ga_stub = DbuApplicationStub(self._grpc_client.channel)
         request = RunScriptFileRequest(


### PR DESCRIPTION
## Description
As title says - some methods were only accepting strings and not pathlib.Path objects

## Issue linked
Related to #1384 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
