### PR TITLE
ci: run smoke tests with and without optional target

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -92,6 +92,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        target: ['', 'all']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -104,7 +105,7 @@ jobs:
           library-name: ${{ env.PACKAGE_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          target: 'all'
+          target: ${{ matrix.target }}
 
   docker-style:
     name: Docker Style Check

--- a/doc/changelog.d/2714.maintenance.md
+++ b/doc/changelog.d/2714.maintenance.md
@@ -1,0 +1,1 @@
+Run smoke tests with and without optional target


### PR DESCRIPTION
## Description
This PR enforces that the `ansys/actions/build-wheelhouse` not only runs with the `all` target but also without any optional dependencies. While this will populate the release artifacts (filtering feature under development in https://github.com/ansys/actions/pull/1260), it will ensure that the smoke test really does what we expect it to do.

In a recent release of `pyaedt`, we were impacted by such an issue due to some type hints improvement and refactoring. When running with `all` target nothing was wrong but installing `pyaedt` and then running `import ansys.aedt.core` led us to an import error associated to a graphic dependency.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
