### PR TITLE
fix: make_child_logger only takes 2 args.

### DIFF
--- a/doc/changelog.d/1603.fixed.md
+++ b/doc/changelog.d/1603.fixed.md
@@ -1,0 +1,1 @@
+make_child_logger only takes 2 args.

--- a/src/ansys/geometry/core/logger.py
+++ b/src/ansys/geometry/core/logger.py
@@ -499,7 +499,7 @@ class Logger:
             Logger class.
         """
         name = self.logger.name + "." + suffix
-        self._instances[name] = self._make_child_logger(self, name, level)
+        self._instances[name] = self._make_child_logger(name, level)
         return self._instances[name]
 
     def add_instance_logger(


### PR DESCRIPTION
## Description
Too many positional args were provided to `make_child_logger`.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
