### PR TITLE
fix: respect product_version when launching geometry service

### DIFF
--- a/doc/changelog.d/1486.fixed.md
+++ b/doc/changelog.d/1486.fixed.md
@@ -1,0 +1,1 @@
+respect product_version when launching Geometry Service

--- a/doc/changelog.d/1486.fixed.md
+++ b/doc/changelog.d/1486.fixed.md
@@ -1,1 +1,1 @@
-respect product_version when launching Geometry Service
+respect product_version when launching geometry service

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -327,10 +327,9 @@ def prepare_and_start_backend(
             )
 
     elif backend_type == BackendType.WINDOWS_SERVICE:
-        latest_version = get_latest_ansys_installation()[0]
         args.append(
             Path(
-                installations[latest_version], WINDOWS_GEOMETRY_SERVICE_FOLDER, GEOMETRY_SERVICE_EXE
+                installations[product_version], WINDOWS_GEOMETRY_SERVICE_FOLDER, GEOMETRY_SERVICE_EXE
             )
         )
     else:

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -329,7 +329,9 @@ def prepare_and_start_backend(
     elif backend_type == BackendType.WINDOWS_SERVICE:
         args.append(
             Path(
-                installations[product_version], WINDOWS_GEOMETRY_SERVICE_FOLDER, GEOMETRY_SERVICE_EXE
+                installations[product_version],
+                WINDOWS_GEOMETRY_SERVICE_FOLDER,
+                GEOMETRY_SERVICE_EXE,
             )
         )
     else:


### PR DESCRIPTION
## Description
When launching the Geometry Service with `launch_modeler`, respect the provided `product_version` keyword argument.

## Issue linked
When launching with `mode="geometry_service"`, the latest installed Ansys version was always used. Notably, also when only an older version actually has the Geometry Service installed.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
