### PR TITLE
fix: pyproject-fmt hook error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     rev: a007bb7dd9043d022292401abc3061cb1906b4bc # frozen: v2.21.2
     hooks:
       - id: pyproject-fmt
+        additional_dependencies: [toml-fmt-common<1.3.3]
         args: [--keep-full-version]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/doc/changelog.d/2813.fixed.md
+++ b/doc/changelog.d/2813.fixed.md
@@ -1,0 +1,1 @@
+Pyproject-fmt hook error


### PR DESCRIPTION
## Description
`pyproject-fmt` pre-commit hook is currently broken because of a breaking change in the latest release of `toml-fmt-common`, on which `pyproject-fmt` depends.

## Issue linked
This was detected in the ci of **ansys/actions** as we test the code-style action against **pyansys-geometry**. See https://github.com/tox-dev/toml-fmt/issues/355 for full details. The maintainer seems to be working on a fix, so an alternative action could be to just wait for that. I will leave to @ansys/pyansys-geometry-maintainers to decide.

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
