### PR TITLE
ci: fix unstable workflows for Linux (missing headless display)

### DIFF
--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -214,6 +214,11 @@ jobs:
           docker pull ${{ env.ANSRV_GEO_IMAGE_LINUX_CORE_TAG }}
           docker run --detach --name ${{ env.GEO_CONT_NAME }} -e LICENSE_SERVER=${{ env.ANSRV_GEO_LICENSE_SERVER }} -p ${{ env.ANSRV_GEO_PORT }}:50051 ${{ env.ANSRV_GEO_IMAGE_LINUX_CORE_TAG }}
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
+        with:
+          pyvista: false
+
       - name: Run pytest
         uses: ansys/actions/tests-pytest@1f1f205361706d22f67c71c29b775222380cd95a # v9.0.6
         env:

--- a/doc/changelog.d/1931.maintenance.md
+++ b/doc/changelog.d/1931.maintenance.md
@@ -1,0 +1,1 @@
+fix unstable workflows for Linux (missing headless display)


### PR DESCRIPTION
## Description
Unstable builds are failing for Linux because we were missing the headless display configuration. Setting it properly
