### PR TITLE
fix: ``share_topology`` is available on 24R2

### DIFF
--- a/doc/changelog.d/1472.fixed.md
+++ b/doc/changelog.d/1472.fixed.md
@@ -1,0 +1,1 @@
+``share_topology`` is available on 24R2

--- a/src/ansys/geometry/core/tools/prepare_tools.py
+++ b/src/ansys/geometry/core/tools/prepare_tools.py
@@ -156,7 +156,7 @@ class PrepareTools:
 
     @protect_grpc
     @check_input_types
-    @min_backend_version(25, 1, 0)
+    @min_backend_version(24, 2, 0)
     def share_topology(
         self, bodies: list["Body"], tol: Real = 0.0, preserve_instances: bool = False
     ) -> bool:


### PR DESCRIPTION
## Description
ShareTopology is already available in 24R2 - changing decorator

## Issue linked
Discussion #1468 