### PR TITLE
feat: allow for platform input when using Ansys Lab

### DIFF
--- a/doc/changelog.d/1416.added.md
+++ b/doc/changelog.d/1416.added.md
@@ -1,0 +1,1 @@
+allow for platform input when using Ansys Lab

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -928,7 +928,7 @@ def _launch_pim_instance(
 
     # Platform is used mostly for Ansys Lab purposes. If product_version is defined, use it.
     # Higher priority is given to product_version.
-    if product_platform:
+    if product_platform: # pragma: no cover
         if product_version:
             LOG.warning(
                 "The 'product_platform' parameter is not used when 'product_version' is defined."

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -928,7 +928,7 @@ def _launch_pim_instance(
 
     # Platform is used mostly for Ansys Lab purposes. If product_version is defined, use it.
     # Higher priority is given to product_version.
-    if product_platform: # pragma: no cover
+    if product_platform:  # pragma: no cover
         if product_version:
             LOG.warning(
                 "The 'product_platform' parameter is not used when 'product_version' is defined."

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -221,6 +221,7 @@ def _launch_with_automatic_detection(**kwargs: dict | None) -> "Modeler":
 
 
 def launch_remote_modeler(
+    platform: str | None = None,
     version: str | None = None,
     client_log_level: int = logging.INFO,
     client_log_file: str | None = None,
@@ -236,6 +237,15 @@ def launch_remote_modeler(
 
     Parameters
     ----------
+    platform : str
+        **Specific for Ansys Lab**. The platform option for the Geometry service.
+        The default is ``"windows"``.
+        This parameter is used to specify the operating system on which the
+        Geometry service will run. The possible values are:
+
+        * ``"windows"``: The Geometry service runs on a Windows machine.
+        * ``"linux"``: The Geometry service runs on a Linux machine.
+
     version : str, default: None
         Version of the Geometry service to run in the three-digit format.
         For example, "232". If you do not specify the version, the server
@@ -257,6 +267,7 @@ def launch_remote_modeler(
     return _launch_pim_instance(
         is_pim_light=False,
         product_name="geometry",
+        product_platform=platform,
         product_version=version,
         backend_type=None,
         client_log_level=client_log_level,
@@ -861,6 +872,7 @@ def launch_modeler_with_spaceclaim(
 def _launch_pim_instance(
     is_pim_light: bool,
     product_name: str,
+    product_platform: str | None = None,
     product_version: str | None = None,
     backend_type: BackendType | None = None,
     client_log_level: int = logging.INFO,
@@ -881,6 +893,14 @@ def _launch_pim_instance(
         running on a local machine.
     product_name : str
         Name of the service to run.
+    product_platform : str, default: None
+        Platform on which the service will run. **Specific for Ansys Lab**.
+        This parameter is used to specify the operating system on which the
+        Geometry service will run. The possible values are:
+
+        * ``"windows"``: The Geometry service runs on a Windows machine.
+        * ``"linux"``: The Geometry service runs on a Linux machine.
+
     product_version : str, default: None
         Version of the service to run.
     backend_type : BackendType, default: None
@@ -905,6 +925,14 @@ def _launch_pim_instance(
         raise ModuleNotFoundError(
             "The package 'ansys-platform-instancemanagement' is required to use this function."
         )
+
+    # Platform is used mostly for Ansys Lab purposes. If product_version is defined, use it.
+    # Higher priority is given to product_version.
+    if product_platform:
+        if product_version:
+            LOG.warning("The 'product_platform' parameter is not used when 'product_version' is defined.")
+        else:
+            product_version = product_platform
 
     # If PIM Light is being used and PyPIM configuration is not defined... use defaults.
     if is_pim_light and not os.environ.get("ANSYS_PLATFORM_INSTANCEMANAGEMENT_CONFIG", None):

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -930,7 +930,9 @@ def _launch_pim_instance(
     # Higher priority is given to product_version.
     if product_platform:
         if product_version:
-            LOG.warning("The 'product_platform' parameter is not used when 'product_version' is defined.")
+            LOG.warning(
+                "The 'product_platform' parameter is not used when 'product_version' is defined."
+            )
         else:
             product_version = product_platform
 

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -237,7 +237,7 @@ def launch_remote_modeler(
 
     Parameters
     ----------
-    platform : str
+    platform : str, default: None
         **Specific for Ansys Lab**. The platform option for the Geometry service.
         The default is ``"windows"``.
         This parameter is used to specify the operating system on which the

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -221,7 +221,7 @@ def _launch_with_automatic_detection(**kwargs: dict | None) -> "Modeler":
 
 
 def launch_remote_modeler(
-    platform: str | None = None,
+    platform: str = "windows",
     version: str | None = None,
     client_log_level: int = logging.INFO,
     client_log_file: str | None = None,

--- a/tests/integration/test_launcher_remote.py
+++ b/tests/integration/test_launcher_remote.py
@@ -80,7 +80,9 @@ def test_launch_remote_instance(monkeypatch, modeler: Modeler):
     # Assert: PyAnsys Geometry went through the PyPIM workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    mock_client.create_instance.assert_called_with(product_name="geometry", product_version="windows")
+    mock_client.create_instance.assert_called_with(
+        product_name="geometry", product_version="windows"
+    )
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with(
         options=[

--- a/tests/integration/test_launcher_remote.py
+++ b/tests/integration/test_launcher_remote.py
@@ -80,7 +80,7 @@ def test_launch_remote_instance(monkeypatch, modeler: Modeler):
     # Assert: PyAnsys Geometry went through the PyPIM workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    mock_client.create_instance.assert_called_with(product_name="geometry", product_version=None)
+    mock_client.create_instance.assert_called_with(product_name="geometry", product_version="windows")
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with(
         options=[


### PR DESCRIPTION
## Description
Coming from an old request and to make it even more explicit for users.... Users can now benefit from the new "platform" argument when running on Ansys Lab to make it clear they want to use either the "windows" or the "linux" service. This is only available on Ansys Lab for now. If ``version`` is passed, this will take precedence since this is the expected argument for PyPIM

## Issue linked
Closes #478 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
