### PR TITLE
test: reverting PR re-enable part of extrusion failures test (#2520)

### DIFF
--- a/doc/changelog.d/2520.test.md
+++ b/doc/changelog.d/2520.test.md
@@ -1,1 +1,0 @@
-Re-enable part of extrusion failures test

--- a/tests/integration/test_geometry_commands.py
+++ b/tests/integration/test_geometry_commands.py
@@ -1502,21 +1502,24 @@ def test_failures_to_extrude(modeler: Modeler):
     assert results == []
     assert len(design.bodies[0].faces) == 1
     assert len(design.bodies[1].faces) == 1
-
     # Failing to revolve face by helix
-    if modeler._grpc_client.backend_version >= (25, 2, 0):
-        modeler.geometry_commands.revolve_faces_by_helix(
-            circle_surface.faces[0],
-            Line([0.5, 0.5, 0], [0, 0, 1]),
-            UnitVector3D([1, 0, 0]),
-            5,
-            1,
-            np.pi / 4,
-            True,
-            True,
-        )
-
-        assert len(design.bodies[1].faces) == 4
+    # Commenting out test due to it causing a segfault inside the container
+    # modeler.geometry_commands.revolve_faces_by_helix(
+    #     circle_surface.faces[0],
+    #     Line([0.5, 0.5, 0], [0, 0, 1]),
+    #     UnitVector3D([1, 0, 0]),
+    #     5,
+    #     1,
+    #     np.pi / 4,
+    #     True,
+    #     True,
+    # )
+    # assert len(design.bodies[0].faces) == 1
+    # # Only in 252 does the revolve not fail. This is reproducible in 252 SpaceClaim and latest
+    # if modeler._grpc_client.backend_version == "25.2.0":
+    #     assert len(design.bodies[1].faces) == 4
+    # else:
+    #     assert len(design.bodies[1].faces) == 1
 
 
 def test_offset_faces(modeler: Modeler):


### PR DESCRIPTION
This reverts commit 8c12ecef02881de367fdb45aebb7bb5c995206b5.

