### PR TITLE
ci: checkout LFS files from previous version to ensure upload

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -493,6 +493,10 @@ jobs:
           $env:PREVIOUS_PATCH_VERSION_NUMBER=$env:VERSION.substring($env:VERSION.Length - 1)
           $env:PREVIOUS_PATCH_VERSION_NUMBER=[int]$env:PREVIOUS_PATCH_VERSION_NUMBER - 1
           $env:PREVIOUS_VERSION=$env:PREVIOUS_VERSION + $env:PREVIOUS_PATCH_VERSION_NUMBER
+          # Fetch the LFS files from the previous version
+          git lfs fetch origin --include="$env:PREVIOUS_VERSION/*"
+          git lfs checkout $env:PREVIOUS_VERSION
+          # Copy the binaries from the previous version
           cp ./$env:PREVIOUS_VERSION/windows-binaries.zip windows-binaries.zip
           cp ./$env:PREVIOUS_VERSION/linux-binaries.zip linux-binaries.zip
 

--- a/doc/changelog.d/1423.maintenance.md
+++ b/doc/changelog.d/1423.maintenance.md
@@ -1,0 +1,1 @@
+checkout LFS files from previous version to ensure upload


### PR DESCRIPTION
## Description
Binaries repo is using LFS which, by default, the actions don't check out for obvious reasons (+100Mb large files). Handling checkout only when needed on the pipeline. This default behavior has been modified recently in the ``actions/checkout@v4`` action.

## Issue linked
None
