### PR TITLE
fix: filter set export id to only CoreService based backends

### DIFF
--- a/doc/changelog.d/1685.fixed.md
+++ b/doc/changelog.d/1685.fixed.md
@@ -1,0 +1,1 @@
+filter set export id to only CoreService based backends

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -170,19 +170,21 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     # Create top of car - applies to BOTH cars
     sketch = Sketch(Plane(Point3D([0, 5, 5]))).box(Point2D([5, 2.5]), 10, 5)
     comp1.extrude_sketch("Top", sketch, 5)
+    
+    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
 
-    modeler.unsupported.set_export_id(base_body.id, PersistentIdType.PRIME_ID, "1")
-    modeler.unsupported.set_export_id(wheel_body.id, PersistentIdType.PRIME_ID, "2")
+        modeler.unsupported.set_export_id(base_body.id, PersistentIdType.PRIME_ID, "1")
+        modeler.unsupported.set_export_id(wheel_body.id, PersistentIdType.PRIME_ID, "2")
 
-    modeler.unsupported.set_export_id(base_body.faces[0].id, PersistentIdType.PRIME_ID, "3")
-    modeler.unsupported.set_export_id(base_body.edges[0].id, PersistentIdType.PRIME_ID, "4")
+        modeler.unsupported.set_export_id(base_body.faces[0].id, PersistentIdType.PRIME_ID, "3")
+        modeler.unsupported.set_export_id(base_body.edges[0].id, PersistentIdType.PRIME_ID, "4")
 
-    bodies1 = modeler.unsupported.get_body_occurrences_from_import_id(
-        "1", PersistentIdType.PRIME_ID
-    )
-    bodies2 = modeler.unsupported.get_body_occurrences_from_import_id(
-        "2", PersistentIdType.PRIME_ID
-    )
+        bodies1 = modeler.unsupported.get_body_occurrences_from_import_id(
+            "1", PersistentIdType.PRIME_ID
+        )
+        bodies2 = modeler.unsupported.get_body_occurrences_from_import_id(
+            "2", PersistentIdType.PRIME_ID
+        )
 
     # requires a change to core service, uncomment on next core service update
     # assert base_body.id in [b.id for b in bodies1]

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -170,9 +170,8 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     # Create top of car - applies to BOTH cars
     sketch = Sketch(Plane(Point3D([0, 5, 5]))).box(Point2D([5, 2.5]), 10, 5)
     comp1.extrude_sketch("Top", sketch, 5)
-    
-    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
 
+    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
         modeler.unsupported.set_export_id(base_body.id, PersistentIdType.PRIME_ID, "1")
         modeler.unsupported.set_export_id(wheel_body.id, PersistentIdType.PRIME_ID, "2")
 
@@ -186,20 +185,24 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
             "2", PersistentIdType.PRIME_ID
         )
 
-    # requires a change to core service, uncomment on next core service update
-    # assert base_body.id in [b.id for b in bodies1]
-    # assert wheel_body.id in [b.id for b in bodies2]
-    assert base_body.id not in [b.id for b in bodies1]
-    assert wheel_body.id not in [b.id for b in bodies2]
+        # requires a change to core service, uncomment on next core service update
+        # assert base_body.id in [b.id for b in bodies1]
+        # assert wheel_body.id in [b.id for b in bodies2]
+        assert base_body.id not in [b.id for b in bodies1]
+        assert wheel_body.id not in [b.id for b in bodies2]
 
-    faces = modeler.unsupported.get_face_occurrences_from_import_id("3", PersistentIdType.PRIME_ID)
-    edges = modeler.unsupported.get_edge_occurrences_from_import_id("4", PersistentIdType.PRIME_ID)
+        faces = modeler.unsupported.get_face_occurrences_from_import_id(
+            "3", PersistentIdType.PRIME_ID
+        )
+        edges = modeler.unsupported.get_edge_occurrences_from_import_id(
+            "4", PersistentIdType.PRIME_ID
+        )
 
-    # requires a change to core service, uncomment on next core service update
-    # assert base_body.faces[0].id in [f.id for f in faces]
-    # assert base_body.edges[0].id in [e.id for e in edges]
-    assert base_body.faces[0].id not in [f.id for f in faces]
-    assert base_body.edges[0].id not in [e.id for e in edges]
+        # requires a change to core service, uncomment on next core service update
+        # assert base_body.faces[0].id in [f.id for f in faces]
+        # assert base_body.edges[0].id in [e.id for e in edges]
+        assert base_body.faces[0].id not in [f.id for f in faces]
+        assert base_body.edges[0].id not in [e.id for e in edges]
 
     file = tmp_path_factory.mktemp("test_design_import") / "two_cars.scdocx"
     design.download(str(file))


### PR DESCRIPTION
## Description
This change is to fix the test_open_file. We used to call set and get export id for whatever backend type we where testing against. Right now those apis are only implemented in CoreService based backends, so we should only use set and get export id against those.
## Checklist
- [x] I have tested my changes locally.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
