### PR TITLE
chore: removing backwards-compatibility testing for 24R1

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -97,7 +97,7 @@ jobs:
           }
 
       - name: Define SERVER_ENDPOINT variable if needed
-        if: matrix.backend-version == '24.1' || matrix.backend-version == '24.2' || matrix.backend-version == '25.1'
+        if: matrix.backend-version == '24.2' || matrix.backend-version == '25.1'
         run: |
           $env:SERVER_ENDPOINT = "-e SERVER_ENDPOINT=50051@0.0.0.0"
           echo "SERVER_ENDPOINT variable set to: $env:SERVER_ENDPOINT"

--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -37,8 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image-tag: "windows-24.1"
-            backend-version: "24.1"
           - image-tag: "windows-24.2"
             backend-version: "24.2"
           - image-tag: "windows-25.1"

--- a/doc/changelog.d/2757.maintenance.md
+++ b/doc/changelog.d/2757.maintenance.md
@@ -1,0 +1,1 @@
+Removing backwards-compatibility testing for 24R1


### PR DESCRIPTION
## Description
24R1 backwards compatibility checks are no longer needed. Let's alleviate some workload on CI/CD...

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
