### PR TITLE
fix: Invert parameters order to match the one in the backend

### DIFF
--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -380,7 +380,7 @@ def test_find_and_fix_split_edges(modeler: Modeler):
     """Test to read geometry, find and fix split edges and validate they are fixed removed."""
     design = modeler.open_file(FILES_DIR / "bracket-with-split-edges.scdocx")
     assert len(design.bodies[0].edges) == 304
-    split_edges = modeler.repair_tools.find_split_edges(design.bodies, 150, 0.0001)
+    split_edges = modeler.repair_tools.find_split_edges(design.bodies, 0.0001, 150)
     assert len(split_edges) == 166
     for i in split_edges:
         try:  # Try/Except is a workaround. Having .alive would be better


### PR DESCRIPTION
## Description
Invert parameters order to match the one in the backend

## Checklist
- [x] I have tested my changes locally.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
