### PR TITLE
ci: make doc releases dependent on GH and PyPI release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -889,7 +889,7 @@ jobs:
     name: Upload release documentation
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, release-pypi]
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@c4fcd69508c0981431c7e85eed02b5008729d01a # v9.0.1

--- a/doc/changelog.d/1902.maintenance.md
+++ b/doc/changelog.d/1902.maintenance.md
@@ -1,0 +1,1 @@
+make doc releases dependent on GH and PyPI release


### PR DESCRIPTION
Released docs should depend on PyPI and GH releases going through