### PR TITLE
fix: make sure export_glb is handling a single Polydata object

### DIFF
--- a/doc/changelog.d/2032.fixed.md
+++ b/doc/changelog.d/2032.fixed.md
@@ -1,0 +1,1 @@
+Make sure export_glb is handling a single polydata object

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -557,6 +557,24 @@ class GeometryPlotter(PlotterInterface):
         ~pathlib.Path
             Path to the exported glb file.
         """
+        # Export to GLB requires merging the object into a single mesh
+        LOG.debug(
+            "Exporting to GLB requires merging the object into a single mesh. "
+            "This may take some time depending on the size of the object."
+        )
+        LOG.debug(
+            "When calling export_glb, if you had previously set the plotting_options "
+            "'merge_bodies' or 'merge_component' to False, they will be ignored."
+        )
+        plotting_options["merge_component"] = True
+        plotting_options["merge_bodies"] = True
+        if plotting_object is None:
+            LOG.warning(
+                "If you had previously added the objects to the plotter, "
+                "make sure that the options 'merge_bodies' and 'merge_component' "
+                "are set to True, otherwise the export will not work as expected."
+            )
+
         if plotting_object is not None:
             self.plot(plotting_object, **plotting_options)
 

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -577,6 +577,7 @@ class GeometryPlotter(PlotterInterface):
                 "make sure that the options 'merge_bodies' and 'merge_component' "
                 "are set to True, otherwise the export will not work as expected."
             )
+
         # Depending on whether a name is provided, the file will be saved with the name
         # provided or with a default name (temp_glb). If a name is provided, the file will
         # be saved in the current working directory. If a path is provided, the file will be

--- a/src/ansys/geometry/core/plotting/plotter.py
+++ b/src/ansys/geometry/core/plotting/plotter.py
@@ -568,16 +568,15 @@ class GeometryPlotter(PlotterInterface):
         )
         plotting_options["merge_component"] = True
         plotting_options["merge_bodies"] = True
-        if plotting_object is None:
+
+        if plotting_object is not None:
+            self.plot(plotting_object, **plotting_options)
+        else:
             LOG.warning(
                 "If you had previously added the objects to the plotter, "
                 "make sure that the options 'merge_bodies' and 'merge_component' "
                 "are set to True, otherwise the export will not work as expected."
             )
-
-        if plotting_object is not None:
-            self.plot(plotting_object, **plotting_options)
-
         # Depending on whether a name is provided, the file will be saved with the name
         # provided or with a default name (temp_glb). If a name is provided, the file will
         # be saved in the current working directory. If a path is provided, the file will be


### PR DESCRIPTION
## Description
``export_glb`` requires that the actor is a single Polydata. Multiblock's are not handled properly by PyVista's export_gltf function.

## Issue linked
Closes #2030

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
