### PR TITLE
docs: adapt examples to use launch_modeler instead of Modeler obj connection

### DIFF
--- a/doc/changelog.d/1410.documentation.md
+++ b/doc/changelog.d/1410.documentation.md
@@ -1,0 +1,1 @@
+adapt examples to use launch_modeler instead of Modeler obj connection

--- a/doc/source/examples/01_getting_started/05_plotter_picker.mystnb
+++ b/doc/source/examples/01_getting_started/05_plotter_picker.mystnb
@@ -40,35 +40,22 @@ from ansys.geometry.core.plotting import GeometryPlotter
 from ansys.geometry.core.sketch import Sketch
 ```
 
-## Load modeling service
+## Launch modeling service
 
-Load the modeling service. While the following code uses a Docker image to interact
-with the modeling service, you can use any suitable method mentioned in the
-preceding examples.
+Launch a modeling service session.
 
 ```{code-cell} ipython3
+from ansys.geometry.core import launch_modeler
 
-list_images = []
-list_containers = []
-available_images = LocalDockerInstance.docker_client().images.list(
-    name=GEOMETRY_SERVICE_DOCKER_IMAGE
-)
-is_image_available_cont = None
-for image in available_images:
-    for geom_image, geom_cont in zip(list_images, list_containers):
-        if geom_image in image.tags:
-            is_image_available = True
-            is_image_available_cont = geom_cont
-            break
-
-docker_instance = LocalDockerInstance(
-    connect_to_existing_service=True,
-    restart_if_existing_service=True,
-    image=is_image_available_cont,
-)
-
-modeler = Modeler(docker_instance=docker_instance)
+# Start a modeler session
+modeler = launch_modeler()
+print(modeler)
 ```
+
+You can also launch your own services and connect to them. For information on
+connecting to an existing service, see the
+[Modeler API](https://geometry.docs.pyansys.com/version/stable/api/ansys/geometry/core/modeler/Modeler.html)
+documentation.
 
 +++
 
@@ -119,6 +106,7 @@ plot_list.append(sketch)
 ```
 
 ## Create a PyVista cylinder
+
 Use PyVista to create a cylinder.
 
 ```{code-cell} ipython3
@@ -128,6 +116,7 @@ plot_list.append(cyl)
 ```
 
 ## Create a PyVista multiblock
+
 Use PyVista to create a multiblock with a sphere and a cube.
 
 ```{code-cell} ipython3
@@ -245,6 +234,7 @@ print(picked_list)
 ```
 
 ## Close session
+
 When you finish interacting with your modeling service, you should close the active
 server session. This frees resources wherever the service is running.
 

--- a/doc/source/examples/02_sketching/advanced_sketching_gears.mystnb
+++ b/doc/source/examples/02_sketching/advanced_sketching_gears.mystnb
@@ -25,14 +25,15 @@ the basic elements that define a sketch.
 ```{code-cell} ipython3
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import Plane, Point2D, Point3D
 from ansys.geometry.core.misc import UNITS, Distance
 from ansys.geometry.core.sketch import Sketch
 from ansys.geometry.core.plotting import GeometryPlotter
 
 # Start a modeler session
-modeler = Modeler()
+modeler = launch_modeler()
+print(modeler)
 
 # Define the origin point of the plane
 origin = Point3D([1, 1, 1])
@@ -127,4 +128,10 @@ dummy_gear = design.extrude_sketch("SpurGear", sketch, Distance(200, UNITS.mm))
 
 # Plot design
 design.plot()
+```
+
+## Close the modeler
+
+```{code-cell} ipython3	
+modeler.close()
 ```

--- a/doc/source/examples/02_sketching/advanced_sketching_gears.mystnb
+++ b/doc/source/examples/02_sketching/advanced_sketching_gears.mystnb
@@ -132,6 +132,6 @@ design.plot()
 
 ## Close the modeler
 
-```{code-cell} ipython3	
+```{code-cell} ipython3
 modeler.close()
 ```

--- a/doc/source/examples/02_sketching/dynamic_sketch_plane.mystnb
+++ b/doc/source/examples/02_sketching/dynamic_sketch_plane.mystnb
@@ -35,7 +35,7 @@ Perform the required imports.
 ```{code-cell} ipython3
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import UNITVECTOR3D_Z, Point2D
 from ansys.geometry.core.misc import UNITS
 from ansys.geometry.core.sketch import Sketch
@@ -73,17 +73,25 @@ sketch = Sketch()
 sketch.plot()
 ```
 
+## Instantiate the modeler
+
+Launch a modeling service and connect to it.
+
+```{code-cell} ipython3
+modeler = launch_modeler()
+print(modeler)
+```
+
 ## Extrude multiple bodies
 
-Establish a server connection and use the single sketch profile to extrude the board profile
-at multiple Z-offsets. Create a named selection from the resulting list of layer bodies.
+Use the single sketch profile to extrude the board profile at multiple Z-offsets.
+Create a named selection from the resulting list of layer bodies.
 
 Note that translating the sketch plane prior to extrusion is more effective (10 server calls)
 than creating a design body on the supporting server and then translating the body on the
 server (20 server calls).
 
 ```{code-cell} ipython3
-modeler = Modeler()
 design = modeler.create_design("ExtrudedBoardProfile")
 
 layers = []
@@ -94,4 +102,12 @@ for layer_index in range(10):
 
 board_named_selection = design.create_named_selection("FullBoard", bodies=layers)
 design.plot()
+```
+
+## Close the modeler
+
+Close the modeler to release the resources.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/add_design_material.mystnb
+++ b/doc/source/examples/03_modeling/add_design_material.mystnb
@@ -29,7 +29,7 @@ Perform the required imports.
 ```{code-cell} ipython3
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.materials import Material, MaterialProperty, MaterialPropertyType
 from ansys.geometry.core.math import UNITVECTOR3D_Z, Frame, Plane, Point2D, Point3D, UnitVector3D
 from ansys.geometry.core.misc import UNITS
@@ -47,10 +47,13 @@ sketch.circle(Point2D([10, 10], UNITS.mm), Quantity(10, UNITS.mm))
 
 ## Initiate design on server
 
-Establish a server connection and initiate a design on the server.
+Launch a modeling service session  and initiate a design on the server.
 
 ```{code-cell} ipython3
-modeler = Modeler()
+# Start a modeler session
+modeler = launch_modeler()
+print(modeler)
+
 design_name = "ExtrudeProfile"
 design = modeler.create_design(design_name)
 ```
@@ -87,4 +90,15 @@ body = design.extrude_sketch("SingleBody", sketch, Quantity(10, UNITS.mm))
 body.assign_material(material)
 
 body.plot()
+```
+
+## Close session
+
+When you finish interacting with your modeling service, you should close the active
+server session. This frees resources wherever the service is running.
+
+Close the server session.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/boolean_operations.mystnb
+++ b/doc/source/examples/03_modeling/boolean_operations.mystnb
@@ -21,7 +21,7 @@ Perform the required imports.
 ```{code-cell} ipython3
 from typing import List
 
-from ansys.geometry.core import launch_docker_modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.designer import Body
 from ansys.geometry.core.math import Point2D
 from ansys.geometry.core.misc import UNITS
@@ -37,7 +37,8 @@ modeler, see the "Launch a modeling service" section in the
 [PyAnsys Geometry 101: Modeling](../01_getting_started/04_modeling.mystnb) example.
 
 ```{code-cell} ipython3
-modeler = launch_docker_modeler()
+modeler = launch_modeler()
+print(modeler)
 ```
 
 ## Define bodies
@@ -212,6 +213,14 @@ the ``prism`` body has been consumed.
 
 ```{code-cell} ipython3
 print(design.bodies)
+```
+
+### Close the modeler
+
+Close the modeler to release the resources.
+
+```{code-cell} ipython3
+modeler.close()
 ```
 
 ## Summary

--- a/doc/source/examples/03_modeling/design_organization.mystnb
+++ b/doc/source/examples/03_modeling/design_organization.mystnb
@@ -35,7 +35,7 @@ node of the design tree to place the new body under.
 Perform the required imports.
 
 ```{code-cell} ipython3
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import UNITVECTOR3D_X, Point2D
 from ansys.geometry.core.misc import UNITS, Distance
 from ansys.geometry.core.sketch import Sketch
@@ -48,7 +48,7 @@ top-level design component. Assign the slot to the component nested
 one level beneath the top-level design component.
 
 ```{code-cell} ipython3
-modeler = Modeler()
+modeler = launch_modeler()
 
 design = modeler.create_design("DesignHierarchyExample")
 
@@ -93,4 +93,12 @@ cylinder_from_face = nested_component.extrude_face("CylinderFromFace", circle_su
 cylinder_from_face.translate(UNITVECTOR3D_X, Distance(-25, UNITS.mm))
 
 design.plot()
+```
+
+## Close the modeler
+
+Close the modeler to release the resources.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/design_tree.mystnb
+++ b/doc/source/examples/03_modeling/design_tree.mystnb
@@ -23,7 +23,7 @@ For the following example, we need to import these modules:
 ```{code-cell} ipython3
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math.constants import UNITVECTOR3D_X, UNITVECTOR3D_Y
 from ansys.geometry.core.math.point import Point2D, Point3D
 from ansys.geometry.core.misc.units import UNITS
@@ -37,7 +37,7 @@ several cylinders extruded. The interesting part is visualizing the correspondin
 
 ```{code-cell} ipython3
 # Create a modeler object
-modeler = Modeler()
+modeler = launch_modeler()
 
 # Create your design on the server side
 design = modeler.create_design("TreePrintComponent")
@@ -171,4 +171,12 @@ method on the component object.
 
 ```{code-cell} ipython3
 nested_1_comp_1.tree_print()
+```
+
+### Closing the modeler
+
+Finally, close the modeler.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/export_design.mystnb
+++ b/doc/source/examples/03_modeling/export_design.mystnb
@@ -23,12 +23,12 @@ The code creates a simple design for demonstration purposes. The design consists
 a set of rectangular pads with a circular hole in the center.
 
 ```{code-cell} ipython3
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import UNITVECTOR3D_X, UNITVECTOR3D_Y, Point2D
 from ansys.geometry.core.sketch import Sketch
 
-# Instantiate the modeler - this connects to the service
-modeler = Modeler()
+# Instantiate the modeler
+modeler = launch_modeler()
 
 # Create a design
 design = modeler.create_design("ExportDesignExample")
@@ -161,4 +161,13 @@ file_location = design.export_to_pmdb(download_dir)
 # Print the file location
 print(f"Design exported to {file_location}")
 print(f"Does the file exist? {Path(file_location).exists()}")
+```
+
+### Close the modeler
+
+Close the modeler after exporting the design.
+
+```{code-cell} ipython3
+# Close the modeler
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/plate_with_hole.mystnb
+++ b/doc/source/examples/03_modeling/plate_with_hole.mystnb
@@ -33,7 +33,7 @@ Perform the required imports.
 import numpy as np
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import Plane, Point3D, Point2D, UnitVector3D
 from ansys.geometry.core.misc import UNITS
 from ansys.geometry.core.sketch import Sketch
@@ -71,7 +71,8 @@ resulting list of bodies. In only three server calls, the design extrudes
 the four segments with the desired thickness.
 
 ```{code-cell} ipython3
-modeler = Modeler()
+modeler = launch_modeler()
+
 design = modeler.create_design("ExtrudedPlate")
 
 body = design.extrude_sketch(f"PlateLayer", sketch, Quantity(2, UNITS.m))
@@ -125,4 +126,12 @@ a sketch around the global coordinate system. For more information, see the
 ```{code-cell} ipython3
 longer_body.translate(UnitVector3D([1, 0, 0]), Quantity(4, UNITS.m))
 design.plot()
+```
+
+## Close the modeler
+
+Close the modeler to free up resources and release the connection.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/03_modeling/revolving.mystnb
+++ b/doc/source/examples/03_modeling/revolving.mystnb
@@ -19,7 +19,7 @@ specify the angle of revolution to create a partial body.
 
 ```{code-cell} ipython3
 # Imports
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import (
   Plane,
   Point2D,
@@ -32,9 +32,12 @@ from ansys.geometry.core.sketch import Sketch
 
 ```
 
+## Initialize the modeler
+
 ```{code-cell} ipython3
 # Initialize the modeler for this example notebook
-m = Modeler()
+m = launch_modeler()
+print(m)
 ```
 
 ## Example: Creating a quarter of a donut
@@ -123,4 +126,11 @@ design.revolve_sketch(
 )
 
 design.plot()
+```
+
+## Close the modeler
+
+```{code-cell} ipython3
+# Close the modeler
+m.close()
 ```

--- a/doc/source/examples/03_modeling/scale_map_mirror_bodies.mystnb
+++ b/doc/source/examples/03_modeling/scale_map_mirror_bodies.mystnb
@@ -20,7 +20,7 @@ and their usage for transforming bodies.
 # Imports
 import numpy as np
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import (
   Frame,
   Plane,
@@ -33,12 +33,13 @@ from ansys.geometry.core.math import (
 from ansys.geometry.core.sketch import Sketch
 ```
 
+## Initialize the modeler
+
 ```{code-cell} ipython3
 # Initialize the modeler for this example notebook
-m = Modeler()
+m = launch_modeler()
+print(m)
 ```
-
-+++
 
 ## Scale body
 
@@ -313,4 +314,10 @@ mirrored_triangle = triangle.copy(triangle.parent_component, "mirrored_triangle"
 mirrored_triangle.mirror(Plane(direction_x=UNITVECTOR3D_Y, direction_y=UNITVECTOR3D_Z))
 
 design.plot()
+```
+
+## Closing the modeler
+
+```{code-cell} ipython3
+m.close()
 ```

--- a/doc/source/examples/03_modeling/sweep_chain_profile.mystnb
+++ b/doc/source/examples/03_modeling/sweep_chain_profile.mystnb
@@ -21,7 +21,7 @@ function with a closed sketch profile and the ``sweep_chain()`` function for an 
 # Imports
 import numpy as np
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import (
   Plane,
   Point2D,
@@ -34,9 +34,12 @@ from ansys.geometry.core.shapes import Circle, Ellipse, Interval
 from ansys.geometry.core.sketch import Sketch
 ```
 
+## Initialize the modeler
+
 ```{code-cell} ipython3
 # Initialize the modeler for this example notebook
-m = Modeler()
+m = launch_modeler()
+print(m)
 ```
 
 ## Example: Creating a donut
@@ -174,4 +177,11 @@ result of this operation is stored in the variable ``body``.
 body = design_chain.sweep_chain("bowlsweep", path, profile)
 
 design_chain.plot()
+```
+
+## Closing the modeler
+
+```{code-cell} ipython3
+# Close the modeler
+m.close()
 ```

--- a/doc/source/examples/03_modeling/tessellation_usage.mystnb
+++ b/doc/source/examples/03_modeling/tessellation_usage.mystnb
@@ -25,7 +25,7 @@ Perform the required imports.
 ```{code-cell} ipython3
 from pint import Quantity
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import Point2D, Point3D, Plane
 from ansys.geometry.core.misc import UNITS
 from ansys.geometry.core.sketch import Sketch
@@ -44,7 +44,7 @@ merge each body into a single dataset. This effectively combines all the faces
 of each individual body into a single dataset without separating faces.
 
 ```{code-cell} ipython3
-modeler = Modeler()
+modeler = launch_modeler()
 
 sketch_1 = Sketch()
 box = sketch_1.box(
@@ -102,4 +102,12 @@ Plot the design.
 
 ```{code-cell} ipython3
 design.plot()
+```
+
+## Close the modeler
+
+Close the modeler.
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/04_applied/01_naca_airfoils.mystnb
+++ b/doc/source/examples/04_applied/01_naca_airfoils.mystnb
@@ -194,6 +194,12 @@ file = design.export_to_fmd()
 print(f"Design saved to {file}")
 ```
 
+### Close the modeler
+
+```{code-cell} ipython3
+modeler.close()
+```
+
 ## Example of a cambered airfoil: NACA 6412
 
 This code creates a NACA 6412 airfoil, which is cambered. This airfoil has a maximum
@@ -251,4 +257,10 @@ In this case, the design is saved as an SCDOCX file.
 # Save the design
 file = design.export_to_scdocx()
 print(f"Design saved to {file}")
+```
+
+### Close the modeler
+
+```{code-cell} ipython3
+modeler.close()
 ```

--- a/doc/source/examples/04_applied/02_naca_fluent.mystnb
+++ b/doc/source/examples/04_applied/02_naca_fluent.mystnb
@@ -147,3 +147,9 @@ For an example of how to set up the mesh and boundary conditions in Fluent, see 
 
 The main difference between the Fluent example and this geometry is the coordinate system. The Fluent example
 defines the airfoil in the XY plane, while this geometry defines the airfoil in the XZ plane.
+
+## Close the modeler
+
+```{code-cell} ipython3
+modeler.close()
+```


### PR DESCRIPTION
## Description
Coming from the Ansys Lab team - we should adapt our examples so that they can also be easily consumed on Ansys Lab... and not only that but any user that wants to try them locally! Most of them were assuming that there was a running service in the backend - which is not the usual case.

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
