### PR TITLE
ci: use v4 of pyvista/setup-headless-display-action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -160,7 +160,6 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       SKIP_UNSTABLE: false
-      PYVISTA_OFF_SCREEN: true
     strategy:
       fail-fast: false
       matrix:
@@ -203,12 +202,7 @@ jobs:
 
       - name: Set up headless display
         if: env.SKIP_UNSTABLE == 'false'
-        uses: RobPasMue/setup-headless-display-action@offscreen-mesa3d
-        with:
-          pyvista: false
-          # Mesa3D off screen rendering only needed on Windows self-hosted runners
-          # without GPU support (e.g. pygeometry-ci-2 has GPU, so it doesn't need it)
-          install-mesa3d-offscreen: ${{ runner.name != 'pygeometry-ci-2' }}
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Create Python venv
         if: env.SKIP_UNSTABLE == 'false'
@@ -326,11 +320,9 @@ jobs:
     name: Documentation
     needs: [docs-style]
     runs-on: ubuntu-latest
-    env:
-      PYVISTA_OFF_SCREEN: true
     steps:
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -406,9 +398,7 @@ jobs:
 
       - name: Set up headless display
         if: env.SKIP_UNSTABLE == 'false'
-        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
-        with:
-          pyvista: false
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Login in Github Container registry
         if: env.SKIP_UNSTABLE == 'false'
@@ -484,9 +474,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
-        with:
-          pyvista: false
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Login in Github Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -686,12 +674,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up headless display
-        uses: RobPasMue/setup-headless-display-action@offscreen-mesa3d
-        with:
-          pyvista: false
-          # Mesa3D off screen rendering only needed on Windows self-hosted runners
-          # without GPU support (e.g. pygeometry-ci-2 has GPU, so it doesn't need it)
-          install-mesa3d-offscreen: ${{ runner.name != 'pygeometry-ci-2' }}
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Set up Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
@@ -792,9 +775,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
-        with:
-          pyvista: false
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Download Linux binaries
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -100,12 +100,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Set up headless display
-        uses: RobPasMue/setup-headless-display-action@offscreen-mesa3d
-        with:
-          pyvista: false
-          # Mesa3D off screen rendering only needed on Windows self-hosted runners
-          # without GPU support (e.g. pygeometry-ci-2 has GPU, so it doesn't need it)
-          install-mesa3d-offscreen: ${{ runner.name != 'pygeometry-ci-2' }}
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Create Python venv
         run: |
@@ -218,9 +213,7 @@ jobs:
           docker run --detach --name ${{ env.GEO_CONT_NAME }} -e LICENSE_SERVER=${{ env.ANSRV_GEO_LICENSE_SERVER }} -p ${{ env.ANSRV_GEO_PORT }}:50051 ${{ env.ANSRV_GEO_IMAGE_LINUX_CORE_TAG }}
 
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8 # v3.2
-        with:
-          pyvista: false
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Run pytest
         uses: ansys/actions/tests-pytest@1f1f205361706d22f67c71c29b775222380cd95a # v9.0.6

--- a/doc/changelog.d/1934.maintenance.md
+++ b/doc/changelog.d/1934.maintenance.md
@@ -1,0 +1,1 @@
+use v4 of pyvista/setup-headless-display-action


### PR DESCRIPTION
## Description
Using ``pyvista/setup-headless-display-action`` instead of private fork
