### PR TITLE
ci: allowing new tags for Windows Core Service

### DIFF
--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         package-name: 'geometry'
         token: ${{ secrets.GITHUB_TOKEN }}
-        tags-kept: 'windows-latest, windows-latest-unstable, linux-latest, linux-latest-unstable, 24.1, 24.2, 25.1, windows-24.1, windows-24.2, windows-25.1, linux-24.1, linux-24.2, linux-25.1'
+        tags-kept: 'windows-latest, windows-latest-unstable, windows-coreservice, windows-coreservice-unstable, linux-latest, linux-latest-unstable, 24.1, 24.2, 25.1, windows-24.1, windows-24.2, windows-25.1, linux-24.1, linux-24.2, linux-25.1'

--- a/doc/changelog.d/1497.maintenance.md
+++ b/doc/changelog.d/1497.maintenance.md
@@ -1,0 +1,1 @@
+allowing new tags for Windows Core Service


### PR DESCRIPTION
As title says. Allowing new tags called ``windows-coreservice`` and ``windows-coreservice-unstable``