### PR TITLE
fix: change ``iterdir()`` for ``rglob('*')``

### DIFF
--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -442,7 +442,7 @@ class Modeler:
                 ext in str(file_path) for ext in [".CATProduct", ".asm", ".solution", ".sldasm"]
             ):
                 dir = fp_path.parent
-                for file in dir.iterdir():
+                for file in dir.rglob("*"):
                     full_path = file.resolve()
                     if full_path != fp_path:
                         if full_path.stat().st_size < pygeom_defaults.MAX_MESSAGE_LENGTH:


### PR DESCRIPTION
## Description
Instead of iterating the top-level of the directory, let's retrieve all files and upload them directly.

## Issue linked
Closes #2099 

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
