### PR TITLE
feat: allow version input to automatically consider the nuances for the Ansys Student version

### DIFF
--- a/doc/changelog.d/1548.added.md
+++ b/doc/changelog.d/1548.added.md
@@ -1,0 +1,1 @@
+allow version input to automatically consider the nuances for the Ansys Student version

--- a/doc/source/getting_started/local/index.rst
+++ b/doc/source/getting_started/local/index.rst
@@ -3,7 +3,7 @@
 Launch a local session
 ======================
 
-If Ansys 2023 R2 or later and PyAnsys Geometry are installed, you can create a local backend session using
+If Ansys 2024 R1 or later and PyAnsys Geometry are installed, you can create a local backend session using
 Discovery, SpaceClaim, or the Geometry service. Once the backend is running, PyAnsys Geometry can manage the connection.
 
 To launch and establish a connection to the service, open Python and use the following commands for

--- a/doc/source/getting_started/remote/index.rst
+++ b/doc/source/getting_started/remote/index.rst
@@ -3,7 +3,7 @@
 Launch a remote session
 =======================
 
-If a remote server is running Ansys 2023 R2 or later and is also running PIM (Product
+If a remote server is running Ansys 2024 R1 or later and is also running PIM (Product
 Instance Manager), you can use PIM to start a Discovery or SpaceClaim session
 that PyAnsys Geometry can connect to.
 

--- a/docker/build_docker_windows.py
+++ b/docker/build_docker_windows.py
@@ -33,12 +33,12 @@ awp_root = {}
 for env_key, env_val in os.environ.items():
     if env_key.startswith("AWP_ROOT"):
         # There is an Ansys installation... Check that the version is at
-        # least 2023R2. Environment variables are in the form
-        # AWP_ROOT232=/path/to/2023R2
+        # least 2024R1. Environment variables are in the form
+        # AWP_ROOT241=/path/to/2024R1
         #
         # Get the version number
         version = env_key.split("AWP_ROOT")[1]
-        if version < "232":
+        if version < "241":
             # This version is too old, so we will ignore it
             continue
         else:
@@ -48,7 +48,7 @@ for env_key, env_val in os.environ.items():
 if len(awp_root) == 0:
     # There are no Ansys installations
     print("XXXXXXX No Ansys compatible installations found.. exiting process. XXXXXXX")
-    print("XXXXXXX Please install Ansys 2023R2 or newer.                      XXXXXXX")
+    print("XXXXXXX Please install Ansys 2024R1 or newer.                      XXXXXXX")
     exit(0)
 
 # Request the user to select the version of Ansys to use

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -248,7 +248,7 @@ def launch_remote_modeler(
 
     version : str, default: None
         Version of the Geometry service to run in the three-digit format.
-        For example, "232". If you do not specify the version, the server
+        For example, "241". If you do not specify the version, the server
         chooses the version.
     client_log_level : int, default: logging.INFO
         Log level for the client. The default is ``logging.INFO``.
@@ -367,7 +367,7 @@ def launch_modeler_with_discovery_and_pimlight(
     ----------
     version : str, default: None
         Version of Discovery to run in the three-digit format.
-        For example, "232". If you do not specify the version, the server
+        For example, "241". If you do not specify the version, the server
         chooses the version.
     client_log_level : int, default: logging.INFO
         Log level for the client. The default is ``logging.INFO``.
@@ -410,7 +410,7 @@ def launch_modeler_with_geometry_service_and_pimlight(
     ----------
     version : str, default: None
         Version of the Geometry service to run in the three-digit format.
-        For example, "232". If you do not specify the version, the server
+        For example, "241". If you do not specify the version, the server
         chooses the version.
     client_log_level : int, default: logging.INFO
         Log level for the client. The default is ``logging.INFO``.
@@ -453,7 +453,7 @@ def launch_modeler_with_spaceclaim_and_pimlight(
     ----------
     version : str, default: None
         Version of SpaceClaim to run in the three-digit format.
-        For example, "232". If you do not specify the version, the server
+        For example, "241". If you do not specify the version, the server
         chooses the version.
     client_log_level : int, default: logging.INFO
         Log level for the client. The default is ``logging.INFO``.
@@ -505,7 +505,7 @@ def launch_modeler_with_geometry_service(
     Parameters
     ----------
     product_version: int, optional
-        The product version to be started. Goes from v23.2.1 to
+        The product version to be started. Goes from v24.1 to
         the latest. Default is ``None``.
         If a specific product version is requested but not installed locally,
         a SystemError will be raised.
@@ -513,6 +513,7 @@ def launch_modeler_with_geometry_service(
         **Ansys products versions and their corresponding int values:**
 
         * ``241`` : Ansys 24R1
+        * ``242`` : Ansys 24R2
     host: str, optional
         IP address at which the Geometry service will be deployed. By default,
         its value will be ``localhost``.
@@ -555,7 +556,7 @@ def launch_modeler_with_geometry_service(
         If the specified endpoint is already in use, a connection
         error will be raised.
     SystemError
-        If there is not an Ansys product 23.2 version or later installed
+        If there is not an Ansys product 24.1 version or later installed
         a SystemError will be raised.
 
     Returns
@@ -629,10 +630,6 @@ def launch_modeler_with_discovery(
 ):
     """Start Ansys Discovery locally using the ``ProductInstance`` class.
 
-    .. note::
-
-       Support for Ansys Discovery is restricted to Ansys 24.1 onward.
-
     When calling this method, a standalone Discovery session is started.
     By default, if an endpoint is specified (by defining `host` and `port` parameters)
     but the endpoint is not available, the startup will fail. Otherwise, it will try to
@@ -641,7 +638,7 @@ def launch_modeler_with_discovery(
     Parameters
     ----------
     product_version: int, optional
-        The product version to be started. Goes from v23.2.1 to
+        The product version to be started. Goes from v24.1 to
         the latest. Default is ``None``.
         If a specific product version is requested but not installed locally,
         a SystemError will be raised.
@@ -649,6 +646,7 @@ def launch_modeler_with_discovery(
         **Ansys products versions and their corresponding int values:**
 
         * ``241`` : Ansys 24R1
+        * ``242`` : Ansys 24R2
     host: str, optional
         IP address at which the Discovery session will be deployed. By default,
         its value will be ``localhost``.
@@ -690,7 +688,7 @@ def launch_modeler_with_discovery(
     ConnectionError
         If the specified endpoint is already in use, a connection error will be raised.
     SystemError:
-        If there is not an Ansys product 23.2 version or later installed
+        If there is not an Ansys product 24.1 version or later installed
         or if a specific product's version is requested but not installed locally then
         a SystemError will be raised.
 
@@ -707,11 +705,11 @@ def launch_modeler_with_discovery(
     >>> from ansys.geometry.core import launch_modeler_with_discovery
     >>> modeler = launch_modeler_with_discovery()
 
-    Starting an Ansys Discovery V 23.2 session, on address ``10.171.22.44``, port ``5001``,
+    Starting an Ansys Discovery V 24.1 session, on address ``10.171.22.44``, port ``5001``,
     with chatty logs, using API v231 and a ``300`` seconds timeout:
 
     >>> from ansys.geometry.core import launch_modeler_with_discovery
-    >>> modeler = launch_modeler_with_discovery(product_version = 232,
+    >>> modeler = launch_modeler_with_discovery(product_version = 241,
         host="10.171.22.44",
         port=5001,
         api_version= 231,
@@ -767,15 +765,15 @@ def launch_modeler_with_spaceclaim(
     Parameters
     ----------
     product_version: int, optional
-        The product version to be started. Goes from v23.2.1 to
+        The product version to be started. Goes from v24.1 to
         the latest. Default is ``None``.
         If a specific product version is requested but not installed locally,
         a SystemError will be raised.
 
         **Ansys products versions and their corresponding int values:**
 
-        * ``232`` : Ansys 23R2 SP1
         * ``241`` : Ansys 24R1
+        * ``242`` : Ansys 24R2
     host: str, optional
         IP address at which the SpaceClaim session will be deployed. By default,
         its value will be ``localhost``.
@@ -817,7 +815,7 @@ def launch_modeler_with_spaceclaim(
     ConnectionError
         If the specified endpoint is already in use, a connection error will be raised.
     SystemError
-        If there is not an Ansys product 23.2 version or later installed
+        If there is not an Ansys product 24.1 version or later installed
         or if a specific product's version is requested but not installed locally then
         a SystemError will be raised.
 
@@ -834,11 +832,11 @@ def launch_modeler_with_spaceclaim(
     >>> from ansys.geometry.core import launch_modeler_with_spaceclaim
     >>> modeler = launch_modeler_with_spaceclaim()
 
-    Starting an Ansys SpaceClaim V 23.2 session, on address ``10.171.22.44``, port ``5001``,
+    Starting an Ansys SpaceClaim V 24.1 session, on address ``10.171.22.44``, port ``5001``,
     with chatty logs, using API v231 and a ``300`` seconds timeout:
 
     >>> from ansys.geometry.core import launch_modeler_with_spaceclaim
-    >>> modeler = launch_modeler_with_spaceclaim(product_version = 232,
+    >>> modeler = launch_modeler_with_spaceclaim(product_version = 241,
         host="10.171.22.44",
         port=5001,
         api_version= 231,

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -192,7 +192,7 @@ def prepare_and_start_backend(
     Parameters
     ----------
     product_version: ``int``, optional
-        The product version to be started. Goes from v23.2.1 to
+        The product version to be started. Goes from v24.1 to
         the latest. Default is ``None``.
         If a specific product version is requested but not installed locally,
         a SystemError will be raised.
@@ -242,7 +242,7 @@ def prepare_and_start_backend(
     ConnectionError
         If the specified endpoint is already in use, a connection error will be raised.
     SystemError
-        If there is not an Ansys product 23.2 version or later installed
+        If there is not an Ansys product 24.1 version or later installed
         or if a specific product's version is requested but not installed locally then
         a SystemError will be raised.
 
@@ -494,12 +494,12 @@ def __start_program(args: list[str], local_env: dict[str, str]) -> subprocess.Po
 def _check_minimal_versions(latest_installed_version: int) -> None:
     """Check client is compatible with Ansys Products.
 
-    Check that at least V232 is installed.
+    Check that at least V241 is installed.
     """
-    if abs(latest_installed_version) < 232:
+    if abs(latest_installed_version) < 241:
         msg = (
-            "PyAnsys Geometry is compatible with Ansys Products from version 23.2.1. "
-            + "Please install Ansys products 23.2.1 or later."
+            "PyAnsys Geometry is compatible with Ansys Products from version 24.1.0. "
+            + "Please install Ansys products 24.1.0 or later."
         )
         raise SystemError(msg)
 

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -283,7 +283,7 @@ def prepare_and_start_backend(
             product_version = -product_version
     else:
         product_version = get_latest_ansys_installation()[0]
-    
+
     # Verify that the minimum version is installed.
     _check_minimal_versions(product_version)
 

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -400,7 +400,7 @@ class Modeler:
             bodies in the design.
 
         The implied API version of the script should match the API version of the running
-        Geometry Service. DMS API versions 23.2.1 and later are supported. DMS is a
+        Geometry Service. DMS API versions 24.1 and later are supported. DMS is a
         Windows-based modeling service that has been containerized to ease distribution,
         execution, and remotability operations.
 
@@ -417,8 +417,8 @@ class Modeler:
             script modifies the current design, the design may be out-of-sync. By default,
             ``False``.
         api_version : int | str | ApiVersions, optional
-            The scripting API version to use. For example, version 23.2 can be passed as
-            an integer 232, a string "232" or using the
+            The scripting API version to use. For example, version 24.1 can be passed as
+            an integer 241, a string "241" or using the
             ``ansys.geometry.core.connection.backend.ApiVersions`` enum class.
             By default, ``None``. When specified, the service will attempt to run the script with
             the specified API version. If the API version is not supported, the service will raise


### PR DESCRIPTION
## Description
Allow the Ansys Student version to be considered as a potential option with the same version numbering as the normal versions (according to ansys-tools-path, student versions are negated).

Also taken the opportunity to "remove" support for 23R2 since it was very limited and restricted only to a specific PyAnsys Geometry minor version (0.2 and 0.3).

## Issue linked
Closes #1526 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
