### PR TITLE
chore: remove towncrier info duplicates

### DIFF
--- a/doc/changelog.d/1702.maintenance.md
+++ b/doc/changelog.d/1702.maintenance.md
@@ -1,0 +1,1 @@
+remove towncrier info duplicates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,16 +211,6 @@ name = "Miscellaneous"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "documentation"
-name = "Documentation"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "maintenance"
-name = "Maintenance"
-showcontent = true
-
-[[tool.towncrier.type]]
 directory = "test"
 name = "Test"
 showcontent = true


### PR DESCRIPTION
## Description

Information associated to changes of type 'documentation' and 'maintenance' is duplicated.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
