### PR TITLE
feat: default logs folder on Geometry Service started by Python at PUBLIC (Windows)

### DIFF
--- a/doc/changelog.d/1386.added.md
+++ b/doc/changelog.d/1386.added.md
@@ -1,1 +1,1 @@
-logs on Geometry Service started by Python client always on specific dir at APPDATA (Windows)
+default logs folder on Geometry Service started by Python at PUBLIC (Windows)

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -578,16 +578,10 @@ def launch_modeler_with_geometry_service(
         )
 
     # If we are in a Windows environment, we are going to write down the server
-    # logs in the %APPDATA%/Ansys/v{product_version}/GeometryService folder.
+    # logs in the %PUBLIC%/Documents/Ansys/GeometryService folder.
     if os.name == "nt" and server_logs_folder is None:
-        from ansys.tools.path import get_latest_ansys_installation
-
-        # Making lazy assumption on the product version...
-        product_version = product_version if product_version else get_latest_ansys_installation()[0]
-        server_logs_folder = Path(
-            os.getenv("APPDATA"), "Ansys", f"v{product_version}", "GeometryService"
-        )
-        server_logs_folder.mkdir(parents=True, exist_ok=True)
+        # Writing to the "Public" folder by default - no write permissions specifically required.
+        server_logs_folder = Path(os.getenv("PUBLIC"), "Documents", "Ansys", "GeometryService")
         LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
 
     return prepare_and_start_backend(

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -23,6 +23,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
@@ -575,6 +576,19 @@ def launch_modeler_with_geometry_service(
             "The 'api_version' parameter is not used in 'launch_modeler_with_geometry_service'. "
             "Please remove it from the arguments."
         )
+
+    # If we are in a Windows environment, we are going to write down the server
+    # logs in the %APPDATA%/Ansys/v{product_version}/GeometryService folder.
+    if os.name == "nt" and server_logs_folder is None:
+        from ansys.tools.path import get_latest_ansys_installation
+
+        # Making lazy assumption on the product version...
+        product_version = product_version if product_version else get_latest_ansys_installation()[0]
+        server_logs_folder = Path(
+            os.getenv("APPDATA"), "Ansys", f"v{product_version}", "GeometryService"
+        )
+        server_logs_folder.mkdir(parents=True, exist_ok=True)
+        LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
 
     return prepare_and_start_backend(
         BackendType.WINDOWS_SERVICE,

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -270,6 +270,18 @@ def prepare_and_start_backend(
         product_version = get_latest_ansys_installation()[0]
         _check_minimal_versions(product_version)
 
+    if server_logs_folder is not None:
+        # Verify that the user has write permissions to the folder and that it exists.
+        try:
+            # Make sure the folder exists...
+            Path(server_logs_folder).mkdir(parents=True, exist_ok=True)
+            # Create a file to test write permissions...
+            Path(server_logs_folder, ".verify").touch(exist_ok=True)
+        except PermissionError:
+            raise RuntimeError(
+                f"User does not have write permissions to the logs folder {server_logs_folder}"
+            )
+
     args = []
     env_copy = _get_common_env(
         host=host,

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -279,7 +279,8 @@ def prepare_and_start_backend(
             Path(server_logs_folder, ".verify").touch(exist_ok=True)
         except PermissionError:
             raise RuntimeError(
-                f"User does not have write permissions to the logs folder {server_logs_folder}"
+                "User does not have write permissions to the logs folder "
+                f"{Path(server_logs_folder).resolve()}"
             )
 
     args = []


### PR DESCRIPTION
## Description
Whenever we launch the Geometry Service locally (on Windows), we will make use of the APPDATA directory for Ansys products. Users should always have write permissions to it, and it will prevent from having some common issues like https://github.com/ansys/pyansys-geometry/discussions/1374#discussioncomment-10464047

## Issue linked
Closes #1377 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
