### PR TITLE
fix: empty tessellation data conversion

### DIFF
--- a/src/ansys/geometry/core/_grpc/_services/v0/conversions.py
+++ b/src/ansys/geometry/core/_grpc/_services/v0/conversions.py
@@ -369,6 +369,9 @@ def from_grpc_tess_to_pd(tess: GRPCTessellation) -> "pv.PolyData":
     import numpy as np
     import pyvista as pv
 
+    if len(tess.faces) == 0 or len(tess.vertices) == 0:
+        return pv.PolyData()
+
     return pv.PolyData(var_inp=np.array(tess.vertices).reshape(-1, 3), faces=tess.faces)
 
 


### PR DESCRIPTION
## Description
- addresses issue where tessellation fails to convert from gRPC object to Polydata when tessellation response data has empty vertices/faces arrays

## Issue linked
TFS Bug 1335500

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
