### PR TITLE
build: temporary workaround for using trusted publisher approach

### DIFF
--- a/doc/changelog.d/1783.dependencies.md
+++ b/doc/changelog.d/1783.dependencies.md
@@ -1,0 +1,1 @@
+temporary workaround for using trusted publisher approach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<3.11"]
 build-backend = "flit_core.buildapi"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<3.11"]
+requires = ["flit_core >=3.2,<3.11"] # THIS SHOULD BE REVERTED TO '["flit_core >=3.2,<4"]'
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
## Description
Following issues with trusted publisher listed in https://github.com/ansys/actions/issues/687 - we need to limit the flit version used to build the project. This is a temporary workaround until we properly fix this issue.

## Issue linked
None

