### PR TITLE
fix: add skip_if_discovery method

### DIFF
--- a/doc/changelog.d/2202.fixed.md
+++ b/doc/changelog.d/2202.fixed.md
@@ -1,0 +1,1 @@
+Add skip_if_discovery method

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,10 +89,14 @@ def skip_if_spaceclaim(modeler: Modeler, test_name: str, element_not_available: 
 
 def skip_if_discovery(modeler: Modeler, test_name: str, element_not_available: str):
     """Skip test if running on Discovery."""
-    if modeler.client.backend_type == BackendType.DISCOVERY or modeler.client.backend_type == BackendType.DISCOVERY_HEADLESS:
+    if (
+        modeler.client.backend_type == BackendType.DISCOVERY
+        or modeler.client.backend_type == BackendType.DISCOVERY_HEADLESS
+    ):
         pytest.skip(
             reason=f"Skipping '{test_name}'. '{element_not_available}' not on Discovery."
         )  # skip!
+
 
 @pytest.fixture(scope="session")
 def docker_instance(use_existing_service):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,13 @@ def skip_if_spaceclaim(modeler: Modeler, test_name: str, element_not_available: 
         )  # skip!
 
 
+def skip_if_discovery(modeler: Modeler, test_name: str, element_not_available: str):
+    """Skip test if running on Discovery."""
+    if modeler.client.backend_type == BackendType.DISCOVERY or modeler.client.backend_type == BackendType.DISCOVERY_HEADLESS:
+        pytest.skip(
+            reason=f"Skipping '{test_name}'. '{element_not_available}' not on Discovery."
+        )  # skip!
+
 @pytest.fixture(scope="session")
 def docker_instance(use_existing_service):
     # This will only have a value in case that:

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -161,7 +161,9 @@ def _checker_method(comp: Component, comp_ref: Component, precise_check: bool = 
 
 def test_export_to_scdocx(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to scdocx format."""
-    skip_if_discovery(modeler, test_export_to_scdocx.__name__, "SCDOCX format")  # Skip test on Discovery
+    skip_if_discovery(
+        modeler, test_export_to_scdocx.__name__, "SCDOCX format"
+    )  # Skip test on Discovery
 
     # Create a demo design
     design = _create_demo_design(modeler)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -322,7 +322,7 @@ def test_export_to_iges(modeler: Modeler, tmp_path_factory: pytest.TempPathFacto
 
 def test_export_to_fmd(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to FMD format."""
-    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(modeler, test_export_to_fmd.__name__, "FMD format")  # Skip test on Discovery
 
     # Create a demo design
     design = _create_demo_design(modeler)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -364,7 +364,9 @@ def test_import_export_reimport_design_scdocx(
     modeler: Modeler, tmp_path_factory: pytest.TempPathFactory
 ):
     """Test importing, exporting, and re-importing a design file."""
-    skip_if_discovery(modeler, test_import_export_reimport_design_scdocx.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(
+        modeler, test_import_export_reimport_design_scdocx.__name__, "design"
+    )  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file = Path(FILES_DIR, "reactorWNS.scdocx")

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -365,7 +365,7 @@ def test_import_export_reimport_design_scdocx(
 ):
     """Test importing, exporting, and re-importing a design file."""
     skip_if_discovery(
-        modeler, test_import_export_reimport_design_scdocx.__name__, "design"
+        modeler, test_import_export_reimport_design_scdocx.__name__, "SCDOCX format"
     )  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -462,7 +462,7 @@ def test_import_export_open_file_design(
     expected_bodies,
 ):
     """Test importing, exporting, and opening a file in a new design."""
-    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(modeler, test_import_export_open_file_design.__name__, "design")  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file_path = Path(FILES_DIR, original_file)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -464,7 +464,9 @@ def test_import_export_open_file_design(
     expected_bodies,
 ):
     """Test importing, exporting, and opening a file in a new design."""
-    skip_if_discovery(modeler, test_import_export_open_file_design.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(
+        modeler, test_import_export_open_file_design.__name__, "design"
+    )  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file_path = Path(FILES_DIR, original_file)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -364,7 +364,7 @@ def test_import_export_reimport_design_scdocx(
     modeler: Modeler, tmp_path_factory: pytest.TempPathFactory
 ):
     """Test importing, exporting, and re-importing a design file."""
-    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(modeler, test_import_export_reimport_design_scdocx.__name__, "design")  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file = Path(FILES_DIR, "reactorWNS.scdocx")

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -161,7 +161,7 @@ def _checker_method(comp: Component, comp_ref: Component, precise_check: bool = 
 
 def test_export_to_scdocx(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to scdocx format."""
-    skip_if_discovery(modeler, test_export_to_scdocx.__name__, "design")  # Skip test on Discovery
+    skip_if_discovery(modeler, test_export_to_scdocx.__name__, "SCDOCX format")  # Skip test on Discovery
 
     # Create a demo design
     design = _create_demo_design(modeler)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -38,6 +38,7 @@ from .conftest import (
     skip_if_core_service,
     skip_if_spaceclaim,
     skip_if_windows,
+    skip_if_discovery,
 )
 
 
@@ -160,6 +161,8 @@ def _checker_method(comp: Component, comp_ref: Component, precise_check: bool = 
 
 def test_export_to_scdocx(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to scdocx format."""
+    skip_if_discovery(modeler, test_export_to_scdocx.__name__, "design")  # Skip test on Discovery
+    
     # Create a demo design
     design = _create_demo_design(modeler)
 
@@ -319,6 +322,7 @@ def test_export_to_iges(modeler: Modeler, tmp_path_factory: pytest.TempPathFacto
 
 def test_export_to_fmd(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to FMD format."""
+    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
 
     # Create a demo design
     design = _create_demo_design(modeler)
@@ -360,6 +364,7 @@ def test_import_export_reimport_design_scdocx(
     modeler: Modeler, tmp_path_factory: pytest.TempPathFactory
 ):
     """Test importing, exporting, and re-importing a design file."""
+    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file = Path(FILES_DIR, "reactorWNS.scdocx")
@@ -457,6 +462,7 @@ def test_import_export_open_file_design(
     expected_bodies,
 ):
     """Test importing, exporting, and opening a file in a new design."""
+    skip_if_discovery(modeler, test_export_to_fmd.__name__, "design")  # Skip test on Discovery
     # Define the working directory and file paths
     working_directory = tmp_path_factory.mktemp("test_import_export_reimport")
     original_file_path = Path(FILES_DIR, original_file)

--- a/tests/integration/test_design_export.py
+++ b/tests/integration/test_design_export.py
@@ -36,9 +36,9 @@ from ..conftest import are_graphics_available
 from .conftest import (
     FILES_DIR,
     skip_if_core_service,
+    skip_if_discovery,
     skip_if_spaceclaim,
     skip_if_windows,
-    skip_if_discovery,
 )
 
 
@@ -162,7 +162,7 @@ def _checker_method(comp: Component, comp_ref: Component, precise_check: bool = 
 def test_export_to_scdocx(modeler: Modeler, tmp_path_factory: pytest.TempPathFactory):
     """Test exporting a design to scdocx format."""
     skip_if_discovery(modeler, test_export_to_scdocx.__name__, "design")  # Skip test on Discovery
-    
+
     # Create a demo design
     design = _create_demo_design(modeler)
 


### PR DESCRIPTION
Add skip_if_discovery method
skip export tests for unsupported formats in Discovery

## Description
**Please provide a brief description of the changes made in this pull request.**
Skip unsupported formats when testing against Discovery

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**
https://github.com/ansys/pyansys-geometry/discussions/2201

## Checklist
- [X] I have tested my changes locally.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
