### PR TITLE
docs: provide information on how to build a single example

### DIFF
--- a/doc/changelog.d/1490.documentation.md
+++ b/doc/changelog.d/1490.documentation.md
@@ -1,0 +1,1 @@
+provide information on how to build a single example

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -176,6 +176,11 @@ html_theme_options = {
         "ignoreLocation": True,
     },
 }
+
+# Determine whether to skip cheat sheet build or not
+if os.environ.get("SKIP_BUILD_CHEAT_SHEET"):
+    html_theme_options.pop("cheatsheet")
+
 # Sphinx extensions
 extensions = [
     "sphinx.ext.intersphinx",

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -153,19 +153,19 @@ You can also test the correct build process of a new example by performing the f
 
     pip install myst-nb
 
-3. Run the following command to build a single example (i.e. substitute
+3. Run the following command to build a single example (that is, substitute
    ``<PATH_TO_MY_EXAMPLE_FILE>`` with the path to your example file)::
 
     mystnb-docutils-html --nb-read-as-md=1 <PATH_TO_MY_EXAMPLE_FILE> output.html
 
 4. Check the output file ``output.html`` to ensure that the example is correctly built.
-   Rendered output will not have the documentation styling but users should have the
+   Rendered output does not have documentation styling but users should have the
    ability to see its proper execution.
 
 .. note::
 
-  Plots will not be rendered in the output file, but the code and markdown cells should
-  be correctly rendered. In case of failure during execution you will also see the error
+  Plots are not be rendered in the output file, but the code and markdown cells should
+  be correctly rendered. In case of failure during execution users can also see the error
   message in the output file.
 
 Run tests

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -126,6 +126,48 @@ You can clean the documentation build by running this command::
   # On Windows
   ./make.bat clean
 
+Adding examples
+---------------
+
+Users can collaborate with examples to this documentation by adding new examples. A reference
+commit of the changes that adding an example requieres is shown here:
+
+https://github.com/ansys/pyansys-geometry/pull/1454/commits/7fcf02f86f05e0e5ce1c1071c3c5fcd274ec481c
+
+To add a new example, follow these steps:
+
+1. Create a new notebook in the ``doc/source/examples`` directory, under the appropriate
+   folder for your example.
+2. Take as reference an existing example to see how the notebook should be structured.
+3. Add the new notebook to the ``doc/source/examples.rst`` file.
+4. Store a thumbnail image of the example in the ``doc/source/_static/thumbnails`` directory.
+5. Link the thumbnail image to your example file in ``doc/source/conf.py`` as shown in the reference commit.
+
+You can also test the correct build process of a new example by performing the following steps:
+
+1. Run the following command to install the documentation dependencies::
+
+    pip install -e .[doc]
+
+2. Install ``myst-nb`` by running this command::
+
+    pip install myst-nb
+
+3. Run the following command to build a single example (i.e. substitute
+   ``<PATH_TO_MY_EXAMPLE_FILE>`` with the path to your example file)::
+
+    mystnb-docutils-html --nb-read-as-md=1 <PATH_TO_MY_EXAMPLE_FILE> output.html
+
+4. Check the output file ``output.html`` to ensure that the example is correctly built.
+   Rendered output will not have the documentation styling but users should have the
+   ability to see its proper execution.
+
+.. note:: 
+
+  Plots will not be rendered in the output file, but the code and markdown cells should
+  be correctly rendered. In case of failure during execution you will also see the error
+  message in the output file.
+
 Run tests
 ---------
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -130,7 +130,7 @@ Adding examples
 ---------------
 
 Users can collaborate with examples to this documentation by adding new examples. A reference
-commit of the changes that adding an example requieres is shown here:
+commit of the changes that adding an example requires is shown here:
 
 https://github.com/ansys/pyansys-geometry/pull/1454/commits/7fcf02f86f05e0e5ce1c1071c3c5fcd274ec481c
 
@@ -162,7 +162,7 @@ You can also test the correct build process of a new example by performing the f
    Rendered output will not have the documentation styling but users should have the
    ability to see its proper execution.
 
-.. note:: 
+.. note::
 
   Plots will not be rendered in the output file, but the code and markdown cells should
   be correctly rendered. In case of failure during execution you will also see the error

--- a/doc/source/examples/03_modeling/service_colors.mystnb
+++ b/doc/source/examples/03_modeling/service_colors.mystnb
@@ -24,7 +24,7 @@ Perform the required imports.
 ```{code-cell} ipython3
 import ansys.geometry.core as pyansys_geometry
 
-from ansys.geometry.core import Modeler
+from ansys.geometry.core import launch_modeler
 from ansys.geometry.core.math import Point2D, UNITVECTOR3D_X, UNITVECTOR3D_Y
 from ansys.geometry.core.sketch import Sketch
 ```
@@ -44,7 +44,7 @@ sketch.box(Point2D([0, 0]), 10, 10)
 Establish a server connection and initiate a design on the server.
 
 ```{code-cell} ipython3
-modeler = Modeler()
+modeler = launch_modeler()
 design = modeler.create_design("ServiceColors")
 ```
 


### PR DESCRIPTION
## Description
Provide docs on how to build an example and align previous examples as well. Also, provide capability to exclude cheat sheet build.

## Issue linked
None

