### PR TITLE
fix: is_suppressed is not available until 25R2

### DIFF
--- a/doc/changelog.d/1916.fixed.md
+++ b/doc/changelog.d/1916.fixed.md
@@ -1,0 +1,1 @@
+is_suppressed is not available until 25R2

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -853,6 +853,7 @@ class MasterBody(IBody):
         self.set_fill_style(value)
 
     @property
+    @min_backend_version(25, 2, 0)
     def is_suppressed(self) -> bool:  # noqa: D102
         response = self._grpc_client.services.bodies.is_suppressed(id=self.id)
         return response.get("result")

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -252,7 +252,7 @@ class GeometryPlotter(PlotterInterface):
         try:
             if body.is_suppressed:
                 return
-        except GeometryRuntimeError: # pragma: no cover
+        except GeometryRuntimeError:  # pragma: no cover
             # For backward compatibility with older versions of PyAnsys Geometry
             # Inserted in 25R2
             pass

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -44,6 +44,7 @@ from ansys.geometry.core.designer.component import Component
 from ansys.geometry.core.designer.design import Design
 from ansys.geometry.core.designer.designpoint import DesignPoint
 from ansys.geometry.core.designer.face import Face
+from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.logger import LOG
 from ansys.geometry.core.math.frame import Frame
 from ansys.geometry.core.math.plane import Plane
@@ -248,8 +249,13 @@ class GeometryPlotter(PlotterInterface):
             Keyword arguments. For allowable keyword arguments,
             see the :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
         """
-        if body.is_suppressed:
-            return
+        try:
+            if body.is_suppressed:
+                return
+        except GeometryRuntimeError:
+            # For backward compatibility with older versions of PyAnsys Geometry
+            # Inserted in 25R2
+            pass
 
         if self.use_service_colors:
             faces = body.faces

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -252,7 +252,7 @@ class GeometryPlotter(PlotterInterface):
         try:
             if body.is_suppressed:
                 return
-        except GeometryRuntimeError:
+        except GeometryRuntimeError: # pragma: no cover
             # For backward compatibility with older versions of PyAnsys Geometry
             # Inserted in 25R2
             pass


### PR DESCRIPTION
## Description
API call ``is_suppressed`` is not available until 25R2.

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
