### PR TITLE
feat: conservative approach to single design per modeler

### DIFF
--- a/doc/changelog.d/1740.added.md
+++ b/doc/changelog.d/1740.added.md
@@ -1,0 +1,1 @@
+conservative approach to single design per modeler

--- a/src/ansys/geometry/core/__init__.py
+++ b/src/ansys/geometry/core/__init__.py
@@ -55,11 +55,17 @@ USE_SERVICE_COLORS: bool = False
 """Global constant for checking whether to use service colors for plotting
 purposes. If set to False, the default colors will be used (speed gain)."""
 
-DISABLE_MULTIPLE_DESIGN_CHECK: bool = False
+# TODO: This is a deprecated constant. Not used in the codebase.
+# Left here for backwards compatibility (with older versions of the codebase).
+# https://github.com/ansys/pyansys-geometry/issues/1319
+DISABLE_MULTIPLE_DESIGN_CHECK: bool = True
+"""Deprecated constant. Use ``DISABLE_ACTIVE_DESIGN_CHECK`` instead."""
+
+DISABLE_ACTIVE_DESIGN_CHECK: bool = False
 """Global constant for disabling the ``ensure_design_is_active`` check.
 
 Only set this to false if you are sure you want to disable this check
-and you will ONLY be working with one design.
+and your objects will always exist on the server side.
 """
 
 DOCUMENTATION_BUILD: bool = os.environ.get("PYANSYS_GEOMETRY_DOC_BUILD", "false").lower() == "true"

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -29,6 +29,7 @@ from typing import Optional
 import warnings
 
 from ansys.geometry.core.errors import protect_grpc
+from ansys.geometry.core.misc.checks import deprecated_method
 
 # TODO: Remove this context and filter once the protobuf UserWarning issue is downgraded to INFO
 # https://github.com/grpc/grpc/issues/37609
@@ -224,18 +225,6 @@ class GrpcClient:
 
         # Store the backend type
         self._backend_type = backend_type
-        self._multiple_designs_allowed = (
-            False
-            if backend_type
-            in (
-                BackendType.DISCOVERY,
-                BackendType.LINUX_SERVICE,
-                BackendType.CORE_LINUX,
-                BackendType.CORE_WINDOWS,
-                BackendType.DISCOVERY_HEADLESS,
-            )
-            else True
-        )
 
         # retrieve the backend version
         if hasattr(grpc_backend_response, "version"):
@@ -277,15 +266,18 @@ class GrpcClient:
         return self._backend_version
 
     @property
+    @deprecated_method(info="Multiple designs for the same service are no longer supported.")
     def multiple_designs_allowed(self) -> bool:
         """Flag indicating whether multiple designs are allowed.
 
+        Deprecated since version 0.8.X.
+
         Notes
         -----
-        This method will return ``False`` if the backend type is ``Discovery`` or
-        ``Linux Service``. Otherwise, it will return ``True``.
+        Currently, only one design is allowed per service. This method will always
+        return ``False``.
         """
-        return self._multiple_designs_allowed
+        return False
 
     @property
     def channel(self) -> grpc.Channel:

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -143,7 +143,6 @@ class Design(Component):
         self._beam_profiles = {}
         self._design_id = ""
         self._is_active = False
-        self._is_closed = False
         self._modeler = modeler
 
         # Check whether we want to process an existing design or create a new one.
@@ -189,13 +188,13 @@ class Design(Component):
 
     @property
     def is_closed(self) -> bool:
-        """Whether the design is closed."""
-        return self._is_closed
+        """Whether the design is closed (i.e. not active)."""
+        return not self._is_active
 
     def close(self) -> None:
         """Close the design."""
         # Check if the design is already closed
-        if self._is_closed:
+        if self.is_closed:
             self._grpc_client.log.warning(f"Design {self.name} is already closed.")
             return
 
@@ -207,15 +206,11 @@ class Design(Component):
             self._grpc_client.log.warning("Ignoring response and assuming the design is closed.")
 
         # Consider the design closed (even if the close request failed)
-        self._is_closed = True
+        self._is_active = False
 
     @protect_grpc
     def _activate(self, called_after_design_creation: bool = False) -> None:
         """Activate the design."""
-        # Deactivate all designs first
-        for design in self._modeler._designs.values():
-            design._is_active = False
-
         # Activate the current design
         if not called_after_design_creation:
             self._design_stub.PutActive(EntityIdentifier(id=self._design_id))
@@ -1199,13 +1194,5 @@ class Design(Component):
         self._named_selections = {}
         self._coordinate_systems = {}
 
-        # Get the previous design id
-        previous_design_id = self._design_id
-
         # Read the existing design
         self.__read_existing_design()
-
-        # If the design id has changed, update the design id in the Modeler
-        if previous_design_id != self._design_id:
-            self._modeler._designs[self._design_id] = self
-            self._modeler._designs.pop(previous_design_id)

--- a/src/ansys/geometry/core/misc/checks.py
+++ b/src/ansys/geometry/core/misc/checks.py
@@ -45,7 +45,7 @@ def ensure_design_is_active(method):
         import ansys.geometry.core as pyansys_geometry
         from ansys.geometry.core.errors import GeometryRuntimeError
 
-        if pyansys_geometry.DISABLE_MULTIPLE_DESIGN_CHECK:
+        if pyansys_geometry.DISABLE_ACTIVE_DESIGN_CHECK:
             # If the user has disabled the check, then we can skip it
             return method(self, *args, **kwargs)
 
@@ -72,17 +72,6 @@ def ensure_design_is_active(method):
             raise GeometryRuntimeError(
                 "The design has been closed on the backend. Cannot perform any operations on it."
             )
-
-        # Activate the design if it is not active
-        if not design.is_active:
-            # First, check the backend allows for multiple documents
-            if not design._grpc_client.multiple_designs_allowed:
-                raise GeometryRuntimeError(
-                    "The design is not active and multiple designs are "
-                    "not allowed with the current backend."
-                )
-            else:
-                design._activate()
 
         # Finally, call method
         return method(self, *args, **kwargs)

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -37,8 +37,7 @@ from ansys.geometry.core.connection.backend import ApiVersions, BackendType
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.defaults import DEFAULT_HOST, DEFAULT_PORT
 from ansys.geometry.core.errors import GeometryRuntimeError, protect_grpc
-from ansys.geometry.core.logger import LOG
-from ansys.geometry.core.misc.checks import check_type, min_backend_version
+from ansys.geometry.core.misc.checks import check_type, deprecated_method, min_backend_version
 from ansys.geometry.core.misc.options import ImportOptions
 from ansys.geometry.core.tools.measurement_tools import MeasurementTools
 from ansys.geometry.core.tools.prepare_tools import PrepareTools
@@ -120,15 +119,15 @@ class Modeler:
             backend_type=backend_type,
         )
 
-        # Maintaining references to all designs within the modeler workspace
-        self._designs: dict[str, "Design"] = {}
+        # Single design for the Modeler
+        self._design: Optional["Design"] = None
 
         # Initialize the RepairTools - Not available on Linux
         # TODO: delete "if" when Linux service is able to use repair tools
         # https://github.com/ansys/pyansys-geometry/issues/1319
         if BackendType.is_core_service(self.client.backend_type):
             self._measurement_tools = None
-            LOG.warning("CoreService backend does not support measurement tools.")
+            self.client.log.warning("CoreService backend does not support measurement tools.")
         else:
             self._measurement_tools = MeasurementTools(self._grpc_client)
 
@@ -138,28 +137,26 @@ class Modeler:
         self._geometry_commands = GeometryCommands(self._grpc_client)
         self._unsupported = UnsupportedCommands(self._grpc_client, self)
 
-        # Check if the backend allows for multiple designs and throw warning if needed
-        if not self.client.multiple_designs_allowed:
-            LOG.warning(
-                "Linux and Ansys Discovery backends do not support multiple "
-                "designs open in the same session. Only the last design created "
-                "will be available to perform modeling operations."
-            )
-
     @property
     def client(self) -> GrpcClient:
         """``Modeler`` instance client."""
         return self._grpc_client
 
     @property
+    def design(self) -> "Design":
+        """Retrieve the design within the modeler workspace."""
+        return self._design
+
+    @property
+    @deprecated_method(alternative="design")
     def designs(self) -> dict[str, "Design"]:
-        """All designs within the modeler workspace.
+        """Retrieve the design within the modeler workspace.
 
         Notes
         -----
-        This property is read-only. **DO NOT** modify the dictionary.
+        This method is deprecated. Use the :func:`design` property instead.
         """
-        return self._designs
+        return {self._design.id: self._design}
 
     def create_design(self, name: str) -> "Design":
         """Initialize a new design with the connected client.
@@ -177,14 +174,20 @@ class Modeler:
         from ansys.geometry.core.designer.design import Design
 
         check_type(name, str)
+
+        # If a previous design was available... inform the user that it will be deleted
+        # when creating a new design.
+        if self._design is not None and self._design.is_active:
+            self.client.log.warning("Closing previous design before creating a new one.")
+            self._design.close()
+
+        # Create the new design
         design = Design(name, self)
-        self._designs[design.design_id] = design
-        if len(self._designs) > 1:
-            LOG.warning(
-                "Some backends only support one design. "
-                + "Previous designs may be deleted (on the service) when creating a new one."
-            )
-        return self._designs[design.design_id]
+
+        # Update the design stored in the modeler
+        self._design = design
+
+        return self._design
 
     def get_active_design(self, sync_with_backend: bool = True) -> "Design":
         """Get the active design on the modeler object.
@@ -201,14 +204,13 @@ class Modeler:
         Design
             Design object already existing on the modeler.
         """
-        for _, design in self._designs.items():
-            if design._is_active:
-                # Check if sync_with_backend is requested
-                if sync_with_backend:
-                    design._update_design_inplace()
-
-                # Return the active design
-                return design
+        if self._design is not None and self._design.is_active:
+            # Check if sync_with_backend is requested
+            if sync_with_backend:
+                self._design._update_design_inplace()
+            return self._design
+        else:
+            self.client.log.warning("No active design available.")
 
         return None
 
@@ -222,43 +224,45 @@ class Modeler:
         """
         from ansys.geometry.core.designer.design import Design
 
-        design = Design("", self, read_existing_design=True)
-        self._designs[design.design_id] = design
-        if len(self._designs) > 1:
-            LOG.warning(
-                "Some backends only support one design. "
-                + "Previous designs may be deleted (on the service) when reading a new one."
-            )
-        return self._designs[design.design_id]
+        # Simply deactivate the existing design in case it is active...
+        # - If it is the same design, it will be re-read (but we should not close it on the server)
+        # - If it is a different design, it was closed previously (via open_file or create_design)
+        if self._design is not None and self._design.is_active:
+            self._design._is_active = False
 
-    def close(self, close_designs: bool = True) -> None:
+        self._design = Design("", self, read_existing_design=True)
+
+        return self._design
+
+    def close(self, close_design: bool = True) -> None:
         """Access the client's close method.
 
         Parameters
         ----------
-        close_designs : bool, default: True
-            Whether to close all designs before closing the client.
+        close_design : bool, default: True
+            Whether to close the design before closing the client.
         """
-        # Close all designs (if requested)
-        [design.close() for design in self._designs.values() if close_designs]
+        # Close design (if requested)
+        if close_design and self._design is not None:
+            self._design.close()
 
         # Close the client
         self.client.close()
 
-    def exit(self, close_designs: bool = True) -> None:
+    def exit(self, close_design: bool = True) -> None:
         """Access the client's close method.
 
         Parameters
         ----------
-        close_designs : bool, default: True
-            Whether to close all designs before closing the client.
+        close_design : bool, default: True
+            Whether to close the design before closing the client.
 
         Notes
         -----
         This method is calling the same method as
         :func:`close() <ansys.geometry.core.modeler.Modeler.close>`.
         """
-        self.close(close_designs=close_designs)
+        self.close(close_design=close_design)
 
     def _upload_file(
         self,
@@ -301,7 +305,7 @@ class Modeler:
         with fp_path.open(mode="rb") as file:
             data = file.read()
 
-        c_stub = CommandsStub(self._grpc_client.channel)
+        c_stub = CommandsStub(self.client.channel)
 
         response = c_stub.UploadFile(
             UploadFileRequest(
@@ -348,6 +352,10 @@ class Modeler:
         # Use str format of Path object here
         file_path = str(file_path) if isinstance(file_path, Path) else file_path
 
+        # Close the existing design if it is active
+        if self._design is not None and self._design.is_active:
+            self._design.close()
+
         # Format-specific logic - upload the whole containing folder for assemblies
         if upload_to_server:
             if any(
@@ -361,7 +369,7 @@ class Modeler:
                         self._upload_file(full_path)
             self._upload_file(file_path, True, import_options)
         else:
-            DesignsStub(self._grpc_client.channel).Open(
+            DesignsStub(self.client.channel).Open(
                 OpenRequest(filepath=file_path, import_options=import_options.to_dict())
             )
 
@@ -372,7 +380,7 @@ class Modeler:
         lines = []
         lines.append(f"Ansys Geometry Modeler ({hex(id(self))})")
         lines.append("")
-        lines.append(str(self._grpc_client))
+        lines.append(str(self.client))
         return "\n".join(lines)
 
     @protect_grpc
@@ -468,7 +476,7 @@ class Modeler:
                 api_version = ApiVersions.parse_input(api_version)
 
         serv_path = self._upload_file(file_path)
-        ga_stub = DbuApplicationStub(self._grpc_client.channel)
+        ga_stub = DbuApplicationStub(self.client.channel)
         request = RunScriptFileRequest(
             script_path=serv_path,
             script_args=script_args,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -161,11 +161,9 @@ def modeler(session_modeler: Modeler):
     # Yield the modeler
     yield session_modeler
 
-    # Cleanup on exit
-    [design.close() for design in session_modeler.designs.values()]
-
-    # Empty the designs dictionary
-    session_modeler._designs = {}
+    # Cleanup on exit (if design exists)
+    if session_modeler.design:
+        session_modeler.design.close()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1986,18 +1986,13 @@ def test_child_component_instances(modeler: Modeler):
 
 
 def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
-    """Generate multiple designs, make sure they are all separate, and activate
-    them when needed.
+    """Generate multiple designs, make sure they are all separate, and once
+    a design is deactivated, the next one is activated.
     """
-    # Check backend first
-    if modeler.client.backend_type in (
-        BackendType.SPACECLAIM,
-        BackendType.WINDOWS_SERVICE,
-    ):
-        pass
-    else:
-        # Test is only available for DMS and SpaceClaim
-        pytest.skip("Test only available on DMS and SpaceClaim")
+    # Initiate expected output images
+    scshot_dir = tmp_path_factory.mktemp("test_multiple_designs")
+    scshot_1 = scshot_dir / "design1.png"
+    scshot_2 = scshot_dir / "design2.png"
 
     # Create your design on the server side
     design1 = modeler.create_design("Design1")
@@ -2009,6 +2004,9 @@ def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFac
     # Extrude the sketch to create a body
     design1.extrude_sketch("MySlot", sketch1, Quantity(10, UNITS.mm))
 
+    # Request plotting and store images
+    design1.plot(screenshot=scshot_1)
+
     # Create a second design
     design2 = modeler.create_design("Design2")
 
@@ -2019,14 +2017,8 @@ def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFac
     # Extrude the sketch to create a body
     design2.extrude_sketch("MyRectangle", sketch2, Quantity(10, UNITS.mm))
 
-    # Initiate expected output images
-    scshot_dir = tmp_path_factory.mktemp("test_multiple_designs")
-    scshot_1 = scshot_dir / "design1.png"
-    scshot_2 = scshot_dir / "design2.png"
-
     # Request plotting and store images
-    design2.plot(screenshot=scshot_1)
-    design1.plot(screenshot=scshot_2)
+    design2.plot(screenshot=scshot_2)
 
     # Check that the images are different
     assert scshot_1.exists()
@@ -2034,13 +2026,9 @@ def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFac
     err = pv_compare_images(str(scshot_1), str(scshot_2))
     assert not err < 0.1
 
-    # Check that design2 is not active
-    assert not design2.is_active
-    assert design1.is_active
-
-    # Check the same thing inside the modeler
-    assert not modeler.designs[design2.design_id].is_active
-    assert modeler.designs[design1.design_id].is_active
+    # Check that design1 is not active and design2 is active
+    assert not design1.is_active
+    assert design2.is_active
 
 
 def test_get_active_design(modeler: Modeler):

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -246,6 +246,9 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     if not BackendType.is_core_service(modeler.client.backend_type):
         file_step = tmp_path_factory.mktemp("test_design_import") / "two_cars.step"
         design.download(file_step, DesignFileFormat.STEP)
+        #
+        # file_iges = tmp_path_factory.mktemp("test_design_import") / "two_cars.igs"
+        # design.download(file_iges, DesignFileFormat.IGES)
 
     design2 = modeler.open_file(file)
 
@@ -258,10 +261,7 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
         #
         # TODO: Something has gone wrong with IGES
         # https://github.com/ansys/pyansys-geometry/issues/1146
-        #
-        # file = tmp_path_factory.mktemp("test_design_import") / "two_cars.igs"
-        # design.download(file, DesignFileFormat.IGES)
-        # design2 = modeler.open_file(file)
+        # design2 = modeler.open_file(file_iges)
         # design3 = modeler.open_file(Path(IMPORT_FILES_DIR, "twoCars.igs")
         # _checker_method(design2, design3, False)
 

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -241,6 +241,12 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     file = tmp_path_factory.mktemp("test_design_import") / "two_cars.scdocx"
     design.download(str(file))
 
+    # Pre-download the STEP file for comparison... once the design is closed, the
+    # file is no longer available for download from the original design
+    if not BackendType.is_core_service(modeler.client.backend_type):
+        file_step = tmp_path_factory.mktemp("test_design_import") / "two_cars.step"
+        design.download(file_step, DesignFileFormat.STEP)
+
     design2 = modeler.open_file(file)
 
     # assert the two cars are the same, excepted for the ID, which should be different
@@ -260,9 +266,7 @@ def test_open_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
         # _checker_method(design2, design3, False)
 
         # STEP
-        file = tmp_path_factory.mktemp("test_design_import") / "two_cars.step"
-        design.download(file, DesignFileFormat.STEP)
-        design2 = modeler.open_file(file)
+        design2 = modeler.open_file(file_step)
         design3 = modeler.open_file(Path(IMPORT_FILES_DIR, "twoCars.stp"))
         _checker_method(design2, design3, False)
 

--- a/tests/integration/test_design_import.py
+++ b/tests/integration/test_design_import.py
@@ -318,7 +318,7 @@ def test_design_insert(modeler: Modeler):
 
     # Check that there are two components
     assert len(design.components) == 2
-    assert design._is_active
+    assert design.is_active is True
     assert design.components[0].name == "Component_Cylinder"
     assert design.components[1].name == "DuplicatesDesign"
 
@@ -339,6 +339,6 @@ def test_design_insert_with_import(modeler: Modeler):
 
     # Check that there are two components
     assert len(design.components) == 2
-    assert design._is_active
+    assert design.is_active is True
     assert design.components[0].name == "Component_Cylinder"
     assert design.components[1].name == "Wheel1"


### PR DESCRIPTION
## Description
A single design instance per Modeler object is handled. If a new design is requested, the old design is closed. We are also being conservative and checking that if you use an object belonging to an old design, we are still checking whether the design is active or not. With #1721 we lost this capability. This implementation makes it more robust

## Issue linked
Closes #1710

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
