### PR TITLE
feat: move coordinate systems stub to grpc layer

### DIFF
--- a/doc/changelog.d/1943.added.md
+++ b/doc/changelog.d/1943.added.md
@@ -1,0 +1,1 @@
+move coordinate systems stub to grpc layer

--- a/src/ansys/geometry/core/_grpc/_services/_service.py
+++ b/src/ansys/geometry/core/_grpc/_services/_service.py
@@ -25,6 +25,7 @@ import grpc
 from .._version import GeometryApiProtos, set_proto_version
 from .base.admin import GRPCAdminService
 from .base.bodies import GRPCBodyService
+from .base.coordinate_systems import GRPCCoordinateSystemService
 from .base.dbuapplication import GRPCDbuApplicationService
 from .base.driving_dimensions import GRPCDrivingDimensionsService
 from .base.measurement_tools import GRPCMeasurementToolsService
@@ -77,6 +78,7 @@ class _GRPCServices:
         self._measurement_tools = None
         self._prepare_tools = None
         self._driving_dimensions = None
+        self._coordinate_systems = None
 
     @property
     def bodies(self) -> GRPCBodyService:
@@ -85,7 +87,7 @@ class _GRPCServices:
 
         Returns
         -------
-        BodyServiceBase
+        GRPCBodyService
             The body service for the specified version.
         """
         if not self._bodies:
@@ -111,7 +113,7 @@ class _GRPCServices:
 
         Returns
         -------
-        AdminServiceBase
+        GRPCAdminService
             The admin service for the specified version.
         """
         if not self._admin:
@@ -137,7 +139,7 @@ class _GRPCServices:
 
         Returns
         -------
-        DbuApplicationServiceBase
+        GRPCDbuApplicationService
             The DBU application service for the specified version.
         """
         if not self._dbu_application:
@@ -163,7 +165,7 @@ class _GRPCServices:
 
         Returns
         -------
-        NamedSelectionServiceBase
+        GRPCNamedSelectionService
             The named selection service for the specified version.
         """
         if not self._named_selection:
@@ -189,7 +191,7 @@ class _GRPCServices:
 
         Returns
         -------
-        MeasurementToolsServiceBase
+        GRPCMeasurementToolsService
             The measurement tools service for the specified version.
         """
         if not self._measurement_tools:
@@ -215,7 +217,7 @@ class _GRPCServices:
 
         Returns
         -------
-        PrepareToolsServiceBase
+        GRPCPrepareToolsService
             The prepare tools service for the specified version.
         """
         if not self._prepare_tools:
@@ -241,7 +243,7 @@ class _GRPCServices:
 
         Returns
         -------
-        DrivingDimensionsServiceBase
+        GRPCDrivingDimensionsService
             The driving dimensions service for the specified version.
         """
         if not self._driving_dimensions:
@@ -259,3 +261,29 @@ class _GRPCServices:
                 raise ValueError(f"Unsupported version: {self.version}")
 
         return self._driving_dimensions
+
+    @property
+    def coordinate_systems(self) -> GRPCCoordinateSystemService:
+        """
+        Get the coordinate systems service for the specified version.
+
+        Returns
+        -------
+        GRPCCoordinateSystemService
+            The coordinate systems service for the specified version.
+        """
+        if not self._coordinate_systems:
+            # Import the appropriate coordinate systems service based on the version
+            from .v0.coordinate_systems import GRPCCoordinateSystemServiceV0
+            from .v1.coordinate_systems import GRPCCoordinateSystemServiceV1
+
+            if self.version == GeometryApiProtos.V0:
+                self._coordinate_systems = GRPCCoordinateSystemServiceV0(self.channel)
+            elif self.version == GeometryApiProtos.V1:  # pragma: no cover
+                # V1 is not implemented yet
+                self._coordinate_systems = GRPCCoordinateSystemServiceV1(self.channel)
+            else:  # pragma: no cover
+                # This should never happen as the version is set in the constructor
+                raise ValueError(f"Unsupported version: {self.version}")
+
+        return self._coordinate_systems

--- a/src/ansys/geometry/core/_grpc/_services/base/admin.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/admin.py
@@ -36,7 +36,7 @@ class GRPCAdminService(ABC):
     """
 
     def __init__(self, channel: grpc.Channel):
-        """Initialize the AdminServiceBase class."""
+        """Initialize the GRPCAdminService class."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/ansys/geometry/core/_grpc/_services/base/bodies.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/bodies.py
@@ -36,7 +36,7 @@ class GRPCBodyService(ABC):
     """
 
     def __init__(self, channel: grpc.Channel):
-        """Initialize the BodyServiceBase class."""
+        """Initialize the GRPCBodyService class."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/ansys/geometry/core/_grpc/_services/base/coordinate_systems.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/coordinate_systems.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Module containing the coordinate systems service implementation (abstraction layer)."""
+
+from abc import ABC, abstractmethod
+
+import grpc
+
+
+class GRPCCoordinateSystemService(ABC):
+    """Coordinate systems service for gRPC communication with the Geometry server.
+
+    Parameters
+    ----------
+    channel : grpc.Channel
+        The gRPC channel to the server.
+    """
+
+    def __init__(self, channel: grpc.Channel):
+        """Initialize the GRPCCoordinateSystemService class."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def create(self, **kwargs) -> dict:
+        """Create a coordinate system."""
+        pass  # pragma: no cover

--- a/src/ansys/geometry/core/_grpc/_services/base/driving_dimensions.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/driving_dimensions.py
@@ -36,7 +36,7 @@ class GRPCDrivingDimensionsService(ABC):
     """
 
     def __init__(self, channel: grpc.Channel):
-        """Initialize the DrivingDimensionsServiceBase class."""
+        """Initialize the GRPCDrivingDimensionsService class."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/ansys/geometry/core/_grpc/_services/base/measurement_tools.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/measurement_tools.py
@@ -36,7 +36,7 @@ class GRPCMeasurementToolsService(ABC):
     """
 
     def __init__(self, channel: grpc.Channel):
-        """Initialize the MeasurementToolsService class."""
+        """Initialize the GRPCMeasurementToolsService class."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/ansys/geometry/core/_grpc/_services/base/prepare_tools.py
+++ b/src/ansys/geometry/core/_grpc/_services/base/prepare_tools.py
@@ -36,7 +36,7 @@ class GRPCPrepareToolsService(ABC):
     """
 
     def __init__(self, channel: grpc.Channel):
-        """Initialize the PrepareToolsService class."""
+        """Initialize the GRPCPrepareToolsService class."""
         pass  # pragma: no cover
 
     @abstractmethod

--- a/src/ansys/geometry/core/_grpc/_services/v0/conversions.py
+++ b/src/ansys/geometry/core/_grpc/_services/v0/conversions.py
@@ -264,6 +264,50 @@ def from_frame_to_grpc_frame(frame: "Frame") -> GRPCFrame:
     )
 
 
+def from_grpc_frame_to_frame(frame: GRPCFrame) -> "Frame":
+    """Convert a frame gRPC message to a ``Frame`` class.
+
+    Parameters
+    ----------
+    frame : GRPCFrame
+        Source frame data.
+
+    Returns
+    -------
+    Frame
+        Converted frame.
+    """
+    from ansys.geometry.core.math.frame import Frame
+    from ansys.geometry.core.math.point import Point3D
+    from ansys.geometry.core.math.vector import UnitVector3D
+    from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
+
+    return Frame(
+        Point3D(
+            input=[
+                frame.origin.x,
+                frame.origin.y,
+                frame.origin.z,
+            ],
+            unit=DEFAULT_UNITS.SERVER_LENGTH,
+        ),
+        UnitVector3D(
+            input=[
+                frame.dir_x.x,
+                frame.dir_x.y,
+                frame.dir_x.z,
+            ]
+        ),
+        UnitVector3D(
+            input=[
+                frame.dir_y.x,
+                frame.dir_y.y,
+                frame.dir_y.z,
+            ]
+        ),
+    )
+
+
 def from_plane_to_grpc_plane(plane: "Plane") -> GRPCPlane:
     """Convert a ``Plane`` class to a plane gRPC message.
 

--- a/src/ansys/geometry/core/_grpc/_services/v0/coordinate_systems.py
+++ b/src/ansys/geometry/core/_grpc/_services/v0/coordinate_systems.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Module containing the coordinate systems service implementation for v0."""
+
+import grpc
+
+from ansys.geometry.core.errors import protect_grpc
+
+from ..base.coordinate_systems import GRPCCoordinateSystemService
+
+
+class GRPCCoordinateSystemServiceV0(GRPCCoordinateSystemService):
+    """Coordinate systems service for gRPC communication with the Geometry server.
+
+    This class provides methods to interact with the Geometry server's
+    coordinate systems service. It is specifically designed for the v0 version of the
+    Geometry API.
+
+    Parameters
+    ----------
+    channel : grpc.Channel
+        The gRPC channel to the server.
+    """
+
+    @protect_grpc
+    def __init__(self, channel: grpc.Channel):  # noqa: D102
+        from ansys.api.geometry.v0.coordinatesystems_pb2_grpc import CoordinateSystemsStub
+
+        self.stub = CoordinateSystemsStub(channel)
+
+    @protect_grpc
+    def create(self, **kwargs) -> dict:  # noqa: D102
+        from ansys.api.geometry.v0.coordinatesystems_pb2 import CreateRequest
+        from .conversions import from_frame_to_grpc_frame, from_grpc_frame_to_frame
+
+        # Create the request - assumes all inputs are valid and of the proper type
+        request = CreateRequest(
+            parent=kwargs["parent_id"],
+            name=kwargs["name"],
+            frame=from_frame_to_grpc_frame(kwargs["frame"]),
+        )
+
+        # Call the gRPC service
+        response = self.stub.Create(request=request)
+
+        # Return the response - formatted as a dictionary
+        return {
+            "id": response.id,
+            "name": response.name,
+            "frame": from_grpc_frame_to_frame(response.frame),
+        }

--- a/src/ansys/geometry/core/_grpc/_services/v0/coordinate_systems.py
+++ b/src/ansys/geometry/core/_grpc/_services/v0/coordinate_systems.py
@@ -50,6 +50,7 @@ class GRPCCoordinateSystemServiceV0(GRPCCoordinateSystemService):
     @protect_grpc
     def create(self, **kwargs) -> dict:  # noqa: D102
         from ansys.api.geometry.v0.coordinatesystems_pb2 import CreateRequest
+
         from .conversions import from_frame_to_grpc_frame, from_grpc_frame_to_frame
 
         # Create the request - assumes all inputs are valid and of the proper type

--- a/src/ansys/geometry/core/_grpc/_services/v1/coordinate_systems.py
+++ b/src/ansys/geometry/core/_grpc/_services/v1/coordinate_systems.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Module containing the coordinate systems service implementation for v1."""
+
+import grpc
+
+from ansys.geometry.core.errors import protect_grpc
+
+from ..base.coordinate_systems import GRPCCoordinateSystemService
+
+
+class GRPCCoordinateSystemServiceV1(GRPCCoordinateSystemService):
+    """Coordinate systems service for gRPC communication with the Geometry server.
+
+    This class provides methods to interact with the Geometry server's
+    coordinate systems service. It is specifically designed for the v1 version of the
+    Geometry API.
+
+    Parameters
+    ----------
+    channel : grpc.Channel
+        The gRPC channel to the server.
+    """
+
+    @protect_grpc
+    def __init__(self, channel: grpc.Channel):  # noqa: D102
+        from ansys.api.geometry.v1.coordinatesystems_pb2_grpc import CoordinateSystemsStub
+
+        self.stub = CoordinateSystemsStub(channel)
+
+    @protect_grpc
+    def create(self, **kwargs) -> dict:  # noqa: D102
+        raise NotImplementedError

--- a/src/ansys/geometry/core/designer/coordinate_system.py
+++ b/src/ansys/geometry/core/designer/coordinate_system.py
@@ -23,15 +23,10 @@
 
 from typing import TYPE_CHECKING
 
-from ansys.api.geometry.v0.coordinatesystems_pb2 import CreateRequest
-from ansys.api.geometry.v0.coordinatesystems_pb2_grpc import CoordinateSystemsStub
 from ansys.geometry.core.connection.client import GrpcClient
 from ansys.geometry.core.connection.conversions import frame_to_grpc_frame
 from ansys.geometry.core.errors import protect_grpc
 from ansys.geometry.core.math.frame import Frame
-from ansys.geometry.core.math.point import Point3D
-from ansys.geometry.core.math.vector import UnitVector3D
-from ansys.geometry.core.misc.measurements import DEFAULT_UNITS
 
 if TYPE_CHECKING:  # pragma: no cover
     from ansys.geometry.core.designer.component import Component
@@ -67,7 +62,6 @@ class CoordinateSystem:
         """Initialize the ``CoordinateSystem`` class."""
         self._parent_component = parent_component
         self._grpc_client = grpc_client
-        self._coordinate_systems_stub = CoordinateSystemsStub(grpc_client.channel)
         self._is_alive = True
 
         # Create without going to server
@@ -78,40 +72,15 @@ class CoordinateSystem:
             return
 
         self._grpc_client.log.debug("Requesting creation of a coordinate system.")
-        new_coordinate_system = self._coordinate_systems_stub.Create(
-            CreateRequest(
-                parent=parent_component.id,
-                name=name,
-                frame=frame_to_grpc_frame(frame),
-            )
+        response = self._grpc_client.services.coordinate_systems.create(
+            parent_id=self._parent_component.id,
+            name=name,
+            frame=frame_to_grpc_frame(frame),
         )
 
-        self._id = new_coordinate_system.id
-        self._name = new_coordinate_system.name
-        self._frame = Frame(
-            Point3D(
-                [
-                    new_coordinate_system.frame.origin.x,
-                    new_coordinate_system.frame.origin.y,
-                    new_coordinate_system.frame.origin.z,
-                ],
-                DEFAULT_UNITS.SERVER_LENGTH,
-            ),
-            UnitVector3D(
-                [
-                    new_coordinate_system.frame.dir_x.x,
-                    new_coordinate_system.frame.dir_x.y,
-                    new_coordinate_system.frame.dir_x.z,
-                ]
-            ),
-            UnitVector3D(
-                [
-                    new_coordinate_system.frame.dir_y.x,
-                    new_coordinate_system.frame.dir_y.y,
-                    new_coordinate_system.frame.dir_y.z,
-                ]
-            ),
-        )
+        self._id = response.get("id")
+        self._name = response.get("name")
+        self._frame = response.get("frame")
 
     @property
     def id(self) -> str:

--- a/src/ansys/geometry/core/designer/coordinate_system.py
+++ b/src/ansys/geometry/core/designer/coordinate_system.py
@@ -24,7 +24,6 @@
 from typing import TYPE_CHECKING
 
 from ansys.geometry.core.connection.client import GrpcClient
-from ansys.geometry.core.connection.conversions import frame_to_grpc_frame
 from ansys.geometry.core.errors import protect_grpc
 from ansys.geometry.core.math.frame import Frame
 
@@ -75,7 +74,7 @@ class CoordinateSystem:
         response = self._grpc_client.services.coordinate_systems.create(
             parent_id=self._parent_component.id,
             name=name,
-            frame=frame_to_grpc_frame(frame),
+            frame=frame,
         )
 
         self._id = response.get("id")


### PR DESCRIPTION
Moves the CoordinateSystemStub to the ``_grpc`` layer.

Some extra docstring fixes are performed

Related to #1817 