### PR TITLE
fix: edge start and end were not being mapped correctly

### DIFF
--- a/doc/changelog.d/1816.fixed.md
+++ b/doc/changelog.d/1816.fixed.md
@@ -1,0 +1,1 @@
+edge start and end were not being mapped correctly

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -197,7 +197,10 @@ class Edge:
             # Only for versions earlier than 24.2.0 (before the introduction of the shape property)
             self._grpc_client.log.debug("Requesting edge start point from server.")
             response = self._edges_stub.GetStartAndEndPoints(self._grpc_id)
-            return Point3D([response.start.x, response.start.y, response.start.z])
+            return Point3D(
+                [response.start.x, response.start.y, response.start.z],
+                unit=DEFAULT_UNITS.SERVER_LENGTH,
+            )
 
     @property
     @protect_grpc
@@ -210,4 +213,6 @@ class Edge:
             # Only for versions earlier than 24.2.0 (before the introduction of the shape property)
             self._grpc_client.log.debug("Requesting edge end point from server.")
             response = self._edges_stub.GetStartAndEndPoints(self._grpc_id)
-            return Point3D([response.end.x, response.end.y, response.end.z])
+            return Point3D(
+                [response.end.x, response.end.y, response.end.z], unit=DEFAULT_UNITS.SERVER_LENGTH
+            )

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -127,8 +127,13 @@ class Edge:
             geometry = grpc_curve_to_curve(response)
 
             response = self._edges_stub.GetStartAndEndPoints(self._grpc_id)
-            start = Point3D([response.start.x, response.start.y, response.start.z])
-            end = Point3D([response.end.x, response.end.y, response.end.z])
+            start = Point3D(
+                [response.start.x, response.start.y, response.start.z],
+                unit=DEFAULT_UNITS.SERVER_LENGTH,
+            )
+            end = Point3D(
+                [response.end.x, response.end.y, response.end.z], unit=DEFAULT_UNITS.SERVER_LENGTH
+            )
 
             response = self._edges_stub.GetLength(self._grpc_id)
             length = Quantity(response.length, DEFAULT_UNITS.SERVER_LENGTH)

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -548,8 +548,8 @@ class Face:
         trimmed_curves = []
         for c in curves:
             geometry = grpc_curve_to_curve(c.curve)
-            start = Point3D([c.start.x, c.start.y, c.start.z])
-            end = Point3D([c.end.x, c.end.y, c.end.z])
+            start = Point3D([c.start.x, c.start.y, c.start.z], unit=DEFAULT_UNITS.SERVER_LENGTH)
+            end = Point3D([c.end.x, c.end.y, c.end.z], unit=DEFAULT_UNITS.SERVER_LENGTH)
             interval = Interval(c.interval_start, c.interval_end)
             length = Quantity(c.length, DEFAULT_UNITS.SERVER_LENGTH)
 

--- a/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
+++ b/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
@@ -29,6 +29,7 @@ from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.conversions import trimmed_curve_to_grpc_trimmed_curve
 from ansys.geometry.core.errors import protect_grpc
 from ansys.geometry.core.math.point import Point3D
+from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
 from ansys.geometry.core.shapes.curves.curve import Curve
 from ansys.geometry.core.shapes.curves.curve_evaluation import CurveEvaluation
 from ansys.geometry.core.shapes.parameterization import Interval
@@ -148,7 +149,10 @@ class TrimmedCurve:
         )
         if res.intersect is False:
             return []
-        return [Point3D([point.x, point.y, point.z]) for point in res.points]
+        return [
+            Point3D([point.x, point.y, point.z], unit=DEFAULT_UNITS.SERVER_LENGTH)
+            for point in res.points
+        ]
 
     def __repr__(self) -> str:
         """Represent the trimmed curve as a string."""


### PR DESCRIPTION
## Description
Edge start and end values were not being mapped correctly. They should be using the server length when converted.

## Issue linked
Closes #1813 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
