### PR TITLE
fix: fix parasolid export tests with more precise backend descriptor

### DIFF
--- a/src/ansys/geometry/core/connection/backend.py
+++ b/src/ansys/geometry/core/connection/backend.py
@@ -57,6 +57,25 @@ class BackendType(Enum):
             BackendType.CORE_LINUX,
         )
 
+    @staticmethod
+    def is_linux_service(backend_type: "BackendType") -> bool:
+        """Determine whether the backend is a Linux service or not.
+
+        Parameters
+        ----------
+        backend_type : BackendType
+            The backend type to check whether or not it's running on Linux.
+
+        Returns
+        -------
+        bool
+            True if the backend is running on Linux, False otherwise.
+        """
+        return backend_type in (
+            BackendType.LINUX_SERVICE,
+            BackendType.CORE_LINUX,
+        )
+
 
 class ApiVersions(Enum):
     """Provides an enum for all the compatibles API versions."""

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -504,11 +504,7 @@ class Design(Component):
             The path to the saved file.
         """
         # Determine the extension based on the backend type
-        ext = (
-            "x_t"
-            if self._grpc_client.backend_type in (BackendType.LINUX_SERVICE, BackendType.CORE_LINUX)
-            else "xmt_txt"
-        )
+        ext = "xmt_txt" if BackendType.is_linux_service(self._grpc_client.backend_type) else "x_t"
 
         # Define the file location
         file_location = self.__build_export_file_location(location, ext)
@@ -534,11 +530,7 @@ class Design(Component):
             The path to the saved file.
         """
         # Determine the extension based on the backend type
-        ext = (
-            "x_b"
-            if self._grpc_client.backend_type in (BackendType.LINUX_SERVICE, BackendType.CORE_LINUX)
-            else "xmt_bin"
-        )
+        ext = "xmt_bin" if BackendType.is_linux_service(self._grpc_client.backend_type) else "x_b"
 
         # Define the file location
         file_location = self.__build_export_file_location(location, ext)

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1016,7 +1016,7 @@ def test_download_file(modeler: Modeler, tmp_path_factory: pytest.TempPathFactor
     assert file.exists()
 
     # Check that we can also save it (even if it is not accessible on the server)
-    if modeler.client.backend_type in (BackendType.LINUX_SERVICE, BackendType.CORE_LINUX):
+    if BackendType.is_linux_service(modeler.client.backend_type):
         file_save = "/tmp/cylinder-temp.scdocx"
     else:
         file_save = tmp_path_factory.mktemp("scdoc_files_save") / "cylinder.scdocx"


### PR DESCRIPTION
Use the new precise backend type setting to determine which parasolid extension we should expect as export output

## Description
**Please provide a brief description of the changes made in this pull request.**

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
