### PR TITLE
feat: adapt health check timeout algorithm

### DIFF
--- a/doc/changelog.d/1559.added.md
+++ b/doc/changelog.d/1559.added.md
@@ -1,0 +1,1 @@
+adapt health check timeout algorithm

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -73,8 +73,15 @@ def wait_until_healthy(channel: grpc.Channel, timeout: float):
     channel : ~grpc.Channel
         Channel that must be established and healthy.
     timeout : float
-        Timeout in seconds. An attempt is made every 100 milliseconds
-        until the timeout is exceeded.
+        Timeout in seconds. Attempts are made with the following backoff strategy:
+
+        * Starts with 0.1 seconds.
+        * If the attempt fails, double the timeout.
+        * This is repeated until the next timeoff exceeds the
+          value for the remaining time. In that case, a final attempt
+          is made with the remaining time.
+        * If the total elapsed time exceeds the value for the ``timeout`` parameter,
+          a ``TimeoutError`` is raised.
 
     Raises
     ------

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -288,7 +288,7 @@ class GrpcClient:
         try:
             wait_until_healthy(self._channel, self._grpc_health_timeout)
             return True
-        except TimeoutError:
+        except TimeoutError: # pragma: no cover
             return False
 
     def __repr__(self) -> str:

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -288,7 +288,7 @@ class GrpcClient:
         try:
             wait_until_healthy(self._channel, self._grpc_health_timeout)
             return True
-        except TimeoutError: # pragma: no cover
+        except TimeoutError:  # pragma: no cover
             return False
 
     def __repr__(self) -> str:

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -84,12 +84,21 @@ def wait_until_healthy(channel: grpc.Channel, timeout: float):
     t_max = time.time() + timeout
     health_stub = health_pb2_grpc.HealthStub(channel)
     request = health_pb2.HealthCheckRequest(service="")
+
+    t_out = 0.1
     while time.time() < t_max:
         try:
-            out = health_stub.Check(request, timeout=0.1)
+            out = health_stub.Check(request, timeout=t_out)
             if out.status is health_pb2.HealthCheckResponse.SERVING:
                 break
         except _InactiveRpcError:
+            # Duplicate timeout and try again
+            t_now = time.time()
+            t_out *= 2
+            # If we have time to try again, continue.. but if we don't,
+            # just try for the remaining time
+            if t_now + t_out > t_max:
+                t_out = t_max - t_now
             continue
     else:
         target_str = channel._channel.target().decode()
@@ -171,7 +180,8 @@ class GrpcClient:
             )
 
         # do not finish initialization until channel is healthy
-        wait_until_healthy(self._channel, timeout)
+        self._grpc_health_timeout = timeout
+        wait_until_healthy(self._channel, self._grpc_health_timeout)
 
         # once connection with the client is established, create a logger
         self._log = LOG.add_instance_logger(
@@ -275,12 +285,10 @@ class GrpcClient:
         """Flag indicating whether the client channel is healthy."""
         if self._closed:
             return False
-        health_stub = health_pb2_grpc.HealthStub(self._channel)
-        request = health_pb2.HealthCheckRequest(service="")
         try:
-            out = health_stub.Check(request, timeout=0.1)
-            return out.status is health_pb2.HealthCheckResponse.SERVING
-        except _InactiveRpcError:  # pragma: no cover
+            wait_until_healthy(self._channel, self._grpc_health_timeout)
+            return True
+        except TimeoutError:
             return False
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Description
As title says - timeout for health check is adapted more intelligently by backing off to double the previous timeout... until we reach the timeout limit set by the user. This allows us to adapt to "slow connections" and also avoid exposing parameters. These parameters would be hard to control by users and not expected really.

## Issue linked
Closes #1558 

At least the main problem in #1558 - we won't be exposing the parameter in the end.

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
