### PR TITLE
ci: pyvista/setup-headless-display started failing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -122,6 +122,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       SKIP_UNSTABLE: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY == 1 && matrix.experimental }}
+      PYVISTA_OFF_SCREEN: true
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +145,8 @@ jobs:
       - name: Set up headless display
         if: env.SKIP_UNSTABLE == 'false'
         uses: pyvista/setup-headless-display-action@v2
+        with:
+          pyvista: false
 
       - name: Create Python venv
         if: env.SKIP_UNSTABLE == 'false'
@@ -256,9 +259,13 @@ jobs:
     runs-on:
       group: pyansys-self-hosted
       labels: [Windows, pygeometry]
+    env:
+      PYVISTA_OFF_SCREEN: true
     steps:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v2
+        with:
+          pyvista: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -36,7 +36,8 @@ jobs:
     name: Nightly unstable testing - Windows
     if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1
     runs-on: [self-hosted, Windows, pygeometry]
-
+    env:
+      PYVISTA_OFF_SCREEN: true
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +48,8 @@ jobs:
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v2
+        with:
+          pyvista: false
 
       - name: Create Python venv
         run: |

--- a/doc/changelog.d/1447.maintenance.md
+++ b/doc/changelog.d/1447.maintenance.md
@@ -1,0 +1,1 @@
+pyvista/setup-headless-display started failing


### PR DESCRIPTION
Windows self-hosted runners experiencing issues with ``shell: bash`` commands. This will define the environment variable PYVISTA_OFF_SCREEN on behalf of the action, and we will skip the failing part as well.