### PR TITLE
fix: typo in labeler.yml file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,10 @@
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 'docs/source/**/*'
+  - any-glob-to-any-file: 'doc/source/**/*'
+  - any-glob-to-any-file: 'README.rst'
 maintenance:
 - changed-files:
   - any-glob-to-any-file: '.github/**/*'
-  - any-glob-to-any-file: '.flake8'
   - any-glob-to-any-file: 'pyproject.toml'
 testing:
 - changed-files:

--- a/doc/changelog.d/1776.fixed.md
+++ b/doc/changelog.d/1776.fixed.md
@@ -1,0 +1,1 @@
+typo in labeler.yml file


### PR DESCRIPTION
## Description
Typo in the documentation labeler

## Issue linked
-

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
