### PR TITLE
fix: check lowercase assembly file extensions

### DIFF
--- a/doc/changelog.d/2784.fixed.md
+++ b/doc/changelog.d/2784.fixed.md
@@ -1,0 +1,1 @@
+Check lowercase assembly file extensions

--- a/src/ansys/geometry/core/misc/auxiliary.py
+++ b/src/ansys/geometry/core/misc/auxiliary.py
@@ -459,8 +459,8 @@ def prepare_file_for_server_upload(file_path: Path) -> Path:
         zipf.write(file_path, file_path.name)
 
         # If it's an assembly format, add all files from the same directory
-        assembly_extensions = [".CATProduct", ".asm", ".solution", ".sldasm"]
-        if any(ext in str(file_path) for ext in assembly_extensions):
+        assembly_extensions = [".catproduct", ".asm", ".solution", ".sldasm"]
+        if any(ext in str(file_path).lower() for ext in assembly_extensions):
             dir_path = file_path.parent
             for file in dir_path.iterdir():
                 if file.is_file() and file != file_path:

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -442,7 +442,8 @@ class Modeler:
             fp_path = Path(file_path)
             file_size_kb = fp_path.stat().st_size
             if any(
-                ext in str(file_path).lower() for ext in [".catproduct", ".asm", ".solution", ".sldasm"]
+                ext in str(file_path).lower()
+                for ext in [".catproduct", ".asm", ".solution", ".sldasm"]
             ):
                 dir = fp_path.parent
                 for file in dir.iterdir():

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -442,7 +442,7 @@ class Modeler:
             fp_path = Path(file_path)
             file_size_kb = fp_path.stat().st_size
             if any(
-                ext in str(file_path) for ext in [".CATProduct", ".asm", ".solution", ".sldasm"]
+                ext in str(file_path).lower() for ext in [".catproduct", ".asm", ".solution", ".sldasm"]
             ):
                 dir = fp_path.parent
                 for file in dir.iterdir():


### PR DESCRIPTION
## Description
Convert filepath to lowercase before checking if extension is an assembly. We were missing the block to zip/stream the entire directory for extensions with different cases.

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
