### PR TITLE
fix: remove ``server_logs_folder`` argument for Discovery and SpaceClaim

### DIFF
--- a/doc/changelog.d/1387.fixed.md
+++ b/doc/changelog.d/1387.fixed.md
@@ -1,0 +1,1 @@
+remove ``server_logs_folder`` argument for Discovery and SpaceClaim

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -602,7 +602,6 @@ def launch_modeler_with_geometry_service(
 
 
 @deprecated_argument(arg="log_level", alternative="server_log_level")
-@deprecated_argument(arg="logs_folder", alternative="server_logs_folder")
 def launch_modeler_with_discovery(
     product_version: int = None,
     host: str = "localhost",
@@ -613,10 +612,8 @@ def launch_modeler_with_discovery(
     hidden: bool = False,
     server_log_level: int = 2,
     client_log_level: int = logging.INFO,
-    server_logs_folder: str = None,
     client_log_file: str = None,
     log_level: int = None,  # DEPRECATED
-    logs_folder: str = None,  # DEPRECATED
     **kwargs: dict | None,
 ):
     """Start Ansys Discovery locally using the ``ProductInstance`` class.
@@ -668,16 +665,11 @@ def launch_modeler_with_discovery(
     client_log_level : int, optional
         Logging level to apply to the client. By default, INFO level is used.
         Use the logging module's levels: DEBUG, INFO, WARNING, ERROR, CRITICAL.
-    server_logs_folder : str, optional
-        Sets the backend's logs folder path. If nothing is defined,
-        the backend will use its default path.
     client_log_file : str, optional
         Sets the client's log file path. If nothing is defined,
         the client will log to the console.
     log_level : int, optional
         DEPRECATED. Use ``server_log_level`` instead.
-    logs_folder : str, optional
-        DEPRECATED. Use ``server_logs_folder`` instead.
     **kwargs : dict, default: None
         Placeholder to prevent errors when passing additional arguments that
         are not compatible with this method.
@@ -715,6 +707,13 @@ def launch_modeler_with_discovery(
         timeout=300,
         server_log_level=0)
     """
+    for unused_var in ["server_logs_folder", "logs_folder"]:
+        if unused_var in kwargs:
+            LOG.warning(
+                f"The '{unused_var}' parameter is not used in 'launch_modeler_with_discovery'. "
+                "Please remove it from the arguments."
+            )
+
     return prepare_and_start_backend(
         BackendType.DISCOVERY,
         product_version=product_version,
@@ -727,15 +726,12 @@ def launch_modeler_with_discovery(
         hidden=hidden,
         server_log_level=server_log_level,
         client_log_level=client_log_level,
-        server_logs_folder=server_logs_folder,
         client_log_file=client_log_file,
         log_level=log_level,
-        logs_folder=logs_folder,
     )
 
 
 @deprecated_argument(arg="log_level", alternative="server_log_level")
-@deprecated_argument(arg="logs_folder", alternative="server_logs_folder")
 def launch_modeler_with_spaceclaim(
     product_version: int = None,
     host: str = "localhost",
@@ -746,10 +742,8 @@ def launch_modeler_with_spaceclaim(
     hidden: bool = False,
     server_log_level: int = 2,
     client_log_level: int = logging.INFO,
-    server_logs_folder: str = None,
     client_log_file: str = None,
     log_level: int = None,  # DEPRECATED
-    logs_folder: str = None,  # DEPRECATED
     **kwargs: dict | None,
 ):
     """Start Ansys SpaceClaim locally using the ``ProductInstance`` class.
@@ -798,16 +792,11 @@ def launch_modeler_with_spaceclaim(
     client_log_level : int, optional
         Logging level to apply to the client. By default, INFO level is used.
         Use the logging module's levels: DEBUG, INFO, WARNING, ERROR, CRITICAL.
-    server_logs_folder : str, optional
-        Sets the backend's logs folder path. If nothing is defined,
-        the backend will use its default path.
     client_log_file : str, optional
         Sets the client's log file path. If nothing is defined,
         the client will log to the console.
     log_level : int, optional
         DEPRECATED. Use ``server_log_level`` instead.
-    logs_folder : str, optional
-        DEPRECATED. Use ``server_logs_folder`` instead.
     **kwargs : dict, default: None
         Placeholder to prevent errors when passing additional arguments that
         are not compatible with this method.
@@ -845,6 +834,13 @@ def launch_modeler_with_spaceclaim(
         timeout=300,
         server_log_level=0)
     """
+    for unused_var in ["server_logs_folder", "logs_folder"]:
+        if unused_var in kwargs:
+            LOG.warning(
+                f"The '{unused_var}' parameter is not used in 'launch_modeler_with_spaceclaim'. "
+                "Please remove it from the arguments."
+            )
+
     return prepare_and_start_backend(
         BackendType.SPACECLAIM,
         product_version=product_version,
@@ -857,10 +853,8 @@ def launch_modeler_with_spaceclaim(
         hidden=hidden,
         server_log_level=server_log_level,
         client_log_level=client_log_level,
-        server_logs_folder=server_logs_folder,
         client_log_file=client_log_file,
         log_level=log_level,
-        logs_folder=logs_folder,
     )
 
 

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -83,7 +83,10 @@ BACKEND_PORT_VARIABLE = "API_PORT"
 """The backend's port number environment variable for local start."""
 
 BACKEND_LOGS_FOLDER_VARIABLE = "ANS_DSCO_REMOTE_LOGS_FOLDER"
-"""The backend's logs folder path to be used."""
+"""The backend's logs folder path to be used.
+
+Only applicable to the Ansys Geometry Service.
+"""
 
 BACKEND_API_VERSION_VARIABLE = "API_VERSION"
 """The backend's api version environment variable for local start.


### PR DESCRIPTION
## Description
After conversations with @b-matteo - environment variable ``ANS_DSCO_REMOTE_LOGS_FOLDER`` is only applicable for the Geometry Service. Removing it as a potential input for SpaceClaim and Discovery

## Issue linked
None - but related to #1377

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
