### PR TITLE
ci: skip unnecessary stages when containers are the same

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Calculate SKIP_UNSTABLE
-        if: matrix.experimental == 'true'
+        if: matrix.experimental
         run: |
           # Choose the manifests output to consider (for DMS or Core service)
           # based on the matrix value
@@ -207,7 +207,7 @@ jobs:
           Write-Output "SKIP_UNSTABLE=$Result" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Print SKIP_UNSTABLE
-        if: matrix.experimental == 'true'
+        if: matrix.experimental
         run: |
           Write-Output "SKIP_UNSTABLE is $env:SKIP_UNSTABLE"
 
@@ -425,7 +425,7 @@ jobs:
 
     steps:
       - name: Calculate SKIP_UNSTABLE
-        if: matrix.experimental == 'true'
+        if: matrix.experimental
         run: |
           # Choose the manifests output to consider (for Core service)
           # based on the matrix value
@@ -447,7 +447,7 @@ jobs:
           echo "SKIP_UNSTABLE=$Result" >> $GITHUB_ENV
 
       - name: Print SKIP_UNSTABLE
-        if: matrix.experimental == 'true'
+        if: matrix.experimental
         run: |
           echo "SKIP_UNSTABLE is $SKIP_UNSTABLE"
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -197,19 +197,14 @@ jobs:
           }
 
           $A = $env:SKIP_UNSTABLE_CONTAINERS_TEMPORARILY -eq 1
-          $C = $ImagesAreEqual -eq 1
-          $B = ${{ matrix.experimental }}
+          $B = $ImagesAreEqual -eq 1
 
           # Calculate the logical expression
-          $Result = (($A -or $B) -and $C).ToString().ToLower()
+          $Result = ($A -or $B).ToString().ToLower()
 
           # Export it as an environment variable with true/false value
           Write-Output "SKIP_UNSTABLE=$Result" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Print SKIP_UNSTABLE
-        if: matrix.experimental
-        run: |
-          Write-Output "SKIP_UNSTABLE is $env:SKIP_UNSTABLE"
+          Write-Output "SKIP_UNSTABLE will be: $Result"
 
       - uses: actions/checkout@v4
         if: env.SKIP_UNSTABLE == 'false'
@@ -437,19 +432,14 @@ jobs:
           fi
 
           A=$([[ "$SKIP_UNSTABLE_CONTAINERS_TEMPORARILY" == "1" ]] && echo true || echo false)
-          C=$([[ "$ImagesAreEqual" == "1" ]] && echo true || echo false)
-          B=${{ matrix.experimental }}
+          B=$([[ "$ImagesAreEqual" == "1" ]] && echo true || echo false)
 
           # Calculate the logical expression
-          Result=$([[ "$A" == true || "$B" == true ]] && [[ "$C" == true ]] && echo true || echo false)
+          Result=$([[ "$A" == true || "$B" == true ]] && echo true || echo false)
 
           # Export it as an environment variable with true/false value
           echo "SKIP_UNSTABLE=$Result" >> $GITHUB_ENV
-
-      - name: Print SKIP_UNSTABLE
-        if: matrix.experimental
-        run: |
-          echo "SKIP_UNSTABLE is $SKIP_UNSTABLE"
+          echo "SKIP_UNSTABLE will be: $Result"
 
       - name: Login in Github Container registry
         if: env.SKIP_UNSTABLE == 'false'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -102,20 +102,71 @@ jobs:
           directory: docker
           recursive: true
 
+  manifests:
+    name: Check Docker manifests
+    runs-on: ubuntu-latest
+    outputs:
+      skip_dms: ${{ steps.services.outputs.skip_dms }}
+      skip_core_windows: ${{ steps.services.outputs.skip_core_windows }}
+      skip_core_linux: ${{ steps.services.outputs.skip_core_linux }}
+    strategy:
+      matrix:
+        include:
+          - container-stable: "windows-latest"
+            container-unstable: "windows-latest-unstable"
+            service: "dms"
+            service-name: "Windows DMS"
+          - container-stable: "core-windows-latest"
+            container-unstable: "core-windows-latest-unstable"
+            service: "core_windows"
+            service-name: "Windows Core Service"
+          - container-stable: "core-linux-latest"
+            container-unstable: "core-linux-latest-unstable"
+            service: "core_linux"
+            service-name: "Linux Core Service"
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check ${{ matrix.service-name }} manifest
+        id: services
+        run: |
+          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-stable }} > ${{ matrix.container-stable }}.json
+          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-unstable }} > ${{ matrix.container-unstable }}.json || true
+
+          # Verify that the unstable manifest exists - otherwise create an empty file
+          if [ ! -f ${{ matrix.container-unstable }}.json ]; then
+            touch ${{ matrix.container-unstable }}.json
+          fi
+
+
+          # Check if the manifests are the same (and if so, create an output that will skip the next job)
+          if diff ${{ matrix.container-stable }}.json ${{ matrix.container-unstable }}.json; then
+            echo "${{ matrix.service-name }} container manifests are the same... skipping"
+            echo "skip_${{ matrix.service }}=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "${{ matrix.service-name }} container manifests are different"
+            echo "skip_${{ matrix.service }}=0" >> "$GITHUB_OUTPUT"
+          fi
+
 # =================================================================================================
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # =================================================================================================
 
   testing-windows:
     name: Testing and coverage (Windows)
-    needs: [smoke-tests]
+    needs: [smoke-tests, manifests]
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
       labels:  [self-hosted, Windows, pygeometry]
     continue-on-error: ${{ matrix.experimental }}
     env:
-      SKIP_UNSTABLE: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY == 1 && matrix.experimental }}
+      SKIP_UNSTABLE: false
       PYVISTA_OFF_SCREEN: true
     strategy:
       fail-fast: false
@@ -131,6 +182,35 @@ jobs:
             experimental: true
 
     steps:
+      - name: Calculate SKIP_UNSTABLE
+        if: matrix.experimental == 'true'
+        run: |
+          # Choose the manifests output to consider (for DMS or Core service)
+          # based on the matrix value
+          if ("${{ matrix.docker-image }}" -eq "windows-latest-unstable") {
+            $ImagesAreEqual = ${{ needs.manifests.outputs.skip_dms }}
+          } elseif ("${{ matrix.docker-image }}" -eq "core-windows-latest-unstable") {
+            $ImagesAreEqual = ${{ needs.manifests.outputs.skip_core_windows }}
+          } else {
+            Write-Output "Unknown docker image"
+            exit 1
+          }
+
+          $A = $env:SKIP_UNSTABLE_CONTAINERS_TEMPORARILY -eq 1
+          $C = $ImagesAreEqual -eq 1
+          $B = ${{ matrix.experimental }}
+
+          # Calculate the logical expression
+          $Result = (($A -or $B) -and $C).ToString().ToLower()
+
+          # Export it as an environment variable with true/false value
+          Write-Output "SKIP_UNSTABLE=$Result" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Print SKIP_UNSTABLE
+        if: matrix.experimental == 'true'
+        run: |
+          Write-Output "SKIP_UNSTABLE is $env:SKIP_UNSTABLE"
+
       - uses: actions/checkout@v4
         if: env.SKIP_UNSTABLE == 'false'
 
@@ -329,11 +409,11 @@ jobs:
 
   testing-linux:
     name: Testing and coverage (Linux)
-    needs: [smoke-tests]
+    needs: [smoke-tests, manifests]
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     env:
-      SKIP_UNSTABLE: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY == 1 && matrix.experimental }}
+      SKIP_UNSTABLE: false
     strategy:
       fail-fast: false
       matrix:
@@ -344,6 +424,33 @@ jobs:
             experimental: true
 
     steps:
+      - name: Calculate SKIP_UNSTABLE
+        if: matrix.experimental == 'true'
+        run: |
+          # Choose the manifests output to consider (for Core service)
+          # based on the matrix value
+          if [[ "${{ matrix.docker-image }}" == "core-linux-latest-unstable" ]]; then
+            ImagesAreEqual=${{ needs.manifests.outputs.skip_core_linux }}
+          else
+            echo "Unknown docker image"
+            exit 1
+          fi
+
+          A=$([[ "$SKIP_UNSTABLE_CONTAINERS_TEMPORARILY" == "1" ]] && echo true || echo false)
+          C=$([[ "$ImagesAreEqual" == "1" ]] && echo true || echo false)
+          B=${{ matrix.experimental }}
+
+          # Calculate the logical expression
+          Result=$([[ "$A" == true || "$B" == true ]] && [[ "$C" == true ]] && echo true || echo false)
+
+          # Export it as an environment variable with true/false value
+          echo "SKIP_UNSTABLE=$Result" >> $GITHUB_ENV
+
+      - name: Print SKIP_UNSTABLE
+        if: matrix.experimental == 'true'
+        run: |
+          echo "SKIP_UNSTABLE is $SKIP_UNSTABLE"
+
       - name: Login in Github Container registry
         if: env.SKIP_UNSTABLE == 'false'
         uses: docker/login-action@v3

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0' }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0'
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -203,7 +203,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0' }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0'
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -321,7 +321,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0' }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -98,6 +98,10 @@ jobs:
     env:
       PYVISTA_OFF_SCREEN: true
     steps:
+      - name: Check output
+        run: |
+          echo "skip_dms value is: ${{ needs.manifests.outputs.skip_dms }}"
+
       - uses: actions/checkout@v4
 
       - name: Set up Python
@@ -207,6 +211,10 @@ jobs:
     env:
       PYVISTA_OFF_SCREEN: true
     steps:
+      - name: Check output
+        run: |
+          echo "skip_core_windows value is: ${{ needs.manifests.outputs.skip_core_windows }}"
+
       - uses: actions/checkout@v4
 
       - name: Set up Python
@@ -317,6 +325,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check output
+        run: |
+          echo "skip_core_linux value is: ${{ needs.manifests.outputs.skip_core_linux }}"
+
       - name: Login in Github Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0'
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0' }}
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -203,7 +203,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0'
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0' }}
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -321,7 +321,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0'
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == 0 }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == 0
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -203,7 +203,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == 0 }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == 0
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -321,7 +321,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == 0 }}
+    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == 0
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -98,10 +98,6 @@ jobs:
     env:
       PYVISTA_OFF_SCREEN: true
     steps:
-      - name: Check output
-        run: |
-          echo "skip_dms value is: ${{ needs.manifests.outputs.skip_dms }}"
-
       - uses: actions/checkout@v4
 
       - name: Set up Python
@@ -211,10 +207,6 @@ jobs:
     env:
       PYVISTA_OFF_SCREEN: true
     steps:
-      - name: Check output
-        run: |
-          echo "skip_core_windows value is: ${{ needs.manifests.outputs.skip_core_windows }}"
-
       - uses: actions/checkout@v4
 
       - name: Set up Python
@@ -325,10 +317,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check output
-        run: |
-          echo "skip_core_linux value is: ${{ needs.manifests.outputs.skip_core_linux }}"
-
       - name: Login in Github Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == 0
+    if: needs.manifests.outputs.skip_dms == 0
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -203,7 +203,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == 0
+    if: needs.manifests.outputs.skip_core_windows == 0
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -321,7 +321,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == 0
+    if: needs.manifests.outputs.skip_core_linux == 0
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -35,13 +35,52 @@ concurrency:
 
 jobs:
 
+  manifests:
+    name: Check Docker manifests
+    runs-on: ubuntu-latest
+    outputs:
+      skip_dms: ${{ steps.services.outputs.skip_dms }}
+      skip_core_windows: ${{ steps.services.outputs.skip_core_windows }}
+      skip_core_linux: ${{ steps.services.outputs.skip_core_linux }}
+    strategy:
+      matrix:
+        include:
+          - container-stable: "windows-latest"
+            container-unstable: "windows-latest-unstable"
+            service: "dms"
+            service-name: "Windows DMS"
+          - container-stable: "core-windows-latest"
+            container-unstable: "core-windows-latest-unstable"
+            service: "core_windows"
+            service-name: "Windows Core Service"
+          - container-stable: "core-linux-latest"
+            container-unstable: "core-linux-latest-unstable"
+            service: "core_linux"
+            service-name: "Linux Core Service"
+    steps:
+      - name: Check ${{ matrix.service-name }} manifest
+        id: services
+        run: |
+          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-stable }} > ${{ matrix.container-stable }}.json
+          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-unstable }} > ${{ matrix.container-unstable }}.json || "" > ${{ matrix.container-unstable }}.json
+
+          # Check if the manifests are the same (and if so, create an output that will skip the next job)
+          if diff ${{ matrix.container-stable }}.json ${{ matrix.container-unstable }}.json; then
+            echo "${{ matrix.service-name }} container manifests are the same... skipping"
+            echo "skip_${{ matrix.service }}=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "${{ matrix.service-name }} container manifests are different"
+            echo "skip_${{ matrix.service }}=0" >> "$GITHUB_OUTPUT"
+          fi
+
 # =================================================================================================
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    RUNNING ON SELF-HOSTED RUNNER    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # =================================================================================================
 
   windows-dms-tests:
     name: Windows DMS
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1
+    needs: manifests
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_DMS == '0' }}
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -146,7 +185,8 @@ jobs:
 
   windows-core-tests:
     name: Windows Core Service
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1
+    needs: manifests
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_CORE_WINDOWS == '0' }}
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -259,7 +299,8 @@ jobs:
 
   linux-tests:
     name: Linux Core Service
-    if: vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1
+    needs: manifests
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_CORE_LINUX == '0' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_DMS == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0' }}
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -199,7 +199,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_CORE_WINDOWS == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0' }}
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -313,7 +313,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.SKIP_CORE_LINUX == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -93,7 +93,7 @@ jobs:
   windows-dms-tests:
     name: Windows DMS
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_dms == 0 }}
     runs-on: [self-hosted, Windows, pygeometry]
     env:
       PYVISTA_OFF_SCREEN: true
@@ -203,7 +203,7 @@ jobs:
   windows-core-tests:
     name: Windows Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_windows == 0 }}
     # runs-on: [self-hosted, Windows, pygeometry]
     runs-on: # TODO: Waiting for ansys-network runner to be updated
       group: pyansys-self-hosted
@@ -321,7 +321,7 @@ jobs:
   linux-tests:
     name: Linux Core Service
     needs: manifests
-    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == '0' }}
+    if: ${{ vars.SKIP_UNSTABLE_CONTAINERS_TEMPORARILY != 1 || needs.manifests.outputs.skip_core_linux == 0 }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -69,7 +69,13 @@ jobs:
         id: services
         run: |
           docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-stable }} > ${{ matrix.container-stable }}.json
-          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-unstable }} > ${{ matrix.container-unstable }}.json || "" > ${{ matrix.container-unstable }}.json
+          docker manifest inspect ghcr.io/ansys/geometry:${{ matrix.container-unstable }} > ${{ matrix.container-unstable }}.json || true
+
+          # Verify that the unstable manifest exists - otherwise create an empty file
+          if [ ! -f ${{ matrix.container-unstable }}.json ]; then
+            touch ${{ matrix.container-unstable }}.json
+          fi
+
 
           # Check if the manifests are the same (and if so, create an output that will skip the next job)
           if diff ${{ matrix.container-stable }}.json ${{ matrix.container-unstable }}.json; then

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -58,6 +58,13 @@ jobs:
             service: "core_linux"
             service-name: "Linux Core Service"
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check ${{ matrix.service-name }} manifest
         id: services
         run: |

--- a/doc/changelog.d/1592.maintenance.md
+++ b/doc/changelog.d/1592.maintenance.md
@@ -1,0 +1,1 @@
+skip unnecessary stages when containers are the same


### PR DESCRIPTION
## Description
Looking into saving resources... whenever the manifests for the unstable and stable images are the same, we should try to skip the execution of the unstable ones... no added value and really just consuming resources. Since we are low on VMs currently, we really need to look into saving as much as possible

## Issue linked
None

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
