### PR TITLE
fix: make import component named selections optional

### DIFF
--- a/src/ansys/geometry/core/_grpc/_services/v0/designs.py
+++ b/src/ansys/geometry/core/_grpc/_services/v0/designs.py
@@ -156,7 +156,9 @@ class GRPCDesignsServiceV0(GRPCDesignsService):  # pragma: no cover
         from ansys.api.dbu.v0.designs_pb2 import InsertRequest
 
         # Create the request - assumes all inputs are valid and of the proper type
-        request = InsertRequest(filepath=kwargs["filepath"])
+        request = InsertRequest(
+            filepath=kwargs["filepath"], import_named_selections=kwargs["import_named_selections"]
+        )
 
         # Call the gRPC service
         _ = self.stub.Insert(request)

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -961,6 +961,8 @@ class Design(Component):
         ----------
         file_location : ~pathlib.Path | str
             Location on disk where the file is located.
+        import_named_selections : bool, default: True
+            Import the named selections associated with the file being inserted if ``True``.
         import_options : ImportOptions
             The options to pass into upload file
 

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -950,7 +950,10 @@ class Design(Component):
     @ensure_design_is_active
     @min_backend_version(24, 2, 0)
     def insert_file(
-        self, file_location: Path | str, import_options: ImportOptions = ImportOptions()
+        self,
+        file_location: Path | str,
+        import_named_selections=True,
+        import_options: ImportOptions = ImportOptions(),
     ) -> Component:
         """Insert a file into the design.
 
@@ -974,7 +977,9 @@ class Design(Component):
         filepath_server = self._modeler._upload_file(file_location, import_options=import_options)
 
         # Insert the file into the design
-        self._grpc_client.services.designs.insert(filepath=filepath_server)
+        self._grpc_client.services.designs.insert(
+            filepath=filepath_server, import_named_selections=import_named_selections
+        )
         self._grpc_client.log.debug(f"File {file_location} successfully inserted into design.")
 
         self._update_design_inplace()


### PR DESCRIPTION
## Description
When inserting a file, now specify if you want named selection to be imported, defaults True.

## Issue linked


## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
