### PR TITLE
docs: removing DeepWiki badge per legal request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,6 @@
 |pyansys| |python| |MIT| |ruff|
 |codecov| |GH-CI| |pre-commit|
 |pypi| |pypi-downloads| |conda| |conda-downloads|
-|deep-wiki|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/
@@ -52,10 +51,6 @@
 .. |pre-commit| image:: https://results.pre-commit.ci/badge/github/ansys/pyansys-geometry/main.svg
    :target: https://results.pre-commit.ci/latest/github/ansys/pyansys-geometry/main
    :alt: pre-commit.ci
-
-.. |deep-wiki| image:: https://deepwiki.com/badge.svg
-   :target: https://deepwiki.com/ansys/pyansys-geometry
-   :alt: Ask DeepWiki
 
 .. contents::
 


### PR DESCRIPTION
## Description
Removing DeepWiki badge as requested by legal

## Issue linked
None

