### PR TITLE
fix: static search options

### DIFF
--- a/doc/changelog.d/1478.fixed.md
+++ b/doc/changelog.d/1478.fixed.md
@@ -1,0 +1,1 @@
+static search options

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -171,7 +171,7 @@ html_theme_options = {
     },
     "static_search": {
         "threshold": 0.5,
-        "min_chars_for_search": 2,
+        "minMatchCharLength": 2,
         "ignoreLocation": True,
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ tests-minimal = [
     "pytest-xvfb==3.0.0",
 ]
 doc = [
-    "ansys-sphinx-theme[autoapi]==1.1.3",
+    "ansys-sphinx-theme[autoapi]==1.1.4",
     "ansys-tools-path==0.6.0",
     "ansys-tools-visualization-interface==0.4.5",
     "beartype==0.19.0",


### PR DESCRIPTION
## Description

With the new release of [ansys-sphinx-theme](https://pypi.org/project/ansys-sphinx-theme/), the name of the options need to be the same as the ones in [Fuse.js options](https://www.fusejs.io/api/options.html). This pull-request ensures that.
