### PR TITLE
docs: avoid having a drop down in the top navigation bar

### DIFF
--- a/doc/changelog.d/1485.documentation.md
+++ b/doc/changelog.d/1485.documentation.md
@@ -1,0 +1,1 @@
+avoid having a drop down in the top navigation bar

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -135,6 +135,7 @@ html_context = {
     "doc_path": "doc/source",
 }
 html_theme_options = {
+    "header_links_before_dropdown": 7,
     "logo": "pyansys",
     "switcher": {
         "json_url": f"https://{cname}/versions.json",


### PR DESCRIPTION
## Description

> This is completely optional, so feel free to discard and close.

This pull-request gets rid of the drop-down in the top navigation bar, accommodating all the headers before the drop-down comes in. 