### PR TITLE
ci: keep simba-plugin-geometry tag

### DIFF
--- a/.github/workflows/docker_cleanup.yml
+++ b/.github/workflows/docker_cleanup.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         package-name: 'geometry'
         token: ${{ secrets.GITHUB_TOKEN }}
-        tags-kept: 'windows-latest, windows-latest-unstable, core-windows-latest, core-windows-latest-unstable, core-linux-latest, core-linux-latest-unstable, 24.1, 24.2, 25.1, windows-24.1, windows-24.2, windows-25.1, windows-25.2, core-windows-25.2, core-linux-25.2'
+        tags-kept: 'windows-latest, windows-latest-unstable, core-windows-latest, core-windows-latest-unstable, core-linux-latest, core-linux-latest-unstable, 24.1, 24.2, 25.1, windows-24.1, windows-24.2, windows-25.1, windows-25.2, core-windows-25.2, core-linux-25.2, simba-plugin-geometry'

--- a/doc/changelog.d/1739.maintenance.md
+++ b/doc/changelog.d/1739.maintenance.md
@@ -1,0 +1,1 @@
+keep simba-plugin-geometry tag


### PR DESCRIPTION
Keeping whatever image the Simba team is using internally.