### PR TITLE
ci: remove temporarily 25.1 backwards compatibility checks

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -42,8 +42,10 @@ jobs:
             backend-version: "24.1"
           - image-tag: "windows-24.2"
             backend-version: "24.2"
-          - image-tag: "windows-25.1"
-            backend-version: "25.1"
+          # TODO: This has to be reverted once the issue with 25.1 has been solved
+          # https://github.com/ansys/pyansys-geometry/issues/2167
+          # - image-tag: "windows-25.1"
+          #   backend-version: "25.1"
           - image-tag: "core-windows-25.2"
             backend-version: "25.2"
     steps:

--- a/doc/changelog.d/2168.maintenance.md
+++ b/doc/changelog.d/2168.maintenance.md
@@ -1,0 +1,1 @@
+Remove temporarily 25.1 backwards compatibility checks


### PR DESCRIPTION
## Description
Problems observed with 25.1 image. Reverting checks temporarily. Once https://github.com/ansys/pyansys-geometry/issues/2167 is solved, we can reactivate them
