### PR TITLE
fix: tessellation options were not extended to component/face methods

### DIFF
--- a/doc/changelog.d/1850.fixed.md
+++ b/doc/changelog.d/1850.fixed.md
@@ -1,0 +1,1 @@
+tessellation options were not extended to component/face methods

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -568,7 +568,7 @@ class IBody(ABC):
 
     @abstractmethod
     def tessellate(
-        self, merge: bool = False, tessellation_options: TessellationOptions = None
+        self, merge: bool = False, tess_options: TessellationOptions = None
     ) -> Union["PolyData", "MultiBlock"]:
         """Tessellate the body and return the geometry as triangles.
 
@@ -578,7 +578,7 @@ class IBody(ABC):
             Whether to merge the body into a single mesh. When ``False`` (default), the
             number of triangles are preserved and only the topology is merged.
             When ``True``, the individual faces of the tessellation are merged.
-        tessellation_options : TessellationOptions, default: None
+        tess_options : TessellationOptions, default: None
             A set of options to determine the tessellation quality.
 
         Returns

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -568,7 +568,7 @@ class IBody(ABC):
 
     @abstractmethod
     def tessellate(
-        self, merge: bool = False, tess_options: TessellationOptions = None
+        self, merge: bool = False, tess_options: TessellationOptions | None = None
     ) -> Union["PolyData", "MultiBlock"]:
         """Tessellate the body and return the geometry as triangles.
 
@@ -578,7 +578,7 @@ class IBody(ABC):
             Whether to merge the body into a single mesh. When ``False`` (default), the
             number of triangles are preserved and only the topology is merged.
             When ``True``, the individual faces of the tessellation are merged.
-        tess_options : TessellationOptions, default: None
+        tess_options : TessellationOptions | None, default: None
             A set of options to determine the tessellation quality.
 
         Returns
@@ -1276,13 +1276,21 @@ class MasterBody(IBody):
         self,
         merge: bool = False,
         transform: Matrix44 = IDENTITY_MATRIX44,
-        tess_options: TessellationOptions = None,
+        tess_options: TessellationOptions | None = None,
     ) -> Union["PolyData", "MultiBlock"]:
         # lazy import here to improve initial module load time
         import pyvista as pv
 
         if not self.is_alive:
             return pv.PolyData() if merge else pv.MultiBlock()
+
+        # If the server does not support tessellation options, ignore them
+        if tess_options is not None and self._grpc_client.backend_version < (25, 2, 0):
+            self._grpc_client.log.warning(
+                "Tessellation options are not supported by server"
+                f" version {self._grpc_client.backend_version}. Ignoring options."
+            )
+            tess_options = None
 
         self._grpc_client.log.debug(f"Requesting tessellation for body {self.id}.")
 
@@ -1319,7 +1327,11 @@ class MasterBody(IBody):
                         str(face_id): tess_to_pd(face_tess)
                         for face_id, face_tess in resp.face_tessellation.items()
                     }
-                except Exception:
+                except Exception as err:
+                    # Streaming is not supported in older versions...
+                    if self._grpc_client.backend_version < (25, 2, 0):
+                        raise err
+
                     tessellation_map = {}
                     request = GetTessellationRequest(self._grpc_id)
                     for response in self._bodies_stub.GetTessellationStream(request):
@@ -1854,7 +1866,7 @@ class Body(IBody):
 
     @ensure_design_is_active
     def tessellate(  # noqa: D102
-        self, merge: bool = False, tess_options: TessellationOptions = None
+        self, merge: bool = False, tess_options: TessellationOptions | None = None
     ) -> Union["PolyData", "MultiBlock"]:
         return self._template.tessellate(
             merge, self.parent_component.get_world_transform(), tess_options

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -94,6 +94,7 @@ from ansys.geometry.core.misc.checks import (
     min_backend_version,
 )
 from ansys.geometry.core.misc.measurements import DEFAULT_UNITS, Angle, Distance
+from ansys.geometry.core.misc.options import TessellationOptions
 from ansys.geometry.core.shapes.curves.circle import Circle
 from ansys.geometry.core.shapes.curves.trimmed_curve import TrimmedCurve
 from ansys.geometry.core.shapes.parameterization import Interval, ParamUV
@@ -1608,11 +1609,15 @@ class Component:
         self._is_alive = False
 
     @graphics_required
-    def tessellate(self, _recursive_call: bool = False) -> Union["PolyData", list["MultiBlock"]]:
+    def tessellate(
+        self, tess_options: TessellationOptions = None, _recursive_call: bool = False
+    ) -> Union["PolyData", list["MultiBlock"]]:
         """Tessellate the component.
 
         Parameters
         ----------
+        tess_options : TessellationOptions, default: None
+            A set of options to determine the tessellation quality.
         _recursive_call: bool, default: False
             Internal flag to indicate if this method is being called recursively.
             Not to be used by the user.
@@ -1627,14 +1632,16 @@ class Component:
         import pyvista as pv
 
         # Tessellate the bodies in this component
-        datasets: list["MultiBlock"] = [body.tessellate(merge=False) for body in self.bodies]
+        datasets: list["MultiBlock"] = [
+            body.tessellate(merge=False, tess_options=tess_options) for body in self.bodies
+        ]
 
         # Now, go recursively inside its subcomponents (with no arguments) and
         # merge the PolyData obtained into our blocks
         for comp in self._components:
             if not comp.is_alive:
                 continue
-            datasets.extend(comp.tessellate(_recursive_call=True))
+            datasets.extend(comp.tessellate(tess_options=tess_options, _recursive_call=True))
 
         # Convert to polydata as it's slightly faster than extract surface
         # plus this method is only for visualizing the component as a whole (no

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -1610,13 +1610,13 @@ class Component:
 
     @graphics_required
     def tessellate(
-        self, tess_options: TessellationOptions = None, _recursive_call: bool = False
+        self, tess_options: TessellationOptions | None = None, _recursive_call: bool = False
     ) -> Union["PolyData", list["MultiBlock"]]:
         """Tessellate the component.
 
         Parameters
         ----------
-        tess_options : TessellationOptions, default: None
+        tess_options : TessellationOptions | None, default: None
             A set of options to determine the tessellation quality.
         _recursive_call: bool, default: False
             Internal flag to indicate if this method is being called recursively.

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -63,6 +63,7 @@ from ansys.geometry.core.misc.checks import (
     min_backend_version,
 )
 from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
+from ansys.geometry.core.misc.options import TessellationOptions
 from ansys.geometry.core.shapes.box_uv import BoxUV
 from ansys.geometry.core.shapes.curves.trimmed_curve import TrimmedCurve
 from ansys.geometry.core.shapes.parameterization import Interval
@@ -598,8 +599,18 @@ class Face:
         return result.success
 
     @graphics_required
-    def tessellate(self) -> "pv.PolyData":
+    def tessellate(self, tess_options: TessellationOptions = None) -> "pv.PolyData":
         """Tessellate the face and return the geometry as triangles.
+
+        Parameters
+        ----------
+        tess_options : TessellationOptions, default: None
+            A set of options to determine the tessellation quality.
+
+        Notes
+        -----
+        The tessellation options are ONLY used if the face has not been tessellated before.
+        If the face has been tessellated before, the stored tessellation is returned.
 
         Returns
         -------
@@ -608,7 +619,7 @@ class Face:
         """
         # If tessellation has not been called before... call it
         if self._body._template._tessellation is None:
-            self._body.tessellate()
+            self._body.tessellate(tess_options=tess_options)
 
         # Search the tessellation of the face - if it exists
         # ---> We need to used the last element of the ID since we are looking inside

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -599,12 +599,12 @@ class Face:
         return result.success
 
     @graphics_required
-    def tessellate(self, tess_options: TessellationOptions = None) -> "pv.PolyData":
+    def tessellate(self, tess_options: TessellationOptions | None = None) -> "pv.PolyData":
         """Tessellate the face and return the geometry as triangles.
 
         Parameters
         ----------
-        tess_options : TessellationOptions, default: None
+        tess_options : TessellationOptions | None, default: None
             A set of options to determine the tessellation quality.
 
         Notes

--- a/src/ansys/geometry/core/misc/__init__.py
+++ b/src/ansys/geometry/core/misc/__init__.py
@@ -49,5 +49,5 @@ from ansys.geometry.core.misc.checks import (
     run_if_graphics_required,
 )
 from ansys.geometry.core.misc.measurements import DEFAULT_UNITS, Angle, Distance
-from ansys.geometry.core.misc.options import ImportOptions
+from ansys.geometry.core.misc.options import ImportOptions, TessellationOptions
 from ansys.geometry.core.misc.units import UNITS, PhysicalQuantity

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -438,12 +438,22 @@ class Modeler:
                     if full_path != fp_path:
                         if full_path.stat().st_size < pygeom_defaults.MAX_MESSAGE_LENGTH:
                             self._upload_file(full_path)
-                        else:
+                        elif self.client.backend_version >= (25, 2, 0):
                             self._upload_file_stream(full_path)
+                        else:  # pragma: no cover
+                            raise RuntimeError(
+                                "File is too large to upload."
+                                " Service versions above 25R2 support streaming."
+                            )
+
             if file_size_kb < pygeom_defaults.MAX_MESSAGE_LENGTH:
                 self._upload_file(file_path, True, import_options)
-            else:
+            elif self.client.backend_version >= (25, 2, 0):
                 self._upload_file_stream(file_path, True, import_options)
+            else:  # pragma: no cover
+                raise RuntimeError(
+                    "File is too large to upload. Service versions above 25R2 support streaming."
+                )
         else:
             DesignsStub(self.client.channel).Open(
                 OpenRequest(filepath=file_path, import_options=import_options.to_dict())


### PR DESCRIPTION
## Description
Missing exposure of the tessellation options. Face and components were not able to control them.

## Issue linked
Related to #1328 
