### PR TITLE
docs: remove warnings on doc build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,6 +38,10 @@ BUILD_API = True if os.environ.get("BUILD_API", "true") == "true" else False
 BUILD_EXAMPLES = True if os.environ.get("BUILD_EXAMPLES", "true") == "true" else False
 BUILD_CHEATSHEET = True if os.environ.get("BUILD_CHEATSHEET", "true") == "true" else False
 
+# Make sure it gets defined.. to skip warnings in docs build
+if BUILD_EXAMPLES:
+    os.environ["PYANSYS_GEOMETRY_BUILD_EXAMPLES"] = "true"
+
 ############################################################################
 
 LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml"]

--- a/src/ansys/geometry/core/logger.py
+++ b/src/ansys/geometry/core/logger.py
@@ -129,8 +129,10 @@ these loggers.
 from copy import copy
 from datetime import datetime
 import logging
+import os
 import sys
 from typing import TYPE_CHECKING
+import warnings
 import weakref
 
 from ansys.geometry.core.misc.checks import check_type
@@ -650,3 +652,11 @@ def add_stdout_handler(logger, level=LOG_LEVEL, write_headers=False):
 
 LOG = Logger(level=logging.WARNING, to_file=False, to_stdout=True)
 LOG.debug("Loaded logging module as LOG")
+
+# For documentation build
+if os.environ.get("PYANSYS_GEOMETRY_BUILD_EXAMPLES", "false") == "true":
+    LOG.setLevel(logging.ERROR)
+    # Skip UserWarning as well...
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, message="Starting gRPC client without TLS .*"
+    )


### PR DESCRIPTION
As title says - we should remove these warnings from the documentation since they are not useful for users visualizing them