### PR TITLE
feat: remove the default value for LICENSE_SERVER

### DIFF
--- a/doc/changelog.d/2840.added.md
+++ b/doc/changelog.d/2840.added.md
@@ -1,0 +1,1 @@
+Remove the default value for LICENSE_SERVER

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -465,7 +465,7 @@ def prepare_and_start_backend(
             env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE")
         else:
             LOG.warning(
-                "No license server environment variable found. " \
+                "No license server environment variable found. "
                 "The Geometry Service will use the information from Ansys Licensing Settings."
             )
 

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -465,7 +465,7 @@ def prepare_and_start_backend(
             env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE")
         else:
             LOG.warning(
-                "No license server environment variable found. The Geometry Service might not be able to start without any licence information."
+                "No license server environment variable found. The Geometry Service will use the information from Ansys Licensing Settings."
             )
 
         # If token is provided, set the environment variable to bypass the license checkout process.

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -465,7 +465,8 @@ def prepare_and_start_backend(
             env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE")
         else:
             LOG.warning(
-                "No license server environment variable found. The Geometry Service will use the information from Ansys Licensing Settings."
+                "No license server environment variable found. " \
+                "The Geometry Service will use the information from Ansys Licensing Settings."
             )
 
         # If token is provided, set the environment variable to bypass the license checkout process.

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -461,8 +461,12 @@ def prepare_and_start_backend(
             pass  # Do nothing... the user has defined the license server.
         elif "ANSRV_GEO_LICENSE_SERVER" in os.environ:
             env_copy["LICENSE_SERVER"] = os.getenv("ANSRV_GEO_LICENSE_SERVER")
+        elif "ANSYSLMD_LICENSE_FILE" in os.environ:
+            env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE")
         else:
-            env_copy["LICENSE_SERVER"] = os.getenv("ANSYSLMD_LICENSE_FILE", "1055@localhost")
+            LOG.warning(
+                "No license server environment variable found. The Geometry Service might not be able to start without any licence information."
+            )
 
         # If token is provided, set the environment variable to bypass the license checkout process.
         if bypass_token:


### PR DESCRIPTION
## Description
Remove the default LICENSE_SERVER value (1055@localhost) if no environment variable is defined (LICENSE_SERVER, ANSRV_GEO_LICENSE_SERVER, ANSYSLMD_LICENSE_FILE).
This will cause the licensing client to go grab the license server address directly from the local licensing settings rather than from an environment variable.

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
