### PR TITLE
feat: allow for some additional extrusion direction names

### DIFF
--- a/doc/changelog.d/1534.added.md
+++ b/doc/changelog.d/1534.added.md
@@ -1,0 +1,1 @@
+allow for some additional extrusion direction names

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -107,9 +107,10 @@ class ExtrusionDirection(Enum):
     @classmethod
     def from_string(cls, string: str, use_default_if_error: bool = False) -> "ExtrusionDirection":
         """Convert a string to an ``ExtrusionDirection`` enum."""
-        if string == "+":
+        lcase_string = string.lower()
+        if lcase_string in ("+", "p", "pos", "positive"):
             return cls.POSITIVE
-        elif string == "-":
+        elif lcase_string in ("-", "n", "neg", "negative"):
             return cls.NEGATIVE
         elif use_default_if_error:
             from ansys.geometry.core.logger import LOG


### PR DESCRIPTION
## Description
Allow for additional strings when accepting extrude directions. Makes sense to also support these...

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
