### PR TITLE
feat: is_core_service BackendType static method

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,6 +91,7 @@ jobs:
           library-name: ${{ env.PACKAGE_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+          whitelist-license-check: 'attrs'
 
   docker-style:
     name: Docker Style Check

--- a/doc/changelog.d/1692.added.md
+++ b/doc/changelog.d/1692.added.md
@@ -1,0 +1,1 @@
+iscoreservice backentype

--- a/doc/changelog.d/1692.added.md
+++ b/doc/changelog.d/1692.added.md
@@ -1,1 +1,1 @@
-iscoreservice backentype
+is_core_service BackendType static method

--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -39,7 +39,18 @@ class BackendType(Enum):
 
     @staticmethod
     def is_core_service(backend_type: "BackendType") -> bool:
-        """Is backend of core service type (either Linux or Windosw)?."""
+        """Is backend of core service type (either Linux or Windosw)?.
+
+        Parameters
+        ----------
+        backend_type : BackendType
+            The backend type to check whether or not it's a CoreService type.
+
+        Returns
+        -------
+        bool
+            True if the backend is CoreService based, False otherwise.
+        """
         return backend_type in (
             BackendType.LINUX_SERVICE,
             BackendType.CORE_WINDOWS,

--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -39,7 +39,7 @@ class BackendType(Enum):
 
     @staticmethod
     def is_core_service(backend_type: "BackendType") -> bool:
-        """Determines whether the backend is CoreService based or not.
+        """Determine whether the backend is CoreService based or not.
 
         Parameters
         ----------

--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -33,6 +33,18 @@ class BackendType(Enum):
     SPACECLAIM = 1
     WINDOWS_SERVICE = 2
     LINUX_SERVICE = 3
+    CORE_WINDOWS = 4
+    CORE_LINUX = 5
+    DISCOVERY_HEADLESS = 6
+
+    @staticmethod
+    def is_core_service(backend_type: "BackendType") -> bool:
+        """Is backend of core service type (either Linux or Windosw)?."""
+        return backend_type in (
+            BackendType.LINUX_SERVICE,
+            BackendType.CORE_WINDOWS,
+            BackendType.CORE_LINUX,
+        )
 
 
 class ApiVersions(Enum):

--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -39,7 +39,7 @@ class BackendType(Enum):
 
     @staticmethod
     def is_core_service(backend_type: "BackendType") -> bool:
-        """Determines whether the backend is Core Service based or not.
+        """Determines whether the backend is CoreService based or not.
 
         Parameters
         ----------

--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -39,7 +39,7 @@ class BackendType(Enum):
 
     @staticmethod
     def is_core_service(backend_type: "BackendType") -> bool:
-        """Is backend of core service type (either Linux or Windosw)?.
+        """Determines whether the backend is Core Service based or not.
 
         Parameters
         ----------

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -232,7 +232,7 @@ class GrpcClient:
                 BackendType.LINUX_SERVICE,
                 BackendType.CORE_LINUX,
                 BackendType.CORE_WINDOWS,
-                BackendType.DISCOVERY_HEADLESS
+                BackendType.DISCOVERY_HEADLESS,
             )
             else True
         )

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -232,6 +232,7 @@ class GrpcClient:
                 BackendType.LINUX_SERVICE,
                 BackendType.CORE_LINUX,
                 BackendType.CORE_WINDOWS,
+                BackendType.DISCOVERY_HEADLESS
             )
             else True
         )

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -215,11 +215,25 @@ class GrpcClient:
                 backend_type = BackendType.WINDOWS_SERVICE
             elif grpc_backend_type == GRPCBackendType.LINUX_DMS:
                 backend_type = BackendType.LINUX_SERVICE
+            elif grpc_backend_type == GRPCBackendType.CORE_SERVICE_LINUX:
+                backend_type = BackendType.CORE_LINUX
+            elif grpc_backend_type == GRPCBackendType.CORE_SERVICE_WINDOWS:
+                backend_type = BackendType.CORE_WINDOWS
+            elif grpc_backend_type == GRPCBackendType.DISCOVERY_HEADLESS:
+                backend_type = BackendType.DISCOVERY_HEADLESS
 
         # Store the backend type
         self._backend_type = backend_type
         self._multiple_designs_allowed = (
-            False if backend_type in (BackendType.DISCOVERY, BackendType.LINUX_SERVICE) else True
+            False
+            if backend_type
+            in (
+                BackendType.DISCOVERY,
+                BackendType.LINUX_SERVICE,
+                BackendType.CORE_LINUX,
+                BackendType.CORE_WINDOWS,
+            )
+            else True
         )
 
         # retrieve the backend version

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -263,7 +263,10 @@ def prepare_and_start_backend(
     """
     from ansys.geometry.core.modeler import Modeler
 
-    if os.name != "nt" and backend_type != BackendType.LINUX_SERVICE:  # pragma: no cover
+    if os.name != "nt" and backend_type not in (
+        BackendType.LINUX_SERVICE,
+        BackendType.CORE_LINUX,
+    ):  # pragma: no cover
         raise RuntimeError(
             "Method 'prepare_and_start_backend' is only available on Windows."
             "A Linux version is only available for the Core Geometry Service."
@@ -362,7 +365,7 @@ def prepare_and_start_backend(
             )
         )
     # This should be modified to Windows Core Service in the future
-    elif backend_type == BackendType.LINUX_SERVICE:
+    elif BackendType.is_core_service(backend_type):
         # Define several Ansys Geometry Core Service folders needed
         root_service_folder = Path(installations[product_version], CORE_GEOMETRY_SERVICE_FOLDER)
         native_folder = root_service_folder / "Native"

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -124,7 +124,7 @@ class Modeler:
         # https://github.com/ansys/pyansys-geometry/issues/1319
         if BackendType.is_core_service(self.client.backend_type):
             self._measurement_tools = None
-            LOG.warning("Linux backend does not support measurement tools.")
+            LOG.warning("CoreService backend does not support measurement tools.")
         else:
             self._measurement_tools = MeasurementTools(self._grpc_client)
 

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -122,7 +122,7 @@ class Modeler:
         # Initialize the RepairTools - Not available on Linux
         # TODO: delete "if" when Linux service is able to use repair tools
         # https://github.com/ansys/pyansys-geometry/issues/1319
-        if self.client.backend_type == BackendType.LINUX_SERVICE:
+        if BackendType.is_core_service(self.client.backend_type):
             self._measurement_tools = None
             LOG.warning("Linux backend does not support measurement tools.")
         else:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -51,7 +51,7 @@ FILES_DIR = Path(Path(__file__).parent, "files")
 
 def skip_if_linux(modeler: Modeler, test_name: str, element_not_available: str):
     """Skip test if running on Linux."""
-    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
+    if BackendType.is_core_service(modeler.client.backend_type):
         pytest.skip(
             reason=f"Skipping '{test_name}'. '{element_not_available}' not on Linux service."
         )  # skip!

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,11 +49,11 @@ DSCOSCRIPTS_FILES_DIR = Path(Path(__file__).parent, "files", "disco_scripts")
 FILES_DIR = Path(Path(__file__).parent, "files")
 
 
-def skip_if_linux(modeler: Modeler, test_name: str, element_not_available: str):
-    """Skip test if running on Linux."""
+def skip_if_core_service(modeler: Modeler, test_name: str, element_not_available: str):
+    """Skip test if running on CoreService."""
     if BackendType.is_core_service(modeler.client.backend_type):
         pytest.skip(
-            reason=f"Skipping '{test_name}'. '{element_not_available}' not on Linux service."
+            reason=f"Skipping '{test_name}'. '{element_not_available}' not on CoreService."
         )  # skip!
 
 

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -911,7 +911,7 @@ def test_download_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactor
     assert file.exists()
 
     # Check that we can also save it (even if it is not accessible on the server)
-    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
+    if modeler.client.backend_type in (BackendType.LINUX_SERVICE, BackendType.CORE_LINUX):
         file_save = "/tmp/cylinder-temp.scdocx"
     else:
         file_save = tmp_path_factory.mktemp("scdoc_files_save") / "cylinder.scdocx"
@@ -919,7 +919,7 @@ def test_download_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactor
     design.save(file_location=file_save)
 
     # Check for other exports - Windows backend...
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         binary_parasolid_file = tmp_path_factory.mktemp("scdoc_files_download") / "cylinder.x_b"
         text_parasolid_file = tmp_path_factory.mktemp("scdoc_files_download") / "cylinder.x_t"
 

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -70,7 +70,7 @@ from ansys.geometry.core.shapes.box_uv import BoxUV
 from ansys.geometry.core.sketch import Sketch
 from ansys.tools.visualization_interface.utils.color import Color
 
-from .conftest import FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, skip_if_core_service
 
 
 def test_design_extrusion_and_material_assignment(modeler: Modeler):
@@ -1111,8 +1111,8 @@ def test_copy_body(modeler: Modeler):
 
 def test_beams(modeler: Modeler):
     """Test beam creation."""
-    # Skip on Linux
-    skip_if_linux(modeler, test_beams.__name__, "create_beam")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_beams.__name__, "create_beam")
 
     # Create your design on the server side
     design = modeler.create_design("BeamCreation")
@@ -1414,8 +1414,8 @@ def test_named_selections_beams(modeler: Modeler):
     """Test for verifying the correct creation of ``NamedSelection`` with
     beams.
     """
-    # Skip on Linux
-    skip_if_linux(modeler, test_named_selections_beams.__name__, "create_beam")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_named_selections_beams.__name__, "create_beam")
 
     # Create your design on the server side
     design = modeler.create_design("NamedSelectionBeams_Test")
@@ -2002,7 +2002,8 @@ def test_get_collision(modeler: Modeler):
 
 def test_set_body_name(modeler: Modeler):
     """Test the setting the name of a body."""
-    skip_if_linux(modeler, test_set_body_name.__name__, "set_name")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_set_body_name.__name__, "set_name")
 
     design = modeler.create_design("simple_cube")
     unit = DEFAULT_UNITS.LENGTH
@@ -2023,7 +2024,8 @@ def test_set_body_name(modeler: Modeler):
 
 def test_set_fill_style(modeler: Modeler):
     """Test the setting the fill style of a body."""
-    skip_if_linux(modeler, test_set_fill_style.__name__, "set_fill_style")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_set_fill_style.__name__, "set_fill_style")
 
     design = modeler.create_design("RVE")
     unit = DEFAULT_UNITS.LENGTH
@@ -2196,7 +2198,9 @@ def test_body_mapping(modeler: Modeler):
 
 def test_sphere_creation(modeler: Modeler):
     """Test the creation of a sphere body with a given radius."""
-    skip_if_linux(modeler, test_sphere_creation.__name__, "create_sphere")
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_sphere_creation.__name__, "create_sphere")
+
     design = modeler.create_design("Spheretest")
     center_point = Point3D([10, 10, 10], UNITS.m)
     radius = Distance(1, UNITS.m)
@@ -2208,7 +2212,9 @@ def test_sphere_creation(modeler: Modeler):
 
 def test_body_mirror(modeler: Modeler):
     """Test the mirroring of a body."""
-    skip_if_linux(modeler, test_body_mirror.__name__, "mirror")
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_body_mirror.__name__, "mirror")
+
     design = modeler.create_design("Design1")
 
     # Create shape with no lines of symmetry in any axis
@@ -2414,7 +2420,8 @@ def test_create_body_from_loft_profile(modeler: Modeler):
     """Test the ``create_body_from_loft_profile()`` method to create a vase
     shape.
     """
-    skip_if_linux(
+    # Skip test on CoreService
+    skip_if_core_service(
         modeler, test_create_body_from_loft_profile.__name__, "'create_body_from_loft_profile'"
     )
     design_sketch = modeler.create_design("loftprofile")
@@ -2530,8 +2537,8 @@ def test_revolve_sketch_fail_invalid_path(modeler: Modeler):
 
 def test_component_tree_print(modeler: Modeler):
     """Test for verifying the tree print for ``Component`` objects."""
-    # Skip on Linux
-    skip_if_linux(modeler, test_component_tree_print.__name__, "create_beam")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_component_tree_print.__name__, "create_beam")
 
     def check_list_equality(lines, expected_lines):
         # By doing "a in b" rather than "a == b", we can check for substrings

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -138,7 +138,7 @@ def test_export_to_parasolid_text(modeler: Modeler, tmp_path_factory: pytest.Tem
     # Define the location and expected file location
     location = tmp_path_factory.mktemp("test_export_to_parasolid_text")
 
-    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
+    if BackendType.is_core_service(modeler.client.backend_type):
         file_location = location / f"{design.name}.x_t"
     else:
         file_location = location / f"{design.name}.xmt_txt"
@@ -161,7 +161,7 @@ def test_export_to_parasolid_binary(modeler: Modeler, tmp_path_factory: pytest.T
     # Define the location and expected file location
     location = tmp_path_factory.mktemp("test_export_to_parasolid_binary")
 
-    if modeler.client.backend_type == BackendType.LINUX_SERVICE:
+    if BackendType.is_core_service(modeler.client.backend_type):
         file_location = location / f"{design.name}.x_b"
     else:
         file_location = location / f"{design.name}.xmt_bin"
@@ -191,7 +191,7 @@ def test_export_to_step(modeler: Modeler, tmp_path_factory: pytest.TempPathFacto
     # Check the exported file
     assert file_location.exists()
 
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         # Import the STEP file
         design_read = modeler.open_file(file_location)
 

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -179,7 +179,7 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     _checker_method(design, design2, True)
 
     # Test HOOPS formats (Windows only)
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         # IGES
         #
         # TODO: Something has gone wrong with IGES

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -35,7 +35,7 @@ from ansys.geometry.core.math import Plane, Point2D, Point3D, UnitVector3D, Vect
 from ansys.geometry.core.misc import UNITS
 from ansys.geometry.core.sketch import Sketch
 
-from .conftest import FILES_DIR, IMPORT_FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, IMPORT_FILES_DIR, skip_if_core_service
 
 
 def _checker_method(comp: Component, comp_ref: Component, precise_check: bool = True) -> None:
@@ -226,8 +226,8 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
 
 def test_design_insert(modeler: Modeler):
     """Test inserting a file into the design."""
-    # Skip for Linux service
-    skip_if_linux(modeler, test_design_insert.__name__, "insert_file")
+    # Skip for CoreService
+    skip_if_core_service(modeler, test_design_insert.__name__, "insert_file")
 
     # Create a design and sketch a circle
     design = modeler.create_design("Insert")
@@ -249,8 +249,8 @@ def test_design_insert_with_import(modeler: Modeler):
     """Test inserting a file into the design through the external format import
     process.
     """
-    # Skip for Linux service
-    skip_if_linux(modeler, test_design_insert_with_import.__name__, "insert_file")
+    # Skip for CoreService
+    skip_if_core_service(modeler, test_design_insert_with_import.__name__, "insert_file")
 
     # Create a design and sketch a circle
     design = modeler.create_design("Insert")

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -37,7 +37,7 @@ from ansys.geometry.core.misc import DEFAULT_UNITS, UNITS, Angle, Distance
 from ansys.geometry.core.modeler import Modeler
 from ansys.geometry.core.sketch import Sketch
 
-from .conftest import FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, skip_if_core_service
 
 
 def test_issue_834_design_import_with_surfaces(modeler: Modeler):
@@ -48,7 +48,7 @@ def test_issue_834_design_import_with_surfaces(modeler: Modeler):
     """
     # TODO: to be reactivated
     # https://github.com/ansys/pyansys-geometry/issues/799
-    skip_if_linux(modeler, test_issue_834_design_import_with_surfaces.__name__, "open_file")
+    skip_if_core_service(modeler, test_issue_834_design_import_with_surfaces.__name__, "open_file")
 
     # Open the design
     design = modeler.open_file(Path(FILES_DIR, "DuplicateFacesDesignBefore.scdocx"))
@@ -86,8 +86,8 @@ def test_issue_1184_sphere_creation_crashes(modeler: Modeler):
     For more info see
     https://github.com/ansys/pyansys-geometry/issues/1184
     """
-    # Skip this test on Linux since it is not implemented yet
-    skip_if_linux(modeler, test_issue_1184_sphere_creation_crashes.__name__, "create_sphere")
+    # Skip this test on CoreService since it is not implemented yet
+    skip_if_core_service(modeler, test_issue_1184_sphere_creation_crashes.__name__, "create_sphere")
 
     design = modeler.create_design("SphereCreationIssue")
 

--- a/tests/integration/test_measurement_tools.py
+++ b/tests/integration/test_measurement_tools.py
@@ -25,7 +25,7 @@ from ansys.geometry.core.misc.measurements import Distance
 from ansys.geometry.core.modeler import Modeler
 from ansys.geometry.core.tools.measurement_tools import Gap
 
-from .conftest import FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, skip_if_core_service
 
 
 def test_distance_property(modeler: Modeler):
@@ -36,9 +36,9 @@ def test_distance_property(modeler: Modeler):
 
 def test_min_distance_between_objects(modeler: Modeler):
     """Test if split edge problem areas are detectable."""
-    skip_if_linux(
+    skip_if_core_service(
         modeler, test_min_distance_between_objects.__name__, "measurement_tools"
-    )  # Skip test on Linux
+    )  # Skip test on CoreService
     design = modeler.open_file(FILES_DIR / "MixingTank.scdocx")
     gap = modeler.measurement_tools.min_distance_between_objects(design.bodies[2], design.bodies[1])
     assert abs(gap.distance._value - 0.0892) <= 0.01

--- a/tests/integration/test_prepare_tools.py
+++ b/tests/integration/test_prepare_tools.py
@@ -23,7 +23,7 @@
 
 from ansys.geometry.core.modeler import Modeler
 
-from .conftest import FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, skip_if_core_service
 
 
 def test_volume_extract_from_faces(modeler: Modeler):
@@ -53,7 +53,8 @@ def test_volume_extract_from_edge_loops(modeler: Modeler):
 
 def test_share_topology(modeler: Modeler):
     """Test share topology operation is between two bodies."""
-    skip_if_linux(modeler, test_share_topology.__name__, "prepare_tools")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_share_topology.__name__, "prepare_tools")
     design = modeler.open_file(FILES_DIR / "MixingTank.scdocx")
 
     assert modeler.prepare_tools.share_topology(design.bodies)

--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -23,7 +23,7 @@
 
 from ansys.geometry.core.modeler import Modeler
 
-from .conftest import FILES_DIR, skip_if_linux
+from .conftest import FILES_DIR, skip_if_core_service
 
 
 def test_find_split_edges(modeler: Modeler):
@@ -183,7 +183,8 @@ def test_fix_duplicate_face(modeler: Modeler):
 
 def test_find_small_faces(modeler: Modeler):
     """Test to read geometry and find it's small face problem areas."""
-    skip_if_linux(modeler, test_find_small_faces.__name__, "repair_tools")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_find_small_faces.__name__, "repair_tools")
     design = modeler.open_file(FILES_DIR / "SmallFacesBefore.scdocx")
     problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert len(problem_areas) == 4
@@ -191,7 +192,8 @@ def test_find_small_faces(modeler: Modeler):
 
 def test_find_small_face_id(modeler: Modeler):
     """Test whether problem area has the id."""
-    skip_if_linux(modeler, test_find_small_face_id.__name__, "repair_tools")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_find_small_face_id.__name__, "repair_tools")
     design = modeler.open_file(FILES_DIR / "SmallFacesBefore.scdocx")
     problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert problem_areas[0].id != "0"
@@ -201,9 +203,9 @@ def test_find_small_face_faces(modeler: Modeler):
     """Test to read geometry, find it's small face problem area and return
     connected faces.
     """
-    skip_if_linux(
+    skip_if_core_service(
         modeler, test_find_small_face_faces.__name__, "repair_tools"
-    )  # Skip test on Linux
+    )  # Skip test on CoreService
     design = modeler.open_file(FILES_DIR / "SmallFacesBefore.scdocx")
     problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert len(problem_areas[0].faces) > 0
@@ -211,7 +213,8 @@ def test_find_small_face_faces(modeler: Modeler):
 
 def test_fix_small_face(modeler: Modeler):
     """Test to read geometry and find and fix it's small face problem areas."""
-    skip_if_linux(modeler, test_fix_small_face.__name__, "repair_tools")  # Skip test on Linux
+    # Skip test on CoreService
+    skip_if_core_service(modeler, test_fix_small_face.__name__, "repair_tools")
     design = modeler.open_file(FILES_DIR / "SmallFacesBefore.scdocx")
     problem_areas = modeler.repair_tools.find_small_faces(design.bodies)
     assert problem_areas[0].fix().success is True

--- a/tests/integration/test_runscript.py
+++ b/tests/integration/test_runscript.py
@@ -30,13 +30,13 @@ from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.math.point import Point2D
 from ansys.geometry.core.sketch import Sketch
 
-from .conftest import DSCOSCRIPTS_FILES_DIR, skip_if_linux
+from .conftest import DSCOSCRIPTS_FILES_DIR, skip_if_core_service
 
 
 # Python (.py)
 def test_python_simple_script(modeler: Modeler):
-    # Skip on Linux
-    skip_if_linux(modeler, test_python_simple_script.__name__, "run_discovery_script_file")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_python_simple_script.__name__, "run_discovery_script_file")
 
     result = modeler.run_discovery_script_file(DSCOSCRIPTS_FILES_DIR / "simple_script.py")
     pattern_db = re.compile(r"SpaceClaim\.Api\.[A-Za-z0-9]+\.DesignBody", re.IGNORECASE)
@@ -49,8 +49,8 @@ def test_python_simple_script(modeler: Modeler):
 def test_python_simple_script_ignore_api_version(
     modeler: Modeler, caplog: pytest.LogCaptureFixture
 ):
-    # Skip on Linux
-    skip_if_linux(
+    # Skip on CoreService
+    skip_if_core_service(
         modeler, test_python_simple_script_ignore_api_version.__name__, "run_discovery_script_file"
     )
 
@@ -73,15 +73,17 @@ def test_python_simple_script_ignore_api_version(
 
 
 def test_python_failing_script(modeler: Modeler):
-    # Skip on Linux
-    skip_if_linux(modeler, test_python_failing_script.__name__, "run_discovery_script_file")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_python_failing_script.__name__, "run_discovery_script_file")
     with pytest.raises(GeometryRuntimeError):
         modeler.run_discovery_script_file(DSCOSCRIPTS_FILES_DIR / "failing_script.py")
 
 
 def test_python_integrated_script(modeler: Modeler):
-    # Skip on Linux
-    skip_if_linux(modeler, test_python_integrated_script.__name__, "run_discovery_script_file")
+    # Skip on CoreService
+    skip_if_core_service(
+        modeler, test_python_integrated_script.__name__, "run_discovery_script_file"
+    )
 
     # Tests the workflow of creating a design in PyAnsys Geometry, modifying it with a script,
     # and continuing to use it in PyAnsys Geometry
@@ -103,8 +105,8 @@ def test_python_integrated_script(modeler: Modeler):
 
 # SpaceClaim (.scscript)
 def test_scscript_simple_script(modeler: Modeler):
-    # Skip on Linux
-    skip_if_linux(modeler, test_scscript_simple_script.__name__, "run_discovery_script_file")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_scscript_simple_script.__name__, "run_discovery_script_file")
 
     result = modeler.run_discovery_script_file(DSCOSCRIPTS_FILES_DIR / "simple_script.scscript")
     assert len(result) == 2
@@ -117,8 +119,8 @@ def test_scscript_simple_script(modeler: Modeler):
 
 # Discovery (.dscript)
 def test_dscript_simple_script(modeler: Modeler):
-    # Skip on Linux
-    skip_if_linux(modeler, test_dscript_simple_script.__name__, "run_discovery_script_file")
+    # Skip on CoreService
+    skip_if_core_service(modeler, test_dscript_simple_script.__name__, "run_discovery_script_file")
 
     result = modeler.run_discovery_script_file(DSCOSCRIPTS_FILES_DIR / "simple_script.dscript")
     assert len(result) == 2

--- a/tests/integration/test_tessellation.py
+++ b/tests/integration/test_tessellation.py
@@ -69,7 +69,7 @@ def test_body_tessellate(modeler: Modeler):
     blocks_2 = body_2.tessellate()
     assert "MultiBlock" in str(blocks_2)
     assert blocks_2.n_blocks == 3
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         assert blocks_2.bounds == pytest.approx(
             [0.019999999999999997, 0.04, 0.020151922469877917, 0.03984807753012208, 0.0, 0.03],
             rel=1e-6,
@@ -86,7 +86,7 @@ def test_body_tessellate(modeler: Modeler):
 
     # Tessellate the body merging the individual faces
     mesh_2 = body_2.tessellate(merge=True)
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         assert "PolyData" in str(mesh_2)
         assert mesh_2.n_cells == 72
         assert mesh_2.n_points == 76

--- a/tests/integration/test_trimmed_geometry.py
+++ b/tests/integration/test_trimmed_geometry.py
@@ -87,7 +87,7 @@ def create_hedgehog(modeler: Modeler):
                 create_sketch_line(design, p1, p2)
                 current_gap += 1
     # Add isoparametric curves, not on linux
-    if modeler.client.backend_type != BackendType.LINUX_SERVICE:
+    if not BackendType.is_core_service(modeler.client.backend_type):
         param = 0.20
         while param <= 1:
             for face in body.faces:


### PR DESCRIPTION
## Description
Implement the 3 new backend types: Discovery Headless, CoreService on Linux and CoreService on Windows
Implement a method to determine whether the backend if of CoreService Kind
Rename skip_if_linux method skip_if_core_service
adapt comments

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
