### PR TITLE
fix: use sketch plane for imprint/project curves

### DIFF
--- a/doc/changelog.d/1715.fixed.md
+++ b/doc/changelog.d/1715.fixed.md
@@ -1,0 +1,1 @@
+use sketch plane for imprint/project curves

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -1568,6 +1568,7 @@ class Body(IBody):
                 body=self._id,
                 curves=sketch_shapes_to_grpc_geometries(sketch._plane, sketch.edges, sketch.faces),
                 faces=[face._id for face in faces],
+                plane=plane_to_grpc_plane(sketch.plane),
             )
         )
 
@@ -1613,6 +1614,7 @@ class Body(IBody):
                 curves=curves,
                 direction=unit_vector_to_grpc_direction(direction),
                 closest_face=closest_face,
+                plane=plane_to_grpc_plane(sketch.plane),
             )
         )
 
@@ -1649,6 +1651,7 @@ class Body(IBody):
                 curves=curves,
                 direction=unit_vector_to_grpc_direction(direction),
                 closest_face=closest_face,
+                plane=plane_to_grpc_plane(sketch.plane),
             )
         )
 


### PR DESCRIPTION
## Description
Previously the plane for curves to imprint or project was hardcoded as XY on the backend. I changed this to supply it from the sketch.

## Issue linked
#1622 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
