### PR TITLE
build: limiting ansys-tools-visualization-interface

### DIFF
--- a/doc/changelog.d/2054.dependencies.md
+++ b/doc/changelog.d/2054.dependencies.md
@@ -1,0 +1,1 @@
+Limiting ansys-tools-visualization-interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [project.optional-dependencies]
 graphics = [
-    "ansys-tools-visualization-interface>=0.2.6,<1",
+    "ansys-tools-visualization-interface>=0.2.6,<0.10",
     "pygltflib>=1.16,<2",
     "pyvista[jupyter]>=0.38.1,<1",
     "vtk>=9,<10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ graphics = [
 ]
 all = [
     "ansys-platform-instancemanagement>=1.0.3,<2",
-    "ansys-tools-visualization-interface>=0.2.6,<1",
+    "ansys-tools-visualization-interface>=0.2.6,<0.10",
     "docker>=6.0.1,<8",
     "pygltflib>=1.16,<2",
     "pyvista[jupyter]>=0.38.1,<1",


### PR DESCRIPTION
After the ``ansys-tools-visualization-interface`` 0.10.0 release, we are seeing plenty of failures on our tests. Limiting the minor version until its handled...