### PR TITLE
ci: enable timeout for pytest to prevent blockage

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -101,6 +101,7 @@ jobs:
           python -c "from ansys.geometry.core.connection.validate import validate; validate()"
 
       - name: Testing
+        timeout-minutes: 20  # On Windows self-hosted runners, sometimes hangs...
         run: |
           .\.venv\Scripts\Activate.ps1
           pytest -v --backwards-compatibility=yes --backend-version=${{ matrix.backend-version }} -rf

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -264,6 +264,7 @@ jobs:
 
       - name: Testing
         if: env.SKIP_UNSTABLE == 'false'
+        timeout-minutes: 20  # On Windows self-hosted runners, sometimes hangs...
         run: |
           .\.venv\Scripts\Activate.ps1
           pytest -v
@@ -781,6 +782,7 @@ jobs:
           python -c "from ansys.geometry.core.connection.validate import validate; validate()"
 
       - name: Testing
+        timeout-minutes: 20  # On Windows self-hosted runners, sometimes hangs...
         run: |
           .\.venv\Scripts\Activate.ps1
           pytest -v --use-existing-service=yes

--- a/.github/workflows/nightly_docker_test.yml
+++ b/.github/workflows/nightly_docker_test.yml
@@ -141,6 +141,7 @@ jobs:
           python -c "from ansys.geometry.core.connection.validate import validate; validate()"
 
       - name: Run PyAnsys Geometry tests
+        timeout-minutes: 20  # On Windows self-hosted runners, sometimes hangs...
         run: |
           .\.venv\Scripts\Activate.ps1
           pytest -v


### PR DESCRIPTION
## Description
Prevent blockage of runner usage (self-hosted) when running test phases. Sometimes they keep running for hours because pytest hangs. This will prevent it.

