### PR TITLE
fix: Linux Core Service docker file was missing a dependency

### DIFF
--- a/doc/changelog.d/1758.fixed.md
+++ b/doc/changelog.d/1758.fixed.md
@@ -1,0 +1,1 @@
+Linux Core Service docker file was missing a dependency

--- a/docker/linux/coreservice/Dockerfile
+++ b/docker/linux/coreservice/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip=6.* && \
     apt-get install -y --no-install-recommends gcc=4:12.2.* && \
     apt-get install -y --no-install-recommends mono-mcs=6.8.0.* && \
-    apt-get install -y --no-install-recommends libgfortran5=12.2.0.* && \
+    apt-get install -y --no-install-recommends libgfortran5=12.2.* && \
     rm -rf /var/lib/apt/lists/*
 
 # Add the binary files from the latest release

--- a/docker/linux/coreservice/Dockerfile
+++ b/docker/linux/coreservice/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip=6.* && \
     apt-get install -y --no-install-recommends gcc=4:12.2.* && \
     apt-get install -y --no-install-recommends mono-mcs=6.8.0.* && \
+    apt-get install -y --no-install-recommends libgfortran5=12.2.0.* && \
     rm -rf /var/lib/apt/lists/*
 
 # Add the binary files from the latest release


### PR DESCRIPTION
## Description
Issues with Linux docker image build due to missing dependency

## Issue linked
None

