### PR TITLE
fix: deprecate save method

### DIFF
--- a/doc/changelog.d/2732.fixed.md
+++ b/doc/changelog.d/2732.fixed.md
@@ -1,0 +1,1 @@
+Deprecate save method

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -377,6 +377,7 @@ linkcheck_ignore = [
     r"https://download.ansys.com/",
     r"https://stackoverflow.com/",  # Requires human authentication
     r"https://docs.pyvista.org/",  # Intermittent timeout issues
+    r"https://docs.conda.io/",  # Intermittent timeout issues
     r".*/examples/.*.py",
     r".*/examples/.*.ipynb",
     r"_static/assets/.*",

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -269,7 +269,7 @@ class Design(Component):
         "export_to_*",
         "use the export_to_* or download methods instead",
         "0.15.2",
-        "0.16.0",
+        "0.17.0",
     )
     def save(self, file_location: Path | str, write_body_facets: bool = False) -> None:
         """Save a design to disk on the active Geometry server instance.

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -59,6 +59,7 @@ from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.math.vector import UnitVector3D, Vector3D
 from ansys.geometry.core.misc.auxiliary import prepare_file_for_server_upload
 from ansys.geometry.core.misc.checks import (
+    deprecated_method,
     ensure_design_is_active,
     min_backend_version,
 )
@@ -264,6 +265,12 @@ class Design(Component):
 
     @check_input_types
     @ensure_design_is_active
+    @deprecated_method(
+        "export_to_*",
+        "use the export_to_* or download methods instead",
+        "0.15.2",
+        "0.16.0",
+    )
     def save(self, file_location: Path | str, write_body_facets: bool = False) -> None:
         """Save a design to disk on the active Geometry server instance.
 


### PR DESCRIPTION
## Description
As title says. This should not be used as download or export_to_* methods do the same without the limitation of saving to scdocx file type.

## Issue linked
Related to #2729 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
