### PR TITLE
build: bump ansys api geometry from 0.4.30 to 0.4.32

### DIFF
--- a/doc/changelog.d/1672.dependencies.md
+++ b/doc/changelog.d/1672.dependencies.md
@@ -1,0 +1,1 @@
+bump ansys-api-geometry from 0.4.30 to 0.4.32

--- a/doc/changelog.d/1672.dependencies.md
+++ b/doc/changelog.d/1672.dependencies.md
@@ -1,1 +1,0 @@
-bump ansys-api-geometry from 0.4.30 to 0.4.32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-api-geometry==0.4.30",
+    "ansys-api-geometry==0.4.32",
     "ansys-tools-path>=0.3,<1",
     "ansys-tools-visualization-interface>=0.2.6,<1",
     "attrs!=24.3.0",


### PR DESCRIPTION
## Description
Bumps ansys-api-geometry from 0.4.30 to 0.4.32
