### PR TITLE
build: bump ansys-sphinx-theme to v1.1.3

### DIFF
--- a/doc/changelog.d/1475.dependencies.md
+++ b/doc/changelog.d/1475.dependencies.md
@@ -1,0 +1,1 @@
+bump ansys-sphinx-theme to v1.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ tests-minimal = [
     "pytest-xvfb==3.0.0",
 ]
 doc = [
-    "ansys-sphinx-theme[autoapi]==1.1.2",
+    "ansys-sphinx-theme[autoapi]==1.1.3",
     "ansys-tools-path==0.6.0",
     "ansys-tools-visualization-interface==0.4.5",
     "beartype==0.19.0",


### PR DESCRIPTION
As title says. Enabling PyData search by default