### PR TITLE
fix: ``check_input_types`` not working with forward refs

### DIFF
--- a/doc/changelog.d/1471.fixed.md
+++ b/doc/changelog.d/1471.fixed.md
@@ -1,0 +1,1 @@
+``check_input_types`` not working with forward refs

--- a/src/ansys/geometry/core/tools/prepare_tools.py
+++ b/src/ansys/geometry/core/tools/prepare_tools.py
@@ -116,7 +116,7 @@ class PrepareTools:
     @protect_grpc
     @min_backend_version(25, 1, 0)
     def extract_volume_from_edge_loops(
-        self, sealing_edges: list["Edge"], inside_faces: list["Face"]
+        self, sealing_edges: list["Edge"], inside_faces: list["Face"] = None
     ) -> list["Body"]:
         """Extract a volume from input edge loops.
 
@@ -127,8 +127,8 @@ class PrepareTools:
         ----------
         sealing_edges : list[Edge]
             List of faces that seal the volume.
-        inside_faces : list[Face]
-            List of faces that define the interior of the solid (Not always necessary).
+        inside_faces : list[Face], optional
+            List of faces that define the interior of the solid (not always necessary).
 
         Returns
         -------
@@ -138,9 +138,12 @@ class PrepareTools:
         from ansys.geometry.core.designer.edge import Edge
         from ansys.geometry.core.designer.face import Face
 
-        if not sealing_edges or not inside_faces:
-            self._grpc_client.log.info("No sealing edges or inside faces provided...")
+        if not sealing_edges:
+            self._grpc_client.log.info("No sealing edges provided...")
             return []
+
+        # Assign default values to inside_faces
+        inside_faces = [] if inside_faces is None else inside_faces
 
         # Verify inputs
         check_type_all_elements_in_iterable(sealing_edges, Edge)

--- a/tests/integration/test_prepare_tools.py
+++ b/tests/integration/test_prepare_tools.py
@@ -49,11 +49,9 @@ def test_volume_extract_from_edge_loops(modeler: Modeler):
     design = modeler.open_file(FILES_DIR / "hollowCylinder.scdocx")
 
     body = design.bodies[0]
-    inside_faces = []
     sealing_edges = [body.edges[2], body.edges[3]]
     created_bodies = modeler.prepare_tools.extract_volume_from_edge_loops(
         sealing_edges,
-        inside_faces,
     )
 
     assert len(created_bodies) == 1


### PR DESCRIPTION
## Description
Bugs located in ``prepare_tools`` module regarding forward references and type checking. We cannot use ``check_input_types`` with forward references unless it's the class itself.

## Issue linked
None
