### PR TITLE
fix: asset links changed

### DIFF
--- a/doc/changelog.d/2815.fixed.md
+++ b/doc/changelog.d/2815.fixed.md
@@ -1,0 +1,1 @@
+Asset links changed

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -25,7 +25,7 @@ For example, on Linux with Python 3.10, unzip the wheelhouse archive and install
 
 .. code:: bash
 
-    unzip ansys-geometry-core-v0.16.dev0-all-wheelhouse-ubuntu-latest-3.10.zip wheelhouse
+    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-latest-3.10.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you are on Windows with Python 3.10, unzip to a wheelhouse directory by running ``-d wheelhouse``

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -43,7 +43,7 @@ The following wheelhouse files are available for download:
     {{ "^" * os_name|length }}
 
     {%- for link in download_links %}
-    * `{{ link.os }} wheelhouse for Python {{ link.python_versions }} <{{ link.prefix_url }}/ansys-geometry-core-{{ link.latest_released_version }}-all-wheelhouse-{{ link.runner }}-{{ link.python_versions }}.zip>`_
+    * `{{ link.os }} wheelhouse for Python {{ link.python_versions }} <{{ link.prefix_url }}/ansys_geometry_core-{{ link.latest_released_version }}-all-wheelhouse-{{ link.runner }}-{{ link.python_versions }}.zip>`_
     {%- endfor %}
 
     {%- endfor %}

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -94,7 +94,7 @@ For example, on Linux with Python 3.10, unzip the wheelhouse archive and install
 
 .. code:: bash
 
-    unzip ansys-geometry-core-v0.16.dev0-all-wheelhouse-ubuntu-3.10.zip wheelhouse
+    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-3.10.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you are on Windows with Python 3.10, unzip the wheelhouse archive to a wheelhouse directory


### PR DESCRIPTION
## Description
With the latest ansys/actons version, the asset names changed. Modifying the wheelhouse URLs.