### PR TITLE
feat: if license server points to localhost on docker use gateway

### DIFF
--- a/doc/changelog.d/2766.added.md
+++ b/doc/changelog.d/2766.added.md
@@ -1,0 +1,1 @@
+If license server points to localhost on docker use gateway

--- a/src/ansys/geometry/core/connection/docker_instance.py
+++ b/src/ansys/geometry/core/connection/docker_instance.py
@@ -368,6 +368,14 @@ class LocalDockerInstance:
             )
         if not license_server and bypass_token:
             license_server = ""
+        # If license server contains localhost.. replace it with host.docker.internal for better
+        # compatibility with Docker on Windows and MacOS
+        if license_server and "localhost" in license_server:
+            license_server = license_server.replace("localhost", "host.docker.internal")
+            LOG.info(
+                "License server contained 'localhost'... Replacing it with "
+                "'host.docker.internal' for better compatibility with Docker on Windows and MacOS."
+            )
 
         # Verify the transport mode
         if transport_mode:


### PR DESCRIPTION
## Description
When leveraging docker containers, we cannot use local license servers easily. We must force the docker container to resolve the "localhost" IP via the docker gateway (host.docker.internal).

This is mostly a benefit for local development.

## Issue linked
None

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
