### PR TITLE
feat: surface body from trimmed curves

### DIFF
--- a/doc/changelog.d/1650.added.md
+++ b/doc/changelog.d/1650.added.md
@@ -1,0 +1,1 @@
+surface body from trimmed curves

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -995,7 +995,7 @@ class Component:
         return Body(response.id, response.name, self, tb)
 
     @protect_grpc
-    @min_backend_version(25, 1, 0)
+    @min_backend_version(25, 2, 0)
     def create_surface_from_trimmed_curves(
         self, name: str, trimmed_curves: list[TrimmedCurve]
     ) -> Body:

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -1005,7 +1005,7 @@ class Component:
         ----------
         name : str
             User-defined label for the new surface body.
-        trimmed_curves : TrimmedCurve
+        trimmed_curves : list[TrimmedCurve]
             Curves to define the plane and body.
 
         Returns

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -37,6 +37,7 @@ from ansys.api.geometry.v0.bodies_pb2 import (
     CreateExtrudedBodyRequest,
     CreatePlanarBodyRequest,
     CreateSphereBodyRequest,
+    CreateSurfaceBodyFromTrimmedCurvesRequest,
     CreateSurfaceBodyRequest,
     CreateSweepingChainRequest,
     CreateSweepingProfileRequest,
@@ -987,6 +988,42 @@ class Component:
             f"Creating surface body from trimmed surface provided on {self.id}. Creating body..."
         )
         response = self._bodies_stub.CreateSurfaceBody(request)
+
+        tb = MasterBody(response.master_id, name, self._grpc_client, is_surface=response.is_surface)
+        self._master_component.part.bodies.append(tb)
+        self._clear_cached_bodies()
+        return Body(response.id, response.name, self, tb)
+
+    @protect_grpc
+    @min_backend_version(25, 1, 0)
+    def create_surface_from_trimmed_curves(
+        self, name: str, trimmed_curves: list[TrimmedCurve]
+    ) -> Body:
+        """Create a surface body from a list of trimmed curves all lying on the same plane.
+
+        Parameters
+        ----------
+        name : str
+            User-defined label for the new surface body.
+        trimmed_curves : TrimmedCurve
+            Curves to define the plane and body.
+
+        Returns
+        -------
+        Body
+            Surface body.
+        """
+        curves = [trimmed_curve_to_grpc_trimmed_curve(curve) for curve in trimmed_curves]
+        request = CreateSurfaceBodyFromTrimmedCurvesRequest(
+            name=name,
+            parent=self.id,
+            trimmed_curves=curves,
+        )
+
+        self._grpc_client.log.debug(
+            f"Creating surface body from trimmed curves provided on {self.id}. Creating body..."
+        )
+        response = self._bodies_stub.CreateSurfaceBodyFromTrimmedCurves(request)
 
         tb = MasterBody(response.master_id, name, self._grpc_client, is_surface=response.is_surface)
         self._master_component.part.bodies.append(tb)


### PR DESCRIPTION
## Description
Ability to create a surface body from a list of trimmed curves.

## Issue linked


## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
