### PR TITLE
fix: core service launcher missing CADIntegration bin folder in path

### DIFF
--- a/doc/changelog.d/1958.fixed.md
+++ b/doc/changelog.d/1958.fixed.md
@@ -1,0 +1,1 @@
+core service launcher missing CADIntegration bin folder in path

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -462,7 +462,7 @@ def prepare_and_start_backend(
                 f":{root_service_folder.as_posix()}"
                 + f":{native_folder.as_posix()}"
                 + f":{cad_integration_folder_bin.as_posix()}"
-                + f":{env_copy.get("LD_LIBRARY_PATH", "")}"
+                + f":{env_copy.get('LD_LIBRARY_PATH', '')}"
             )
 
             # For Linux, we need to use the dotnet command to launch the Core Geometry Service

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -384,6 +384,7 @@ def prepare_and_start_backend(
             root_service_folder = Path(root_service_folder)
         native_folder = root_service_folder / "Native"
         cad_integration_folder = root_service_folder / "CADIntegration"
+        cad_integration_folder_bin = cad_integration_folder / "bin"
         schema_folder = root_service_folder / "Schema"
 
         # Adapt the native folder to the OS
@@ -427,7 +428,7 @@ def prepare_and_start_backend(
                 f"{env_copy['PATH']}"
                 + f";{root_service_folder.as_posix()}"
                 + f";{native_folder.as_posix()}"
-                + f";{cad_integration_folder.as_posix()}"
+                + f";{cad_integration_folder_bin.as_posix()}"
             )
 
             # For Windows, we need to use the exe file to launch the Core Geometry Service
@@ -461,7 +462,7 @@ def prepare_and_start_backend(
                 env_copy.get("LD_LIBRARY_PATH", "")
                 + f":{root_service_folder.as_posix()}"
                 + f":{native_folder.as_posix()}"
-                + f":{cad_integration_folder.as_posix()}"
+                + f":{cad_integration_folder_bin.as_posix()}"
             )
 
             # For Linux, we need to use the dotnet command to launch the Core Geometry Service

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -459,7 +459,7 @@ def prepare_and_start_backend(
 
             # Modify the LD_LIBRARY_PATH variable to include the Ansys Geometry Core Service
             env_copy["LD_LIBRARY_PATH"] = (
-                f":{root_service_folder.as_posix()}"
+                f"{root_service_folder.as_posix()}"
                 + f":{native_folder.as_posix()}"
                 + f":{cad_integration_folder_bin.as_posix()}"
                 + f":{env_copy.get('LD_LIBRARY_PATH', '')}"

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -425,10 +425,10 @@ def prepare_and_start_backend(
         if os.name == "nt":
             # Modify the PATH variable to include the path to the Ansys Geometry Core Service
             env_copy["PATH"] = (
-                f"{env_copy['PATH']}"
-                + f";{root_service_folder.as_posix()}"
+                f"{root_service_folder.as_posix()}"
                 + f";{native_folder.as_posix()}"
                 + f";{cad_integration_folder_bin.as_posix()}"
+                + f";{env_copy['PATH']}"
             )
 
             # For Windows, we need to use the exe file to launch the Core Geometry Service
@@ -459,10 +459,10 @@ def prepare_and_start_backend(
 
             # Modify the LD_LIBRARY_PATH variable to include the Ansys Geometry Core Service
             env_copy["LD_LIBRARY_PATH"] = (
-                env_copy.get("LD_LIBRARY_PATH", "")
-                + f":{root_service_folder.as_posix()}"
+                f":{root_service_folder.as_posix()}"
                 + f":{native_folder.as_posix()}"
                 + f":{cad_integration_folder_bin.as_posix()}"
+                + f":{env_copy.get("LD_LIBRARY_PATH", "")}"
             )
 
             # For Linux, we need to use the dotnet command to launch the Core Geometry Service

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -423,7 +423,8 @@ def prepare_and_start_backend(
             env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE", "1055@localhost")
 
         # Adapt the path environment variable to the OS and
-        # modify the PATH/LD_LIBRARY_PATH variable to include the path to the Ansys Geometry Core Service
+        # modify the PATH/LD_LIBRARY_PATH variable to include the path
+        # to the Ansys Geometry Core Service
         path_env_var = "PATH" if os.name == "nt" else "LD_LIBRARY_PATH"
         env_copy[path_env_var] = os.pathsep.join(
             [


### PR DESCRIPTION
## Description
Seems like ``LD_LIBRARY_PATH`` (on Linux) and ``PATH`` (on Windows) need to have ``CADIntegration/bin`` defined... Also, prepending to both ``LD_LIBRARY_PATH`` and ``PATH`` to avoid import resolution issues

## Issue linked
Closes #1955

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
