### PR TITLE
feat: launch core service from envar

### DIFF
--- a/doc/changelog.d/1714.fixed.md
+++ b/doc/changelog.d/1714.fixed.md
@@ -1,0 +1,1 @@
+support body mirror on linux

--- a/doc/source/getting_started/local/index.rst
+++ b/doc/source/getting_started/local/index.rst
@@ -35,6 +35,8 @@ either Discovery, SpaceClaim, or the Geometry service.
 
           modeler = launch_modeler_with_geometry_service()
 
+When launching via Geometry Service, if you have a custom local install, you can define the path of this install
+in the ANSYS_GEOMETRY_SERVICE_ROOT environment variable. The launcher will use this location by default.
 
 For more information on the arguments accepted by the launcher methods, see
 their API documentation:

--- a/doc/source/getting_started/local/index.rst
+++ b/doc/source/getting_started/local/index.rst
@@ -38,6 +38,24 @@ either Discovery, SpaceClaim, or the Geometry service.
 When launching via Geometry Service, if you have a custom local install, you can define the path of this install
 in the ANSYS_GEOMETRY_SERVICE_ROOT environment variable. The launcher will use this location by default.
 
+.. tab-set::
+
+   .. tab-item:: Powershell
+
+      .. code-block:: pwsh
+
+            $env:ANSYS_GEOMETRY_SERVICE_ROOT="C:\Program Files\ANSYS Inc\v252\GeometryService"
+            # or
+            $env:ANSYS_GEOMETRY_SERVICE_ROOT="C:\myCustomPath\CoreGeometryService"
+
+   .. tab-item:: Windows CMD
+
+      .. code-block:: bash
+
+            SET ANSYS_GEOMETRY_SERVICE_ROOT="C:\Program Files\ANSYS Inc\v252\GeometryService"
+            # or
+            SET ANSYS_GEOMETRY_SERVICE_ROOT="C:\myCustomPath\CoreGeometryService"
+
 For more information on the arguments accepted by the launcher methods, see
 their API documentation:
 

--- a/doc/source/getting_started/local/index.rst
+++ b/doc/source/getting_started/local/index.rst
@@ -36,7 +36,7 @@ either Discovery, SpaceClaim, or the Geometry service.
           modeler = launch_modeler_with_geometry_service()
 
 When launching via Geometry Service, if you have a custom local install, you can define the path of this install
-in the ANSYS_GEOMETRY_SERVICE_ROOT environment variable. The launcher will use this location by default.
+in the ANSYS_GEOMETRY_SERVICE_ROOT environment variable. In that case, the launcher uses this location by default.
 
 .. tab-set::
 

--- a/doc/source/getting_started/local/index.rst
+++ b/doc/source/getting_started/local/index.rst
@@ -56,6 +56,13 @@ in the ANSYS_GEOMETRY_SERVICE_ROOT environment variable. The launcher will use t
             # or
             SET ANSYS_GEOMETRY_SERVICE_ROOT="C:\myCustomPath\CoreGeometryService"
 
+   .. tab-item:: Linux
+
+      .. code-block:: bash
+
+            export ANSYS_GEOMETRY_SERVICE_ROOT=/my_path/to/core_geometry_service
+
+
 For more information on the arguments accepted by the launcher methods, see
 their API documentation:
 

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -142,6 +142,8 @@ BACKEND_SPLASH_OFF = "/Splash=False"
 To be used only with Ansys Discovery and Ansys SpaceClaim.
 """
 
+ANSYS_GEOMETRY_SERVICE_ROOT = "ANSYS_GEOMETRY_SERVICE_ROOT"
+
 
 class ProductInstance:
     """``ProductInstance`` class.
@@ -301,7 +303,7 @@ def prepare_and_start_backend(
         product_version = get_latest_ansys_installation()[0]
 
     # Verify that the minimum version is installed.
-    if os.getenv("ANS_CORE_SERVICE_DIR") is None:
+    if os.getenv(ANSYS_GEOMETRY_SERVICE_ROOT) is None:
         _check_minimal_versions(product_version, specific_minimum_version)
 
     if server_logs_folder is not None:
@@ -358,17 +360,23 @@ def prepare_and_start_backend(
             )
 
     elif backend_type == BackendType.WINDOWS_SERVICE:
+        root_service_folder = os.getenv(ANSYS_GEOMETRY_SERVICE_ROOT)
+        if root_service_folder is None:
+            root_service_folder = Path(
+                installations[product_version], WINDOWS_GEOMETRY_SERVICE_FOLDER
+            )
+        else:
+            root_service_folder = Path(root_service_folder)
         args.append(
             Path(
-                installations[product_version],
-                WINDOWS_GEOMETRY_SERVICE_FOLDER,
+                root_service_folder,
                 GEOMETRY_SERVICE_EXE,
             )
         )
     # This should be modified to Windows Core Service in the future
     elif BackendType.is_core_service(backend_type):
         # Define several Ansys Geometry Core Service folders needed
-        root_service_folder = os.getenv("ANS_CORE_SERVICE_DIR")
+        root_service_folder = os.getenv(ANSYS_GEOMETRY_SERVICE_ROOT)
         if root_service_folder is None:
             root_service_folder = Path(installations[product_version], CORE_GEOMETRY_SERVICE_FOLDER)
         else:

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -143,6 +143,7 @@ To be used only with Ansys Discovery and Ansys SpaceClaim.
 """
 
 ANSYS_GEOMETRY_SERVICE_ROOT = "ANSYS_GEOMETRY_SERVICE_ROOT"
+"""Local Geometry Service install location. This is for GeometryService and CoreGeometryService."""
 
 
 class ProductInstance:

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -301,7 +301,8 @@ def prepare_and_start_backend(
         product_version = get_latest_ansys_installation()[0]
 
     # Verify that the minimum version is installed.
-    _check_minimal_versions(product_version, specific_minimum_version)
+    if os.getenv("ANS_CORE_SERVICE_DIR") is None:
+        _check_minimal_versions(product_version, specific_minimum_version)
 
     if server_logs_folder is not None:
         # Verify that the user has write permissions to the folder and that it exists.
@@ -367,7 +368,9 @@ def prepare_and_start_backend(
     # This should be modified to Windows Core Service in the future
     elif BackendType.is_core_service(backend_type):
         # Define several Ansys Geometry Core Service folders needed
-        root_service_folder = Path(installations[product_version], CORE_GEOMETRY_SERVICE_FOLDER)
+        root_service_folder = Path(os.getenv("ANS_CORE_SERVICE_DIR"))
+        if root_service_folder is None:
+            root_service_folder = Path(installations[product_version], CORE_GEOMETRY_SERVICE_FOLDER)
         native_folder = root_service_folder / "Native"
         cad_integration_folder = root_service_folder / "CADIntegration"
         schema_folder = root_service_folder / "Schema"
@@ -395,8 +398,7 @@ def prepare_and_start_backend(
             # For Windows, we need to use the exe file to launch the Core Geometry Service
             args.append(
                 Path(
-                    installations[product_version],
-                    CORE_GEOMETRY_SERVICE_FOLDER,
+                    root_service_folder,
                     CORE_GEOMETRY_SERVICE_EXE,
                 )
             )
@@ -431,8 +433,7 @@ def prepare_and_start_backend(
             args.append("dotnet")
             args.append(
                 Path(
-                    installations[product_version],
-                    CORE_GEOMETRY_SERVICE_FOLDER,
+                    root_service_folder,
                     CORE_GEOMETRY_SERVICE_EXE.replace(".exe", ".dll"),
                 )
             )

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -368,9 +368,11 @@ def prepare_and_start_backend(
     # This should be modified to Windows Core Service in the future
     elif BackendType.is_core_service(backend_type):
         # Define several Ansys Geometry Core Service folders needed
-        root_service_folder = Path(os.getenv("ANS_CORE_SERVICE_DIR"))
+        root_service_folder = os.getenv("ANS_CORE_SERVICE_DIR")
         if root_service_folder is None:
             root_service_folder = Path(installations[product_version], CORE_GEOMETRY_SERVICE_FOLDER)
+        else:
+            root_service_folder = Path(root_service_folder)
         native_folder = root_service_folder / "Native"
         cad_integration_folder = root_service_folder / "CADIntegration"
         schema_folder = root_service_folder / "Schema"

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -2297,9 +2297,6 @@ def test_sphere_creation(modeler: Modeler):
 
 def test_body_mirror(modeler: Modeler):
     """Test the mirroring of a body."""
-    # Skip test on CoreService
-    skip_if_core_service(modeler, test_body_mirror.__name__, "mirror")
-
     design = modeler.create_design("Design1")
 
     # Create shape with no lines of symmetry in any axis


### PR DESCRIPTION
## Description
Allow the option to define ANSYS_GEOMETRY_SERVICE_ROOT envar to provide path to CoreService executable instead of assuming the unified install.

## Issue linked


## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
