### PR TITLE
build: bump PyVista and VTK versions (support Python 3.13)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -442,7 +442,6 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           checkout: false
           randomize: true
-          requires-xvfb: true
 
       - name: Upload integration test logs
         if: always()

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -20,6 +20,7 @@ env:
   RESET_IMAGE_CACHE: 5
   IS_WORKFLOW_RUNNING: True
   ARTIFACTORY_VERSION: v252
+  VTK_DEFAULT_OPENGL_WINDOW: "vtkOSOpenGLRenderWindow"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -400,6 +401,12 @@ jobs:
           # Export it as an environment variable with true/false value
           echo "SKIP_UNSTABLE=$Result" >> $GITHUB_ENV
           echo "SKIP_UNSTABLE will be: $Result"
+
+      - name: Set up headless display
+        if: env.SKIP_UNSTABLE == 'false'
+        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
+        with:
+          pyvista: false
 
       - name: Login in Github Container registry
         if: env.SKIP_UNSTABLE == 'false'
@@ -805,7 +812,6 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           pytest-extra-args: "--use-existing-service=yes"
           checkout: false
-          requires-xvfb: true
           randomize: true
 
       - name: "Compressing Linux Dockerfile"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.12'
+  MAIN_PYTHON_VERSION: '3.13'
   PACKAGE_NAME: 'ansys-geometry-core'
   DOCUMENTATION_CNAME: 'geometry.docs.pyansys.com'
   ANSRV_GEO_IMAGE: 'ghcr.io/ansys/geometry'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -20,7 +20,6 @@ env:
   RESET_IMAGE_CACHE: 5
   IS_WORKFLOW_RUNNING: True
   ARTIFACTORY_VERSION: v252
-  VTK_DEFAULT_OPENGL_WINDOW: "vtkOSOpenGLRenderWindow"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -443,6 +442,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           checkout: false
           randomize: true
+          requires-xvfb: true
 
       - name: Upload integration test logs
         if: always()
@@ -813,6 +813,7 @@ jobs:
           pytest-extra-args: "--use-existing-service=yes"
           checkout: false
           randomize: true
+          requires-xvfb: true
 
       - name: "Compressing Linux Dockerfile"
         uses: vimtor/action-zip@1379ea20d4c5705669ba81fd626dd01b1c738f26 # v1.2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -784,7 +784,7 @@ jobs:
         uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
         with:
           pyvista: false
-  
+
       - name: Download Linux binaries
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -480,6 +480,11 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
+        with:
+          pyvista: false
+
       - name: Login in Github Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -775,6 +780,11 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
+        with:
+          pyvista: false
+  
       - name: Download Linux binaries
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
@@ -812,7 +822,6 @@ jobs:
           pytest-extra-args: "--use-existing-service=yes"
           checkout: false
           randomize: true
-          requires-xvfb: true
 
       - name: "Compressing Linux Dockerfile"
         uses: vimtor/action-zip@1379ea20d4c5705669ba81fd626dd01b1c738f26 # v1.2

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -21,7 +21,7 @@ on:
       - v*
 
 env:
-  MAIN_PYTHON_VERSION: '3.12'
+  MAIN_PYTHON_VERSION: '3.13'
   ANSRV_GEO_IMAGE_WINDOWS_CORE_TAG: ghcr.io/ansys/geometry:core-windows-latest-unstable
   ANSRV_GEO_IMAGE_LINUX_CORE_TAG: ghcr.io/ansys/geometry:core-linux-latest-unstable
   ANSRV_GEO_PORT: 710

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -220,7 +220,6 @@ jobs:
           ALLOW_PLOTTING: true
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          requires-xvfb: true
 
       - name: Stop the Geometry service
         if: always()

--- a/doc/changelog.d/1924.dependencies.md
+++ b/doc/changelog.d/1924.dependencies.md
@@ -1,0 +1,1 @@
+bump PyVista and VTK versions (support Python 3.13)

--- a/doc/changelog.d/1925.fixed.md
+++ b/doc/changelog.d/1925.fixed.md
@@ -1,0 +1,1 @@
+docstyle ordering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ tests = [
     "pytest==8.3.5",
     "pytest-cov==6.1.1",
     "pytest-pyvista==0.1.9",
-    "pytest-xvfb==3.1.1",
     "pyvista[jupyter]==0.45.0",
     "requests==2.32.3",
     "scipy==1.15.2",
@@ -84,7 +83,6 @@ tests-minimal = [
     "pytest==8.3.5",
     "pytest-cov==6.1.1",
     "pytest-pyvista==0.1.9",
-    "pytest-xvfb==3.1.1",
 ]
 doc = [
     "ansys-sphinx-theme[autoapi]==1.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ all = [
 tests = [
     "ansys-platform-instancemanagement==1.1.2",
     "ansys-tools-path==0.7.1",
-    "ansys-tools-visualization-interface==0.8.3",
+    "ansys-tools-visualization-interface==0.9.1",
     "beartype==0.20.2",
     "docker==7.1.0",
     "geomdl==5.3.1",
@@ -89,7 +89,7 @@ tests-minimal = [
 doc = [
     "ansys-sphinx-theme[autoapi]==1.4.2",
     "ansys-tools-path==0.7.1",
-    "ansys-tools-visualization-interface==0.8.3",
+    "ansys-tools-visualization-interface==0.9.1",
     "beartype==0.20.2",
     "docker==7.1.0",
     "geomdl==5.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,12 @@ tests = [
     "pytest-cov==6.1.1",
     "pytest-pyvista==0.1.9",
     "pytest-xvfb==3.1.1",
-    "pyvista[jupyter]==0.44.2",
+    "pyvista[jupyter]==0.45.0",
     "requests==2.32.3",
     "scipy==1.15.2",
     "semver==3.0.4",
     "six==1.17.0",
-    "vtk==9.3.1",
+    "vtk==9.4.2",
 ]
 tests-minimal = [
     "pytest==8.3.5",
@@ -110,7 +110,7 @@ doc = [
     "Pint==0.24.4",
     "protobuf==5.29.3",
     "pygltflib==1.16.3",
-    "pyvista[jupyter]==0.44.2",
+    "pyvista[jupyter]==0.45.0",
     "quarto-cli==1.6.42",
     "requests==2.32.3",
     "scipy==1.15.2",
@@ -121,7 +121,7 @@ doc = [
     "sphinx-copybutton==0.5.2",
     "sphinx-jinja==2.0.2",
     "trame-vtk==2.8.15",
-    "vtk==9.3.1",
+    "vtk==9.4.2",
 ]
 
 [project.urls]

--- a/src/ansys/geometry/core/_grpc/_services/_service.py
+++ b/src/ansys/geometry/core/_grpc/_services/_service.py
@@ -35,14 +35,6 @@ class _GRPCServices:
     """
     Placeholder for the gRPC services (i.e. stubs).
 
-    Notes
-    -----
-    This class provides a unified interface to access the different
-    gRPC services available in the Geometry API. It allows for easy
-    switching between different versions of the API by using the
-    `version` parameter in the constructor. The services are lazy-loaded
-    to avoid unnecessary imports and to improve performance.
-
     Parameters
     ----------
     channel : grpc.Channel
@@ -50,6 +42,14 @@ class _GRPCServices:
     version : GeometryApiProtos | str | None
         The version of the gRPC API protocol to use. If None, the latest
         version is used.
+
+    Notes
+    -----
+    This class provides a unified interface to access the different
+    gRPC services available in the Geometry API. It allows for easy
+    switching between different versions of the API by using the
+    `version` parameter in the constructor. The services are lazy-loaded
+    to avoid unnecessary imports and to improve performance.
     """
 
     def __init__(self, channel: grpc.Channel, version: GeometryApiProtos | str | None = None):

--- a/src/ansys/geometry/core/_grpc/_services/base/conversions.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/conversions.py
@@ -59,11 +59,6 @@ def from_measurement_to_server_angle(input: Measurement) -> float:
 def to_distance(value: float | int) -> Distance:
     """Convert a server value to a Distance object.
 
-    Notes
-    -----
-    The value is converted to a Distance object using the default server length unit.
-    The value should represent a length in the server's unit system.
-
     Parameters
     ----------
     value : float | int
@@ -73,5 +68,10 @@ def to_distance(value: float | int) -> Distance:
     -------
     Distance
         Converted distance.
+
+    Notes
+    -----
+    The value is converted to a Distance object using the default server length unit.
+    The value should represent a length in the server's unit system.
     """
     return Distance(value, DEFAULT_UNITS.SERVER_LENGTH)

--- a/src/ansys/geometry/core/_grpc/_version.py
+++ b/src/ansys/geometry/core/_grpc/_version.py
@@ -71,10 +71,6 @@ class GeometryApiProtos(Enum):
     def verify_supported(self, channel: grpc.Channel) -> bool:
         """Check if the version is supported.
 
-        Notes
-        -----
-        This method checks if the server supports the gRPC API protocol version.
-
         Parameters
         ----------
         channel : grpc.Channel
@@ -84,6 +80,10 @@ class GeometryApiProtos(Enum):
         -------
         bool
             True if the server supports the version, otherwise False.
+
+        Notes
+        -----
+        This method checks if the server supports the gRPC API protocol version.
         """
         pb2_grpc = self.value[1]
         if pb2_grpc is None:

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -51,10 +51,6 @@ except ModuleNotFoundError:  # pragma: no cover
 def _create_geometry_channel(target: str) -> grpc.Channel:
     """Create a Geometry service gRPC channel.
 
-    Notes
-    -----
-    Contains specific options for the Geometry service.
-
     Parameters
     ----------
     target : str
@@ -65,6 +61,10 @@ def _create_geometry_channel(target: str) -> grpc.Channel:
     -------
     ~grpc.Channel
         gRPC channel for the Geometry service.
+
+    Notes
+    -----
+    Contains specific options for the Geometry service.
     """
     return grpc.insecure_channel(
         target,
@@ -94,16 +94,16 @@ def wait_until_healthy(channel: grpc.Channel | str, timeout: float) -> grpc.Chan
         * If the total elapsed time exceeds the value for the ``timeout`` parameter,
           a ``TimeoutError`` is raised.
 
-    Raises
-    ------
-    TimeoutError
-        Raised when the total elapsed time exceeds the value for the ``timeout`` parameter.
-
     Returns
     -------
     grpc.Channel
         The channel that was passed in. This channel is guaranteed to be healthy.
         If a string was passed in, a channel is created using the default insecure channel.
+
+    Raises
+    ------
+    TimeoutError
+        Raised when the total elapsed time exceeds the value for the ``timeout`` parameter.
     """
     t_max = time.time() + timeout
     t_out = 0.1

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -506,12 +506,6 @@ class Component:
     def __build_body_from_response(self, response: dict) -> Body:
         """Build a body from a response dictionary coming out of the gRPC call.
 
-        Notes
-        -----
-        This is a completely private method and is intended to be
-        used only within the class. It handles the MasterBody and
-        Body creation, and addition to the component.
-
         Parameters
         ----------
         response : dict
@@ -521,6 +515,12 @@ class Component:
         -------
         Body
             Body object.
+
+        Notes
+        -----
+        This is a completely private method and is intended to be
+        used only within the class. It handles the MasterBody and
+        Body creation, and addition to the component.
         """
         tb = MasterBody(
             response["master_id"],
@@ -1102,10 +1102,6 @@ class Component:
     ) -> list[Beam]:
         """Create beams under the component.
 
-        Notes
-        -----
-        This is a legacy method, which is used in versions up to Ansys 25.1.1 products.
-
         Parameters
         ----------
         segments : list[tuple[Point3D, Point3D]]
@@ -1117,6 +1113,10 @@ class Component:
         -------
         list[Beam]
             A list of the created Beams.
+
+        Notes
+        -----
+        This is a legacy method, which is used in versions up to Ansys 25.1.1 products.
         """
         request = CreateBeamSegmentsRequest(parent=self.id, profile=profile.id)
 

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -321,11 +321,6 @@ class Design(Component):
     def __export_and_download_legacy(self, format: DesignFileFormat) -> bytes:
         """Export and download the design from the server.
 
-        Notes
-        -----
-        This is a legacy method, which is used in versions
-        up to Ansys 25.1.1 products.
-
         Parameters
         ----------
         format : DesignFileFormat
@@ -335,6 +330,11 @@ class Design(Component):
         -------
         bytes
             The raw data from the exported and downloaded file.
+
+        Notes
+        -----
+        This is a legacy method, which is used in versions
+        up to Ansys 25.1.1 products.
         """
         # Process response
         self._grpc_client.log.debug(f"Requesting design download in {format.value[0]} format.")

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -556,15 +556,15 @@ class Face:
         tess_options : TessellationOptions | None, default: None
             A set of options to determine the tessellation quality.
 
-        Notes
-        -----
-        The tessellation options are ONLY used if the face has not been tessellated before.
-        If the face has been tessellated before, the stored tessellation is returned.
-
         Returns
         -------
         ~pyvista.PolyData
             :class:`pyvista.PolyData` object holding the face.
+
+        Notes
+        -----
+        The tessellation options are ONLY used if the face has not been tessellated before.
+        If the face has been tessellated before, the stored tessellation is returned.
         """
         # If tessellation has not been called before... call it
         if self._body._template._tessellation is None:

--- a/src/ansys/geometry/core/parameters/parameter.py
+++ b/src/ansys/geometry/core/parameters/parameter.py
@@ -58,11 +58,6 @@ class ParameterUpdateStatus(Enum):
     def _from_update_status(status: GRPCUpdateStatus) -> "ParameterUpdateStatus":
         """Convert GRPCUpdateStatus to ParameterUpdateStatus.
 
-        Notes
-        -----
-        This method is used to convert the status of the update from gRPC to the
-        parameter update status. Not to be used directly by the user.
-
         Parameters
         ----------
         status : GRPCUpdateStatus
@@ -72,6 +67,11 @@ class ParameterUpdateStatus(Enum):
         -------
         ParameterUpdateStatus
             Parameter update status.
+
+        Notes
+        -----
+        This method is used to convert the status of the update from gRPC to the
+        parameter update status. Not to be used directly by the user.
         """
         status_mapping = {
             GRPCUpdateStatus.SUCCESS: ParameterUpdateStatus.SUCCESS,
@@ -107,11 +107,6 @@ class Parameter:
     def _from_proto(cls, proto: GRPCDrivingDimension) -> "Parameter":
         """Create a ``Parameter`` instance from a ``proto`` object.
 
-        Notes
-        -----
-        This method is used to convert the parameter from gRPC to the parameter
-        object. Not to be used directly by the user.
-
         Parameters
         ----------
         proto : GRPCDrivingDimension
@@ -121,6 +116,11 @@ class Parameter:
         -------
         Parameter
             Parameter object.
+
+        Notes
+        -----
+        This method is used to convert the parameter from gRPC to the parameter
+        object. Not to be used directly by the user.
         """
         return cls(
             id=proto.id,
@@ -162,15 +162,15 @@ class Parameter:
     def _to_proto(self):
         """Convert a ``Parameter`` instance to a ``proto`` object.
 
-        Notes
-        -----
-        This method is used to convert the parameter from the parameter object to
-        gRPC. Not to be used directly by the user.
-
         Returns
         -------
         GRPCDrivingDimension
             Parameter object in gRPC.
+
+        Notes
+        -----
+        This method is used to convert the parameter from the parameter object to
+        gRPC. Not to be used directly by the user.
         """
         return GRPCDrivingDimension(
             id=self.id,

--- a/src/ansys/geometry/core/shapes/curves/nurbs.py
+++ b/src/ansys/geometry/core/shapes/curves/nurbs.py
@@ -218,14 +218,6 @@ class NURBSCurve(Curve):
 
         This method returns the evaluation at the closest point.
 
-        Notes
-        -----
-        Based on `the NURBS book <https://link.springer.com/book/10.1007/978-3-642-59223-2>`_,
-        the projection of a point to a NURBS curve is the solution to the following optimization
-        problem: minimize the distance between the point and the curve. The distance is defined
-        as the Euclidean distance squared. For more information, please refer to
-        the implementation of the `distance_squared` function.
-
         Parameters
         ----------
         point : Point3D
@@ -239,6 +231,13 @@ class NURBSCurve(Curve):
         CurveEvaluation
             Evaluation at the closest point on the curve.
 
+        Notes
+        -----
+        Based on `the NURBS book <https://link.springer.com/book/10.1007/978-3-642-59223-2>`_,
+        the projection of a point to a NURBS curve is the solution to the following optimization
+        problem: minimize the distance between the point and the curve. The distance is defined
+        as the Euclidean distance squared. For more information, please refer to
+        the implementation of the `distance_squared` function.
         """
         import numpy as np
         from scipy.optimize import minimize

--- a/src/ansys/geometry/core/sketch/ellipse.py
+++ b/src/ansys/geometry/core/sketch/ellipse.py
@@ -203,7 +203,7 @@ class SketchEllipse(SketchFace, Ellipse):
         return pv.Ellipse(
             semi_major_axis=self.major_radius.m_as(DEFAULT_UNITS.LENGTH),
             semi_minor_axis=self.minor_radius.m_as(DEFAULT_UNITS.LENGTH),
-        ).transform(transformation_matrix)
+        ).transform(transformation_matrix, inplace=True)
 
     def plane_change(self, plane: Plane) -> None:
         """Redefine the plane containing ``SketchEllipse`` objects.

--- a/src/ansys/geometry/core/sketch/polygon.py
+++ b/src/ansys/geometry/core/sketch/polygon.py
@@ -172,4 +172,4 @@ class Polygon(SketchFace):
         return pv.Polygon(
             radius=self.inner_radius.m_as(DEFAULT_UNITS.LENGTH),
             n_sides=self.n_sides,
-        ).transform(transformation_matrix)
+        ).transform(transformation_matrix, inplace=True)

--- a/src/ansys/geometry/core/sketch/sketch.py
+++ b/src/ansys/geometry/core/sketch/sketch.py
@@ -964,7 +964,7 @@ class Sketch:
         sketches_polydata_selection = []
         sketches_polydata_selection.extend(
             [
-                sketch_item.visualization_polydata.transform(self._plane.transformation_matrix)
+                sketch_item.visualization_polydata.transform(self._plane.transformation_matrix, inplace=True)
                 for sketch_item in self._current_sketch_context
             ]
         )
@@ -998,7 +998,7 @@ class Sketch:
             List of the polydata configuration for faces in the sketch.
         """
         sketches_polydata_faces = [
-            face.visualization_polydata.transform(self._plane.transformation_matrix)
+            face.visualization_polydata.transform(self._plane.transformation_matrix, inplace=True)
             for face in self.faces
         ]
         return sketches_polydata_faces
@@ -1012,7 +1012,7 @@ class Sketch:
             List of the polydata configuration for edges in the sketch.
         """
         sketches_polydata_edges = [
-            edge.visualization_polydata.transform(self._plane.transformation_matrix)
+            edge.visualization_polydata.transform(self._plane.transformation_matrix, inplace=True)
             for edge in self.edges
         ]
         return sketches_polydata_edges

--- a/src/ansys/geometry/core/sketch/sketch.py
+++ b/src/ansys/geometry/core/sketch/sketch.py
@@ -964,7 +964,9 @@ class Sketch:
         sketches_polydata_selection = []
         sketches_polydata_selection.extend(
             [
-                sketch_item.visualization_polydata.transform(self._plane.transformation_matrix, inplace=True)
+                sketch_item.visualization_polydata.transform(
+                    self._plane.transformation_matrix, inplace=True
+                )
                 for sketch_item in self._current_sketch_context
             ]
         )

--- a/src/ansys/geometry/core/tools/repair_tools.py
+++ b/src/ansys/geometry/core/tools/repair_tools.py
@@ -422,11 +422,6 @@ class RepairTools:
     ) -> list[InterferenceProblemAreas]:
         """Find the interference problem areas.
 
-        Notes
-        -----
-        This method finds and returns a list of ids of interference problem areas
-        objects.
-
         Parameters
         ----------
         bodies : list[Body]
@@ -439,6 +434,11 @@ class RepairTools:
         -------
         list[InterfenceProblemAreas]
             List of objects representing interference problem areas.
+
+        Notes
+        -----
+        This method finds and returns a list of ids of interference problem areas
+        objects.
         """
         from ansys.geometry.core.designer.body import Body
 
@@ -472,10 +472,6 @@ class RepairTools:
     ) -> RepairToolMessage:
         """Find and fix the short edge problem areas.
 
-        Notes
-        -----
-        This method finds the short edges in the bodies and fixes them.
-
         Parameters
         ----------
         bodies : list[Body]
@@ -490,6 +486,10 @@ class RepairTools:
         -------
         RepairToolMessage
             Message containing number of problem areas found/fixed, created and/or modified bodies.
+
+        Notes
+        -----
+        This method finds the short edges in the bodies and fixes them.
         """
         from ansys.geometry.core.designer.body import Body
 
@@ -526,10 +526,6 @@ class RepairTools:
     ) -> RepairToolMessage:
         """Find and fix the extra edge problem areas.
 
-        Notes
-        -----
-        This method finds the extra edges in the bodies and fixes them.
-
         Parameters
         ----------
         bodies : list[Body]
@@ -544,6 +540,10 @@ class RepairTools:
         -------
         RepairToolMessage
             Message containing number of problem areas found/fixed, created and/or modified bodies.
+
+        Notes
+        -----
+        This method finds the extra edges in the bodies and fixes them.
         """
         from ansys.geometry.core.designer.body import Body
 
@@ -581,10 +581,6 @@ class RepairTools:
     ) -> RepairToolMessage:
         """Find and fix the split edge problem areas.
 
-        Notes
-        -----
-        This method finds the extra edges in the bodies and fixes them.
-
         Parameters
         ----------
         bodies : list[Body]
@@ -601,6 +597,10 @@ class RepairTools:
         -------
         RepairToolMessage
             Message containing number of problem areas found/fixed, created and/or modified bodies.
+
+        Notes
+        -----
+        This method finds the extra edges in the bodies and fixes them.
         """
         from ansys.geometry.core.designer.body import Body
 
@@ -643,10 +643,6 @@ class RepairTools:
     ) -> RepairToolMessage:
         """Find and simplify the provided geometry.
 
-        Notes
-        -----
-        This method simplifies the provided geometry.
-
         Parameters
         ----------
         bodies : list[Body]
@@ -659,6 +655,10 @@ class RepairTools:
         -------
         RepairToolMessage
             Message containing number of problem areas found/fixed, created and/or modified bodies.
+
+        Notes
+        -----
+        This method simplifies the provided geometry.
         """
         from ansys.geometry.core.designer.body import Body
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,8 @@ def are_graphics_available() -> bool:
     # ...otherwise, graphics are not available.
     try:
         run_if_graphics_required()
-        return True
+        from pyvista.plotting import system_supports_plotting
+
+        return system_supports_plotting()
     except ImportError:
         return False

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -2115,6 +2115,7 @@ def test_child_component_instances(modeler: Modeler):
     assert len(comp1.components) == len(base2.components[0].components)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="TESTING GRAPHICS")
 def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Generate multiple designs, make sure they are all separate, and once
     a design is deactivated, the next one is activated.

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -2115,7 +2115,6 @@ def test_child_component_instances(modeler: Modeler):
     assert len(comp1.components) == len(base2.components[0].components)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="TESTING GRAPHICS")
 def test_multiple_designs(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Generate multiple designs, make sure they are all separate, and once
     a design is deactivated, the next one is activated.

--- a/tests/integration/test_plotter.py
+++ b/tests/integration/test_plotter.py
@@ -384,6 +384,7 @@ def test_plot_trapezoid(verify_image_cache):
     sketch.plot_selection(view_2d=True, screenshot=Path(IMAGE_RESULTS_DIR, "plot_trapezoid.png"))
 
 
+@skip_no_xserver
 def test_plot_trapezoid_symmetric(verify_image_cache):
     """Test plotting of a trapezoid which is symmetric."""
     # Create a sketch instance

--- a/tests/integration/test_plotter.py
+++ b/tests/integration/test_plotter.py
@@ -578,25 +578,22 @@ def test_visualization_polydata():
         rel=1e-6,
         abs=1e-8,
     )
-    assert polygon.visualization_polydata.n_faces == 2
     assert polygon.visualization_polydata.n_cells == 2
     assert polygon.visualization_polydata.n_points == 5
     assert polygon.visualization_polydata.n_open_edges == 5
 
     # Test for arc visualization polydata
     arc = Arc(Point2D([10, 10]), Point2D([10, -10]), Point2D([10, 0]))
-    assert arc.visualization_polydata.center == ([5.0, 0.0, 0.0])
+    assert arc.visualization_polydata.center == pytest.approx([5.0, 0.0, 0.0])
     assert arc.visualization_polydata.bounds == pytest.approx([0.0, 10.0, -10.0, 10.0, 0.0, 0.0])
-    assert arc.visualization_polydata.n_faces == 2
     assert arc.visualization_polydata.n_cells == 2
     assert arc.visualization_polydata.n_points == 202
     assert arc.visualization_polydata.n_open_edges == 0
 
     # Test for segment visualization polydata
     segment = SketchSegment(Point2D([3, 2]), Point2D([2, 0]))
-    assert segment.visualization_polydata.center == ([2.5, 1.0, 0.0])
+    assert segment.visualization_polydata.center == pytest.approx([2.5, 1.0, 0.0])
     assert segment.visualization_polydata.bounds == pytest.approx([2.0, 3.0, 0.0, 2.0, 0.0, 0.0])
-    assert segment.visualization_polydata.n_faces == 1
     assert segment.visualization_polydata.n_cells == 1
     assert segment.visualization_polydata.n_points == 2
     assert segment.visualization_polydata.n_open_edges == 0
@@ -609,20 +606,18 @@ def test_visualization_polydata():
     )
     assert slot.visualization_polydata
     assert slot.visualization_polydata.bounds == pytest.approx([0.0, 4.0, 2.0, 4.0, 0.0, 0.0])
-    assert slot.visualization_polydata.center == ([2.0, 3.0, 0.0])
+    assert slot.visualization_polydata.center == pytest.approx([2.0, 3.0, 0.0])
     # Two arcs and segments creates the slot, thus it should have 6 faces
-    assert slot.visualization_polydata.n_faces == 6
     assert slot.visualization_polydata.n_cells == 6
     assert slot.visualization_polydata.n_points == 402
     assert slot.visualization_polydata.n_open_edges == 0
 
     # Test for triangle visualization polydata
     triangle = Triangle(Point2D([10, 10]), Point2D([2, 1]), Point2D([10, -10]))
-    assert triangle.visualization_polydata.center == ([6.0, 0.0, 0.0])
+    assert triangle.visualization_polydata.center == pytest.approx([6.0, 0.0, 0.0])
     assert triangle.visualization_polydata.bounds == pytest.approx(
         [2.0, 10.0, -10.0, 10.0, 0.0, 0.0]
     )
-    assert triangle.visualization_polydata.n_faces == 1
     assert triangle.visualization_polydata.n_cells == 1
     assert triangle.visualization_polydata.n_points == 3
     assert triangle.visualization_polydata.n_open_edges == 3
@@ -639,7 +634,6 @@ def test_visualization_polydata():
         rel=1e-6,
         abs=1e-8,
     )
-    assert trapezoid.visualization_polydata.n_faces == 1
     assert trapezoid.visualization_polydata.n_cells == 1
     assert trapezoid.visualization_polydata.n_points == 4
     assert trapezoid.visualization_polydata.n_open_edges == 4
@@ -648,18 +642,16 @@ def test_visualization_polydata():
     circle = SketchCircle(
         Point2D([10, -10], DEFAULT_UNITS.LENGTH), Quantity(1, DEFAULT_UNITS.LENGTH)
     )
-    assert circle.visualization_polydata.center == pytest.approx(([10.0, -10.0, 0.0]))
+    assert circle.visualization_polydata.center == pytest.approx([10.0, -10.0, 0.0])
     assert circle.visualization_polydata.bounds == pytest.approx([9.0, 11.0, -11.0, -9.0, 0.0, 0.0])
-    assert circle.visualization_polydata.n_faces == 1
     assert circle.visualization_polydata.n_cells == 1
     assert circle.visualization_polydata.n_points == 100
     assert circle.visualization_polydata.n_open_edges == 100
 
     # Test for ellipse visualization polydata
     ellipse = SketchEllipse(Point2D([0, 0], UNITS.m), Quantity(1, UNITS.m), Quantity(1, UNITS.m))
-    assert ellipse.visualization_polydata.center == pytest.approx(([0.0, 0.0, 0.0]))
+    assert ellipse.visualization_polydata.center == pytest.approx([0.0, 0.0, 0.0])
     assert ellipse.visualization_polydata.bounds == pytest.approx([-1.0, 1.0, -1.0, 1.0, 0.0, 0.0])
-    assert ellipse.visualization_polydata.n_faces == 1
     assert ellipse.visualization_polydata.n_cells == 1
     assert ellipse.visualization_polydata.n_points == 100
     assert ellipse.visualization_polydata.n_open_edges == 100
@@ -670,9 +662,8 @@ def test_visualization_polydata():
         Distance(4, unit=UNITS.meter),
         Distance(2, unit=UNITS.meter),
     )
-    assert box.visualization_polydata.center == ([3.0, 1.0, 0.0])
+    assert box.visualization_polydata.center == pytest.approx([3.0, 1.0, 0.0])
     assert box.visualization_polydata.bounds == pytest.approx([1.0, 5.0, 0.0, 2.0, 0.0, 0.0])
-    assert box.visualization_polydata.n_faces == 1
     assert box.visualization_polydata.n_cells == 1
     assert box.visualization_polydata.n_points == 4
     assert box.visualization_polydata.n_open_edges == 4

--- a/tests/integration/test_tessellation.py
+++ b/tests/integration/test_tessellation.py
@@ -49,7 +49,7 @@ def test_body_tessellate(modeler: Modeler):
     # Number of blocks will be the number of faces
     assert blocks_1.n_blocks == 6
     # Test the center of the bounding box
-    assert (blocks_1.center == ([2, 0, 0.5])).all()
+    assert blocks_1.center == pytest.approx([2, 0, 0.5])
     # Test the values of blocks which are the length 6 tuple of floats
     # containing min/max along each axis
     assert blocks_1.bounds == pytest.approx([0.0, 4.0, -2.0, 2.0, 0.0, 1.0])
@@ -145,7 +145,6 @@ def test_component_tessellate(modeler: Modeler):
     assert "PolyData" in str(mesh)
     if not BackendType.is_core_service(modeler.client.backend_type):
         assert mesh.n_cells == 3280
-        assert mesh.n_faces == 3280
         assert mesh.n_arrays == 0
         assert mesh.n_points == 3300
         assert mesh.bounds == pytest.approx(
@@ -155,7 +154,6 @@ def test_component_tessellate(modeler: Modeler):
         )
     else:
         assert mesh.n_cells == 3280
-        assert mesh.n_faces == 3280
         assert mesh.n_arrays == 0
         assert mesh.n_points == 3300
         assert mesh.bounds == pytest.approx(


### PR DESCRIPTION
## Description
Supporting new PyVista and VTK versions -- this enables the usage of Python 3.13 across the board on CI/CD (docs build, main testing etc.)

## Issue linked
Closes #1585 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
