### PR TITLE
docs: add captions in examples toctrees

### DIFF
--- a/doc/changelog.d/1434.documentation.md
+++ b/doc/changelog.d/1434.documentation.md
@@ -1,0 +1,1 @@
+add captions in examples toctrees

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -9,6 +9,7 @@ These examples demonstrate basic operations you can perform
 with PyAnsys Geometry.
 
 .. nbgallery::
+    :caption: 101 examples
 
     examples/01_getting_started/01_math.mystnb
     examples/01_getting_started/02_units.mystnb
@@ -22,6 +23,7 @@ These examples demonstrate math operations on geometric objects
 and sketching capabilities, combined with server-based operations.
 
 .. nbgallery::
+    :caption: Sketching examples
 
     examples/02_sketching/basic_usage.mystnb
     examples/02_sketching/dynamic_sketch_plane.mystnb
@@ -32,6 +34,7 @@ Modeling examples
 These examples demonstrate service-based modeling operations.
 
 .. nbgallery::
+    :caption: Modeling examples
 
     examples/03_modeling/add_design_material.mystnb
     examples/03_modeling/plate_with_hole.mystnb
@@ -51,6 +54,7 @@ These examples demonstrate the usage of PyAnsys Geometry for real-world
 applications.
 
 .. nbgallery::
+    :caption: Applied examples
 
     examples/04_applied/01_naca_airfoils.mystnb
     examples/04_applied/02_naca_fluent.mystnb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ tests-minimal = [
     "pytest-xvfb==3.0.0",
 ]
 doc = [
-    "ansys-sphinx-theme[autoapi]==1.0.9",
+    "ansys-sphinx-theme[autoapi]==1.0.10",
     "ansys-tools-visualization-interface==0.4.4",
     "beartype==0.18.5",
     "docker==7.1.0",


### PR DESCRIPTION
## Description

This pull-request enables captions in the left sidebar of the example pages. The latest version of our corporate theme is required.

