### PR TITLE
docs: ignore stackoverflow link

### DIFF
--- a/doc/changelog.d/1957.documentation.md
+++ b/doc/changelog.d/1957.documentation.md
@@ -1,0 +1,1 @@
+ignore stackoverflow link

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -358,6 +358,7 @@ linkcheck_exclude_documents = ["index", "getting_started/local/index", "changelo
 linkcheck_ignore = [
     r"https://github.com/ansys/pyansys-geometry-binaries",
     r"https://download.ansys.com/",
+    r"https://stackoverflow.com/",  # Requires human authentication
     r".*/examples/.*.py",
     r".*/examples/.*.ipynb",
     r"_static/assets/.*",


### PR DESCRIPTION
## Description

Stackoverflow links now requiere human authentication. Ignoring their verification. Surfaced in #1956 