### PR TITLE
fix: change logo link so that it renders properly on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/ansys/pyansys-geometry/blob/main/doc/source/_static/logo/logo.png
+.. image:: https://raw.githubusercontent.com/ansys/pyansys-geometry/blob/main/doc/source/_static/logo/logo.png
    :target: https://github.com/ansys/pyansys-geometry
    :alt: PyAnsys Geometry
 

--- a/doc/changelog.d/1420.fixed.md
+++ b/doc/changelog.d/1420.fixed.md
@@ -1,0 +1,1 @@
+change logo link so that it renders properly on PyPI


### PR DESCRIPTION
As title says - otherwise logo does not render on PyPI. See https://pypi.org/project/ansys-geometry-core/0.7.1/

See PyMechanical, where this is solved: https://pypi.org/project/ansys-mechanical-core/0.11.7/