### PR TITLE
fix: flaky color test due to random face assignment

### DIFF
--- a/doc/changelog.d/1794.fixed.md
+++ b/doc/changelog.d/1794.fixed.md
@@ -1,0 +1,1 @@
+flaky color test due to random face assignment

--- a/tests/integration/test_plotter.py
+++ b/tests/integration/test_plotter.py
@@ -1038,12 +1038,17 @@ def test_plot_face_colors_from_service(modeler: Modeler, verify_image_cache):
     # Extrude the sketch to create a body
     box_body = design.extrude_sketch("JustABox", sketch, Quantity(10, UNITS.m))
     # Let's assign colors to the faces...
-    # 1) Box at large
+    faces = box_body.faces
+    # Box at large
     box_body.set_color((255, 0, 0))
-    # 2) +Z face
-    box_body.faces[1].set_color((0, 255, 0))
-    # 3) +X face
-    box_body.faces[2].set_color((0, 0, 255))
+
+    for face in faces:
+        # A) +Z face
+        if face.normal() == UNITVECTOR3D_Z:
+            face.set_color((0, 255, 0))
+        # B) +X face
+        elif face.normal() == UNITVECTOR3D_X:
+            face.set_color((0, 0, 255))
 
     box_body.plot(
         screenshot=Path(IMAGE_RESULTS_DIR, "test_plot_face_colors_from_service.png"),

--- a/tests/integration/test_plotter.py
+++ b/tests/integration/test_plotter.py
@@ -1037,16 +1037,14 @@ def test_plot_face_colors_from_service(modeler: Modeler, verify_image_cache):
 
     # Extrude the sketch to create a body
     box_body = design.extrude_sketch("JustABox", sketch, Quantity(10, UNITS.m))
-    # Let's assign colors to the faces...
-    faces = box_body.faces
-    # Box at large
+    # Box at large - Red
     box_body.set_color((255, 0, 0))
 
-    for face in faces:
-        # A) +Z face
+    for face in box_body.faces:
+        # A) +Z face - Green
         if face.normal() == UNITVECTOR3D_Z:
             face.set_color((0, 255, 0))
-        # B) +X face
+        # B) +X face - Blue
         elif face.normal() == UNITVECTOR3D_X:
             face.set_color((0, 0, 255))
 


### PR DESCRIPTION
## Description
Flaky test due to face color assignment by order on list retrieval. This fixes it by looking at the normal of the face.

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
