### PR TITLE
docs: typo with the docstrings

### DIFF
--- a/doc/changelog.d/1524.documentation.md
+++ b/doc/changelog.d/1524.documentation.md
@@ -1,0 +1,1 @@
+typo with the docstrings

--- a/src/ansys/geometry/core/shapes/surfaces/plane.py
+++ b/src/ansys/geometry/core/shapes/surfaces/plane.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Provides for creating and managing a cylinder."""
+"""Provides for creating and managing a plane."""
 
 from functools import cached_property
 
@@ -73,22 +73,22 @@ class PlaneSurface(Surface):
 
     @property
     def origin(self) -> Point3D:
-        """Origin of the cylinder."""
+        """Origin of the plane."""
         return self._origin
 
     @property
     def dir_x(self) -> UnitVector3D:
-        """X-direction of the cylinder."""
+        """X-direction of the plane."""
         return self._reference
 
     @property
     def dir_y(self) -> UnitVector3D:
-        """Y-direction of the cylinder."""
+        """Y-direction of the plane."""
         return self.dir_z.cross(self.dir_x)
 
     @property
     def dir_z(self) -> UnitVector3D:
-        """Z-direction of the cylinder."""
+        """Z-direction of the plane."""
         return self._axis
 
     @check_input_types


### PR DESCRIPTION
## Description
**fix typo in docstrings cylinder --> plane.**

## Issue linked
nil

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
