### PR TITLE
fix: handle properly ``np.cross()`` - 2d ops deprecated in Numpy 2.X

### DIFF
--- a/doc/changelog.d/1419.fixed.md
+++ b/doc/changelog.d/1419.fixed.md
@@ -1,0 +1,1 @@
+handle properly ``np.cross()`` - 2d ops deprecated in Numpy 2.X

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -326,7 +326,7 @@ class Vector2D(np.ndarray):
         return all([comp == 0 for comp in self])
 
     @check_input_types
-    def cross(self, v: "Vector2D"):
+    def cross(self, v: "Vector2D") -> np.ndarray:
         """Return the cross product of ``Vector2D`` objects."""
         if _NUMPY_MAJOR_VERSION >= 2:
             # See https://github.com/numpy/numpy/issues/26620 and more specifically
@@ -425,7 +425,7 @@ class Vector2D(np.ndarray):
         """Subtraction operation overload for 2D vectors."""
         return np.subtract(self, other).view(Vector2D)
 
-    def __mod__(self, other: "Vector2D"):
+    def __mod__(self, other: "Vector2D") -> np.ndarray:
         """Overload % operator with cross product."""
         return self.cross(other)
 

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -331,7 +331,7 @@ class Vector2D(np.ndarray):
         if _NUMPY_MAJOR_VERSION >= 2:
             # See https://github.com/numpy/numpy/issues/26620 and more specifically
             # https://github.com/numpy/numpy/issues/26620#issuecomment-2150748569
-            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0])
+            return self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]
         else:
             return np.cross(self, v)
 

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -332,7 +332,9 @@ class Vector2D(np.ndarray):
             # See https://github.com/numpy/numpy/issues/26620 and more specifically
             # https://github.com/numpy/numpy/issues/26620#issuecomment-2150748569
             return self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]
-        else:
+        else: # pragma: no cover
+            # Coverage is measured with the latest version of numpy
+            # so this code is not covered
             return np.cross(self, v)
 
     @check_input_types

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -35,6 +35,9 @@ from ansys.geometry.core.misc.checks import check_ndarray_is_float_int
 from ansys.geometry.core.misc.units import UNITS
 from ansys.geometry.core.typing import Real, RealSequence
 
+_NUMPY_MAJOR_VERSION = int(np.__version__[0])
+"""Major version of the numpy library."""
+
 
 class Vector3D(np.ndarray):
     """Provides for managing and creating a 3D vector.
@@ -190,8 +193,11 @@ class Vector3D(np.ndarray):
 
     @check_input_types
     def cross(self, v: "Vector3D") -> "Vector3D":
-        """Get the cross product of ``Vector3D`` objects."""
-        return np.cross(self, v).view(Vector3D)
+        """Return the cross product of ``Vector3D`` objects."""
+        if _NUMPY_MAJOR_VERSION >= 2:
+            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]).view(Vector3D)
+        else:
+            return np.cross(self, v).view(Vector3D)
 
     @check_input_types
     def __eq__(self, other: "Vector3D") -> bool:
@@ -323,9 +329,14 @@ class Vector2D(np.ndarray):
         return all([comp == 0 for comp in self])
 
     @check_input_types
-    def cross(self, v: "Vector2D"):
+    def cross(self, v: "Vector2D") -> "Vector2D":
         """Return the cross product of ``Vector2D`` objects."""
-        return np.cross(self, v)
+        if _NUMPY_MAJOR_VERSION >= 2:
+            # See https://github.com/numpy/numpy/issues/26620 and more specifically
+            # https://github.com/numpy/numpy/issues/26620#issuecomment-2150748569
+            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]).view(Vector2D)
+        else:
+            return np.cross(self, v).view(Vector2D)
 
     @check_input_types
     def is_perpendicular_to(self, other_vector: "Vector2D") -> bool:

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -326,7 +326,7 @@ class Vector2D(np.ndarray):
         return all([comp == 0 for comp in self])
 
     @check_input_types
-    def cross(self, v: "Vector2D") -> np.ndarray:
+    def cross(self, v: "Vector2D") -> Real:
         """Return the cross product of ``Vector2D`` objects."""
         if _NUMPY_MAJOR_VERSION >= 2:
             # See https://github.com/numpy/numpy/issues/26620 and more specifically
@@ -425,7 +425,7 @@ class Vector2D(np.ndarray):
         """Subtraction operation overload for 2D vectors."""
         return np.subtract(self, other).view(Vector2D)
 
-    def __mod__(self, other: "Vector2D") -> np.ndarray:
+    def __mod__(self, other: "Vector2D") -> Real:
         """Overload % operator with cross product."""
         return self.cross(other)
 

--- a/src/ansys/geometry/core/math/vector.py
+++ b/src/ansys/geometry/core/math/vector.py
@@ -194,10 +194,7 @@ class Vector3D(np.ndarray):
     @check_input_types
     def cross(self, v: "Vector3D") -> "Vector3D":
         """Return the cross product of ``Vector3D`` objects."""
-        if _NUMPY_MAJOR_VERSION >= 2:
-            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]).view(Vector3D)
-        else:
-            return np.cross(self, v).view(Vector3D)
+        return np.cross(self, v).view(Vector3D)
 
     @check_input_types
     def __eq__(self, other: "Vector3D") -> bool:
@@ -329,14 +326,14 @@ class Vector2D(np.ndarray):
         return all([comp == 0 for comp in self])
 
     @check_input_types
-    def cross(self, v: "Vector2D") -> "Vector2D":
+    def cross(self, v: "Vector2D"):
         """Return the cross product of ``Vector2D`` objects."""
         if _NUMPY_MAJOR_VERSION >= 2:
             # See https://github.com/numpy/numpy/issues/26620 and more specifically
             # https://github.com/numpy/numpy/issues/26620#issuecomment-2150748569
-            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0]).view(Vector2D)
+            return (self[..., 0] * v[..., 1] - self[..., 1] * v[..., 0])
         else:
-            return np.cross(self, v).view(Vector2D)
+            return np.cross(self, v)
 
     @check_input_types
     def is_perpendicular_to(self, other_vector: "Vector2D") -> bool:
@@ -426,7 +423,7 @@ class Vector2D(np.ndarray):
         """Subtraction operation overload for 2D vectors."""
         return np.subtract(self, other).view(Vector2D)
 
-    def __mod__(self, other: "Vector2D") -> "Vector2D":
+    def __mod__(self, other: "Vector2D"):
         """Overload % operator with cross product."""
         return self.cross(other)
 


### PR DESCRIPTION
## Description
As title says - once Numpy 1.X is not used anymore we can remove this.

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
