### PR TITLE
build: limit upper version on grpcio & grpcio-health-checking to 1.68

### DIFF
--- a/doc/changelog.d/1544.dependencies.md
+++ b/doc/changelog.d/1544.dependencies.md
@@ -1,1 +1,1 @@
-use aiohttp specific versions (debugging)
+limit upper version on grpcio & grpcio-health-checking to 1.68

--- a/doc/changelog.d/1544.dependencies.md
+++ b/doc/changelog.d/1544.dependencies.md
@@ -1,0 +1,1 @@
+use aiohttp specific versions (debugging)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "aiohttp==3.11.0",
     "ansys-api-geometry==0.4.16",
     "ansys-tools-path>=0.3,<1",
     "ansys-tools-visualization-interface>=0.2.6,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiohttp==3.11.0",
     "ansys-api-geometry==0.4.16",
     "ansys-tools-path>=0.3,<1",
     "ansys-tools-visualization-interface>=0.2.6,<1",
     "beartype>=0.11.0,<0.20",
-    "grpcio>=1.35.0,<2",
-    "grpcio-health-checking>=1.45.0,<2",
+    "grpcio>=1.35.0,<1.68",
+    "grpcio-health-checking>=1.45.0,<1.68",
     "numpy>=1.20.3,<3",
     "Pint>=0.18,<1",
     "protobuf>=3.20.2,<6",


### PR DESCRIPTION
grpcio package upgrade contains breaking changes