### PR TITLE
feat: use central client provider

### DIFF
--- a/doc/changelog.d/2868.added.md
+++ b/doc/changelog.d/2868.added.md
@@ -1,0 +1,1 @@
+Use central client provider

--- a/src/ansys/geometry/core/connection/__init__.py
+++ b/src/ansys/geometry/core/connection/__init__.py
@@ -22,7 +22,7 @@
 """PyAnsys Geometry connection subpackage."""
 
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider, GrpcClient
 import ansys.geometry.core.connection.defaults as defaults
 from ansys.geometry.core.connection.docker_instance import (
     GeometryContainers,

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -22,6 +22,7 @@
 """Module providing a wrapped abstraction of the gRPC stubs."""
 
 import atexit
+from contextvars import ContextVar
 import logging
 from pathlib import Path
 import time
@@ -220,6 +221,35 @@ def wait_until_healthy(
     return tmp_channel
 
 
+class ClientProvider:
+    """Ambient-context holder for the active :class:`GrpcClient` instance."""
+
+    _client: ContextVar["GrpcClient | None"] = ContextVar("client_provider", default=None)
+
+    @classmethod
+    def set(cls, client: "GrpcClient") -> None:
+        """Set the active client for the current context."""
+        cls._client.set(client)
+
+    @classmethod
+    def get(cls) -> "GrpcClient":
+        """Get the active client for the current context."""
+        client = cls._client.get()
+        if client is None:
+            raise RuntimeError("No GrpcClient has been set for the current context.")
+        return client
+
+    @classmethod
+    def get_optional(cls) -> "GrpcClient | None":
+        """Get the active client for the current context, or None if not set."""
+        return cls._client.get()
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear the active client for the current context."""
+        cls._client.set(None)
+
+
 class GrpcClient:
     """Wraps the gRPC connection for the Geometry service.
 
@@ -346,6 +376,8 @@ class GrpcClient:
         # the user calling it or not...
         atexit.register(self.close)
 
+        ClientProvider.set(self)
+
     @property
     def backend_type(self) -> BackendType:
         """Backend type.
@@ -455,6 +487,9 @@ class GrpcClient:
         if self._closed is True:  # pragma: no cover
             self.log.debug("Connection is already closed. Ignoring request.")
             return
+
+        if ClientProvider.get_optional() is self:
+            ClientProvider.clear()
 
         if self._remote_instance:
             self._remote_instance.delete()  # pragma: no cover

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -27,7 +27,7 @@ from contextvars import ContextVar
 import logging
 from pathlib import Path
 import time
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import grpc
 from grpc._channel import _InactiveRpcError
@@ -47,6 +47,9 @@ try:
     from ansys.platform.instancemanagement import Instance
 except ModuleNotFoundError:  # pragma: no cover
     pass
+
+if TYPE_CHECKING:
+    from ansys.geometry.core.modeler import Modeler
 
 
 def _create_geometry_channel(
@@ -228,9 +231,9 @@ class ClientProvider:
     _client: ContextVar["GrpcClient | None"] = ContextVar("client_provider", default=None)
 
     @classmethod
-    def set(cls, client: "GrpcClient") -> None:
+    def set(cls, modeler: "Modeler") -> None:
         """Set the active client for the current context."""
-        cls._client.set(client)
+        cls._client.set(modeler.client)
 
     @classmethod
     def get(cls) -> "GrpcClient":
@@ -377,8 +380,6 @@ class GrpcClient:
         # the user calling it or not...
         atexit.register(self.close)
 
-        ClientProvider.set(self)
-
     @property
     def backend_type(self) -> BackendType:
         """Backend type.
@@ -488,9 +489,6 @@ class GrpcClient:
         if self._closed is True:  # pragma: no cover
             self.log.debug("Connection is already closed. Ignoring request.")
             return
-
-        if ClientProvider.get_optional() is self:
-            ClientProvider.clear()
 
         if self._remote_instance:
             self._remote_instance.delete()  # pragma: no cover

--- a/src/ansys/geometry/core/designer/body.py
+++ b/src/ansys/geometry/core/designer/body.py
@@ -31,7 +31,7 @@ import matplotlib.colors as mcolors
 from pint import Quantity
 
 import ansys.geometry.core as pyansys_geom
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.edge import CurveType, Edge
 from ansys.geometry.core.designer.face import Face, SurfaceType
 from ansys.geometry.core.designer.vertex import Vertex
@@ -989,8 +989,6 @@ class MasterBody(IBody):
         User-defined label for the body.
     parent_component : Component
         Parent component to place the new component under within the design assembly.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     is_surface : bool, default: False
         Whether the master body is a surface or an 3D object (with volume). The default
         is ``False``, in which case the master body is a surface. When ``True``, the
@@ -1001,18 +999,16 @@ class MasterBody(IBody):
         self,
         id: str,
         name: str,
-        grpc_client: GrpcClient,
         is_surface: bool = False,
     ):
         """Initialize the ``MasterBody`` class."""
         check_type(id, str)
         check_type(name, str)
-        check_type(grpc_client, GrpcClient)
         check_type(is_surface, bool)
 
         self._id = id
         self._name = name
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._is_surface = is_surface
         self._surface_thickness = None
         self._surface_offset = None
@@ -1132,7 +1128,6 @@ class MasterBody(IBody):
                 face_resp.get("id"),
                 SurfaceType(face_resp.get("surface_type")),
                 body,
-                self._grpc_client,
                 face_resp.get("is_reversed"),
             )
             for face_resp in response.get("faces")
@@ -1151,7 +1146,6 @@ class MasterBody(IBody):
                 edge_resp.get("id"),
                 CurveType(edge_resp.get("curve_type")),
                 body,
-                self._grpc_client,
                 edge_resp.get("is_reversed"),
             )
             for edge_resp in response.get("edges")
@@ -2048,7 +2042,6 @@ class Body(IBody):
                 edge.get("id"),
                 CurveType(edge.get("curve_type")),
                 self,
-                self._template._grpc_client,
             )
             for edge in imprint_response.get("edges")
         ]
@@ -2058,7 +2051,6 @@ class Body(IBody):
                 face.get("id"),
                 SurfaceType(face.get("surface_type")),
                 self,
-                self._template._grpc_client,
             )
             for face in imprint_response.get("faces")
         ]
@@ -2090,7 +2082,6 @@ class Body(IBody):
                 face.get("id"),
                 SurfaceType(face.get("surface_type")),
                 self,
-                self._template._grpc_client,
             )
             for face in project_response.get("faces")
         ]
@@ -2123,7 +2114,6 @@ class Body(IBody):
                 face.get("id"),
                 SurfaceType(face.get("surface_type")),
                 self,
-                self._template._grpc_client,
             )
             for face in response.get("faces")
         ]
@@ -2200,7 +2190,6 @@ class Body(IBody):
         tb = MasterBody(
             response.get("master_id"),
             copy_name,
-            self._template._grpc_client,
             is_surface=self.is_surface,
         )
         parent._master_component.part.bodies.append(tb)

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -29,7 +29,7 @@ import uuid
 
 from pint import Quantity
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.beam import (
     Beam,
     BeamCrossSectionInfo,
@@ -157,8 +157,6 @@ class Component:
     parent_component : Component or None
         Parent component to place the new component under within the design assembly. The
         default is ``None`` only when dealing with a ``Design`` object.
-    grpc_client : GrpcClient
-        Active supporting Geometry service instance for design modeling.
     template : Component, default: None
         Template to create this component from. This creates an
         instance component that shares a master with the template component.
@@ -190,7 +188,6 @@ class Component:
         self,
         name: str,
         parent_component: Union["Component", None],
-        grpc_client: GrpcClient,
         template: Optional["Component"] = None,
         instance_name: Optional[str] = None,
         preexisting_id: str | None = None,
@@ -199,7 +196,7 @@ class Component:
     ):
         """Initialize the ``Component`` class."""
         # Initialize the client and stubs needed
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
         # Align instance name behavior with the server - empty string if None
         instance_name = instance_name if instance_name else ""
@@ -397,7 +394,6 @@ class Component:
             new = Component(
                 template_comp.name,
                 self,
-                self._grpc_client,
                 template=template_comp,
                 preexisting_id=new_id,
                 master_component=template_comp._master_component,
@@ -495,7 +491,7 @@ class Component:
             New component with no children in the design assembly.
         """
         new_comp = Component(
-            name, self, self._grpc_client, template=template, instance_name=instance_name
+            name, self, template=template, instance_name=instance_name
         )
         master = new_comp._master_component
         master_id = new_comp.id.split("/")[-1]
@@ -505,7 +501,6 @@ class Component:
                     Component(
                         name,
                         comp,
-                        self._grpc_client,
                         template=template,
                         instance_name=instance_name,
                         preexisting_id=f"{comp.id}/{master_id}",
@@ -560,7 +555,6 @@ class Component:
         tb = MasterBody(
             response["master_id"],
             response["name"],
-            self._grpc_client,
             is_surface=response["is_surface"],
         )
         self._master_component.part.bodies.append(tb)
@@ -1199,7 +1193,7 @@ class Component:
         -------
         CoordinateSystem
         """
-        self._coordinate_systems.append(CoordinateSystem(name, frame, self, self._grpc_client))
+        self._coordinate_systems.append(CoordinateSystem(name, frame, self))
         return self._coordinate_systems[-1]
 
     @check_input_types

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -491,9 +491,7 @@ class Component:
         Component
             New component with no children in the design assembly.
         """
-        new_comp = Component(
-            name, self, template=template, instance_name=instance_name
-        )
+        new_comp = Component(name, self, template=template, instance_name=instance_name)
         master = new_comp._master_component
         master_id = new_comp.id.split("/")[-1]
         for comp in self._master_component.occurrences:

--- a/src/ansys/geometry/core/designer/coordinate_system.py
+++ b/src/ansys/geometry/core/designer/coordinate_system.py
@@ -23,7 +23,7 @@
 
 from typing import TYPE_CHECKING
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.math.frame import Frame
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -44,8 +44,6 @@ class CoordinateSystem:
         Frame defining the coordinate system bounds.
     parent_component : Component, default: Component
         Parent component the coordinate system is assigned against.
-    grpc_client : GrpcClient
-        Active supporting Geometry service instance for design modeling.
     """
 
     def __init__(
@@ -53,12 +51,11 @@ class CoordinateSystem:
         name: str,
         frame: Frame,
         parent_component: "Component",
-        grpc_client: GrpcClient,
         preexisting_id: str | None = None,
     ):
         """Initialize the ``CoordinateSystem`` class."""
         self._parent_component = parent_component
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._is_alive = True
 
         # Create without going to server

--- a/src/ansys/geometry/core/designer/datumplane.py
+++ b/src/ansys/geometry/core/designer/datumplane.py
@@ -23,6 +23,7 @@
 
 from typing import TYPE_CHECKING
 
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.math.plane import Plane
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.misc.checks import min_backend_version
@@ -52,6 +53,7 @@ class DatumPlane:
         self._name = name
         self._value = plane
         self._parent_component = parent_component
+        self._grpc_client = ClientProvider.get()
         self._is_alive = True
 
     @property
@@ -74,11 +76,6 @@ class DatumPlane:
     def parent_component(self) -> "Component":
         """Parent component of the datum plane."""
         return self._parent_component
-
-    @property
-    def _grpc_client(self):
-        """Access to the gRPC client through the parent component."""
-        return self._parent_component._grpc_client
 
     @property
     def is_alive(self) -> bool:

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -30,6 +30,7 @@ from pint import Quantity, UndefinedUnitError
 
 from ansys.geometry.core._grpc._version import GeometryApiProtos
 from ansys.geometry.core.connection.backend import BackendType
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.beam import (
     Beam,
     BeamCircularProfile,
@@ -149,7 +150,7 @@ class Design(Component):
     @check_input_types
     def __init__(self, name: str, modeler: Modeler, read_existing_design: bool = False):
         """Initialize the ``Design`` class."""
-        super().__init__(name, None, modeler.client)
+        super().__init__(name, None)
 
         # Initialize needed instance variables
         self._materials = []
@@ -159,6 +160,7 @@ class Design(Component):
         self._is_active = False
         self._modeler = modeler
         self._design_tess = None
+        self._grpc_client = ClientProvider.get()
 
         # Check whether we want to process an existing design or create a new one.
         if read_existing_design:
@@ -847,7 +849,6 @@ class Design(Component):
         named_selection = NamedSelection(
             name,
             self,
-            self._grpc_client,
             bodies=bodies,
             faces=faces,
             edges=edges,
@@ -1340,7 +1341,6 @@ class Design(Component):
             c = Component(
                 comp.get("name"),
                 parent,
-                self._grpc_client,
                 preexisting_id=comp.get("id"),
                 master_component=master,
                 read_existing_comp=True,
@@ -1354,7 +1354,6 @@ class Design(Component):
             tb = MasterBody(
                 body.get("id"),
                 body.get("name"),
-                self._grpc_client,
                 is_surface=body.get("is_surface"),
             )
             part.bodies.append(tb)
@@ -1472,7 +1471,6 @@ class Design(Component):
             new_ns = NamedSelection(
                 ns.get("name"),
                 self,
-                self._grpc_client,
                 preexisting_id=ns.get("id"),
             )
             self._named_selections[new_ns.name] = new_ns
@@ -1486,7 +1484,7 @@ class Design(Component):
             for cs in coordinate_systems:
                 frame = cs.get("frame")
                 new_cs = CoordinateSystem(
-                    cs.get("name"), frame, component, self._grpc_client, cs.get("id")
+                    cs.get("name"), frame, component, cs.get("id")
                 )
                 component.coordinate_systems.append(new_cs)
                 num_created_coord_systems += 1
@@ -1536,7 +1534,6 @@ class Design(Component):
                 dc.get("length"),
                 dc.get("start"),
                 dc.get("end"),
-                self._grpc_client,
                 created_components.get(dc.get("parent_id"), self),
             )
 
@@ -1756,7 +1753,7 @@ class Design(Component):
             )
 
             if not new_body:
-                new_body = MasterBody(body_id, body_name, self._grpc_client, is_surface=is_surface)
+                new_body = MasterBody(body_id, body_name, is_surface=is_surface)
                 self._master_component.part.bodies.append(new_body)
                 self._clear_cached_bodies()
                 self._grpc_client.log.debug(
@@ -1945,7 +1942,6 @@ class Design(Component):
                 parent_component=self,
                 name=component_info["name"],
                 template=self,
-                grpc_client=self._grpc_client,
                 master_component=master_component,
                 preexisting_id=component_info["id"],
                 read_existing_comp=True,
@@ -1961,7 +1957,6 @@ class Design(Component):
                     name=component_info["name"],
                     parent_component=component,
                     template=component,
-                    grpc_client=self._grpc_client,
                     master_component=master_component,
                     preexisting_id=component_info["id"],
                     read_existing_comp=True,
@@ -2063,7 +2058,6 @@ class Design(Component):
                 new_master_body = MasterBody(
                     tracked_body_info["id"],
                     tracked_body_info["name"],
-                    self._grpc_client,
                     is_surface=tracked_body_info.get("is_surface", False),
                 )
 

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -161,7 +161,6 @@ class Design(Component):
         self._is_active = False
         self._modeler = modeler
         self._design_tess = None
-        self._grpc_client = ClientProvider.get()
 
         # Check whether we want to process an existing design or create a new one.
         if read_existing_design:

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -1484,9 +1484,7 @@ class Design(Component):
             coordinate_systems = ccs.get("coordinate_systems")
             for cs in coordinate_systems:
                 frame = cs.get("frame")
-                new_cs = CoordinateSystem(
-                    cs.get("name"), frame, component, cs.get("id")
-                )
+                new_cs = CoordinateSystem(cs.get("name"), frame, component, cs.get("id"))
                 component.coordinate_systems.append(new_cs)
                 num_created_coord_systems += 1
 

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -31,7 +31,6 @@ from pint import Quantity, UndefinedUnitError
 
 from ansys.geometry.core._grpc._version import GeometryApiProtos
 from ansys.geometry.core.connection.backend import BackendType
-from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.beam import (
     Beam,
     BeamCircularProfile,

--- a/src/ansys/geometry/core/designer/designcurve.py
+++ b/src/ansys/geometry/core/designer/designcurve.py
@@ -23,7 +23,7 @@
 
 from typing import TYPE_CHECKING
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.misc.checks import ensure_design_is_active, min_backend_version
 from ansys.geometry.core.misc.measurements import Distance
@@ -53,8 +53,6 @@ class DesignCurve:
         Start point of the curve.
     end : Point3D
         End point of the curve.
-    grpc_client : GrpcClient
-        gRPC client for communicating with the server.
     parent_component : Component
         Parent component that the curve belongs to in the design assembly.
     """
@@ -66,7 +64,6 @@ class DesignCurve:
         length: Distance,
         start: Point3D,
         end: Point3D,
-        grpc_client: GrpcClient,
         parent_component: "Component",
     ):
         """Initialize the ``DesignCurve`` class."""
@@ -75,7 +72,7 @@ class DesignCurve:
         self._length = length
         self._start = start
         self._end = end
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._parent_component = parent_component
         self._is_alive = True
         self._shape = None

--- a/src/ansys/geometry/core/designer/edge.py
+++ b/src/ansys/geometry/core/designer/edge.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 
 from pint import Quantity
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.math.bbox import BoundingBox
 from ansys.geometry.core.math.point import Point3D
@@ -67,8 +67,6 @@ class Edge:
         Type of curve that the edge forms.
     body : Body
         Parent body that the edge constructs.
-    grpc_client : GrpcClient
-        Active supporting Geometry service instance for design modeling.
     is_reversed : bool
         Direction of the edge.
     """
@@ -78,14 +76,13 @@ class Edge:
         id: str,
         curve_type: CurveType,
         body: "Body",
-        grpc_client: GrpcClient,
         is_reversed: bool = False,
     ):
         """Initialize the ``Edge`` class."""
         self._id = id
         self._curve_type = curve_type
         self._body = body
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._is_reversed = is_reversed
         self._shape = None
 
@@ -167,7 +164,6 @@ class Edge:
                 face_resp.get("id"),
                 SurfaceType(face_resp.get("surface_type")),
                 self._body,
-                self._grpc_client,
                 face_resp.get("is_reversed"),
             )
             for face_resp in response.get("faces")

--- a/src/ansys/geometry/core/designer/face.py
+++ b/src/ansys/geometry/core/designer/face.py
@@ -28,7 +28,7 @@ import matplotlib.colors as mcolors
 from pint import Quantity
 
 import ansys.geometry.core as pyansys_geom
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.edge import Edge
 from ansys.geometry.core.designer.vertex import Vertex
 from ansys.geometry.core.errors import GeometryRuntimeError
@@ -163,8 +163,6 @@ class Face:
         Type of surface that the face forms.
     body : Body
         Parent body that the face constructs.
-    grpc_client : GrpcClient
-        Active supporting Geometry service instance for design modeling.
     """
 
     def __init__(
@@ -172,14 +170,13 @@ class Face:
         id: str,
         surface_type: SurfaceType,
         body: "Body",
-        grpc_client: GrpcClient,
         is_reversed: bool = False,
     ):
         """Initialize the ``Face`` class."""
         self._id = id
         self._surface_type = surface_type
         self._body = body
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._is_reversed = is_reversed
         self._shape = None
         self._color = None
@@ -254,7 +251,6 @@ class Face:
                 edge.get("id"),
                 CurveType(edge.get("curve_type")),
                 self._body,
-                self._grpc_client,
                 edge.get("is_reversed"),
             )
             for edge in response.get("edges")
@@ -299,7 +295,6 @@ class Face:
                         response_edge.get("id"),
                         CurveType(response_edge.get("curve_type")),
                         self._body,
-                        self._grpc_client,
                         response_edge.get("is_reversed"),
                     )
                 )
@@ -529,7 +524,6 @@ class Face:
                     curve.get("end"),
                     curve.get("interval"),
                     curve.get("length"),
-                    self._grpc_client,
                 )
             )
 

--- a/src/ansys/geometry/core/designer/geometry_commands.py
+++ b/src/ansys/geometry/core/designer/geometry_commands.py
@@ -28,7 +28,7 @@ from pint import Quantity
 
 import ansys.geometry.core as pyansys_geo
 from ansys.geometry.core._grpc._version import GeometryApiProtos
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.component import Component
 from ansys.geometry.core.designer.mating_conditions import (
     AlignCondition,
@@ -150,8 +150,6 @@ class GeometryCommands:
 
     Parameters
     ----------
-    grpc_client : GrpcClient
-        gRPC client to use for the geometry commands.
     _internal_use : bool, optional
         Internal flag to prevent direct instantiation by users.
         This parameter is for internal use only.
@@ -168,14 +166,14 @@ class GeometryCommands:
     ``modeler.geometry_commands`` instead.
     """
 
-    def __init__(self, grpc_client: GrpcClient, _internal_use: bool = False):
+    def __init__(self, _internal_use: bool = False):
         """Initialize an instance of the ``GeometryCommands`` class."""
         if not _internal_use:
             raise GeometryRuntimeError(
                 "GeometryCommands should not be instantiated directly. "
                 "Use 'modeler.geometry_commands' to access geometry commands."
             )
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @min_backend_version(25, 2, 0)
     def chamfer(
@@ -2289,7 +2287,6 @@ class GeometryCommands:
                     curve_info.get("length"),
                     curve_info.get("start_point"),
                     curve_info.get("end_point"),
-                    self._grpc_client,
                     parent,
                 )
                 parent._design_curves.append(dc)
@@ -2377,7 +2374,6 @@ class GeometryCommands:
                     curve_info.get("length"),
                     curve_info.get("start_point"),
                     curve_info.get("end_point"),
-                    self._grpc_client,
                     parent,
                 )
                 parent._design_curves.append(dc)
@@ -2487,7 +2483,6 @@ class GeometryCommands:
                     curve_info.get("length"),
                     curve_info.get("start_point"),
                     curve_info.get("end_point"),
-                    self._grpc_client,
                     parent,
                 )
                 parent._design_curves.append(dc)

--- a/src/ansys/geometry/core/designer/selection.py
+++ b/src/ansys/geometry/core/designer/selection.py
@@ -23,7 +23,7 @@
 
 from typing import TYPE_CHECKING, Union
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.designer.beam import Beam
 from ansys.geometry.core.designer.body import Body
 from ansys.geometry.core.designer.component import Component
@@ -64,8 +64,6 @@ class NamedSelection:
         User-defined name for the named selection.
     design : Design
         Design instance to which the named selection belongs.
-    grpc_client : GrpcClient
-        Active supporting Geometry service instance for design modeling.
     bodies : list[Body], default: None
         All bodies to include in the named selection.
     faces : list[Face], default: None
@@ -88,7 +86,6 @@ class NamedSelection:
         self,
         name: str,
         design: "Design",
-        grpc_client: GrpcClient,
         bodies: list[Body] | None = None,
         faces: list[Face] | None = None,
         edges: list[Edge] | None = None,
@@ -102,7 +99,7 @@ class NamedSelection:
         """Initialize the ``NamedSelection`` class."""
         self._name = name
         self._design = design
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self._verified = False
 
         # Convert None to empty lists
@@ -362,7 +359,6 @@ class NamedSelection:
             new_ns = NamedSelection(
                 self._name,
                 self._design,
-                self._grpc_client,
                 bodies=bodies + self.bodies,
                 faces=faces + self.faces,
                 edges=edges + self.edges,
@@ -423,7 +419,6 @@ class NamedSelection:
             new_ns = NamedSelection(
                 self._name,
                 self._design,
-                self._grpc_client,
                 bodies=[body for body in self.bodies if body not in members],
                 faces=[face for face in self.faces if face not in members],
                 edges=[edge for edge in self.edges if edge not in members],
@@ -511,7 +506,6 @@ class NamedSelection:
                 face_id,
                 SurfaceType(face_meta_by_id[face_id].get("surface_type")),
                 body_map[face_meta_by_id[face_id].get("body_id")],
-                self._grpc_client,
                 face_meta_by_id[face_id].get("is_reversed", False),
             )
             for face_id in self._ids_cached["faces"]

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -146,11 +146,11 @@ class Modeler:
         self._design: Optional["Design"] = None
 
         # Enabling tools/commands for all: repair and prepare tools, geometry commands
-        self._measurement_tools = MeasurementTools(self._grpc_client, _internal_use=True)
-        self._repair_tools = RepairTools(self._grpc_client, self, _internal_use=True)
-        self._prepare_tools = PrepareTools(self._grpc_client, _internal_use=True)
-        self._geometry_commands = GeometryCommands(self._grpc_client, _internal_use=True)
-        self._unsupported = UnsupportedCommands(self._grpc_client, self, _internal_use=True)
+        self._measurement_tools = MeasurementTools(True)
+        self._repair_tools = RepairTools(self, True)
+        self._prepare_tools = PrepareTools(True)
+        self._geometry_commands = GeometryCommands(True)
+        self._unsupported = UnsupportedCommands(self, True)
 
     @property
     def client(self) -> GrpcClient:

--- a/src/ansys/geometry/core/modeler.py
+++ b/src/ansys/geometry/core/modeler.py
@@ -30,7 +30,7 @@ from grpc import Channel
 
 from ansys.geometry.core._grpc._version import GeometryApiProtos
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider, GrpcClient
 import ansys.geometry.core.connection.defaults as pygeom_defaults
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.misc.auxiliary import prepare_file_for_server_upload
@@ -143,6 +143,8 @@ class Modeler:
             certs_dir=certs_dir,
         )
 
+        ClientProvider.set(self)
+
         # Single design for the Modeler
         self._design: Optional["Design"] = None
 
@@ -250,6 +252,8 @@ class Modeler:
         # Close design (if requested)
         if close_design and self._design is not None:
             self._design.close()
+
+        ClientProvider.clear()
 
         # Close the client
         self.client.close()

--- a/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
+++ b/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
@@ -23,7 +23,7 @@
 
 from pint import Quantity
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.math.matrix import Matrix44
 from ansys.geometry.core.math.point import Point3D
 from ansys.geometry.core.math.vector import UnitVector3D, Vector3D
@@ -51,8 +51,6 @@ class TrimmedCurve:
         Parametric interval that bounds the curve.
     length : Quantity
         Length of the curve.
-    grpc_client : GrpcClient, default: None
-        gRPC client that is required for advanced functions such as ``intersect_curve()``.
     """
 
     def __init__(
@@ -62,7 +60,6 @@ class TrimmedCurve:
         end: Point3D,
         interval: Interval,
         length: Quantity,
-        grpc_client: GrpcClient = None,
     ):
         """Initialize ``TrimmedCurve`` class."""
         self._geometry = geometry
@@ -70,7 +67,7 @@ class TrimmedCurve:
         self._end = end
         self._interval = interval
         self._length = length
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @property
     def geometry(self) -> Curve:
@@ -254,8 +251,6 @@ class ReversedTrimmedCurve(TrimmedCurve):
         Parametric interval that bounds the curve.
     length : Quantity
         Length of the curve.
-    grpc_client : GrpcClient, default: None
-        gRPC client that is required for advanced functions such as `intersect_curve()`.
     """
 
     def __init__(
@@ -265,10 +260,9 @@ class ReversedTrimmedCurve(TrimmedCurve):
         end: Point3D,
         interval: Interval,
         length: Quantity,
-        grpc_client: GrpcClient = None,
     ):
         """Initialize an instance of a reversed trimmed curve."""
-        super().__init__(geometry, start, end, interval, length, grpc_client)
+        super().__init__(geometry, start, end, interval, length)
 
         # Swap start and end points
         temp = self._start

--- a/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
+++ b/src/ansys/geometry/core/shapes/curves/trimmed_curve.py
@@ -128,12 +128,6 @@ class TrimmedCurve:
         list[Point3D]
             All points of intersection between the curves.
         """
-        if self._grpc_client is None:
-            raise ValueError(
-                """Because this trimmed curve was not initialized with a gRPC client,
-                the method cannot be called."""
-            )
-
         response = self._grpc_client.services.curves.intersect_curves(first=self, second=other)
 
         return [] if response.get("intersect") is False else response.get("points")

--- a/src/ansys/geometry/core/tools/check_geometry.py
+++ b/src/ansys/geometry/core/tools/check_geometry.py
@@ -23,7 +23,7 @@
 
 from typing import TYPE_CHECKING
 
-from ansys.geometry.core.connection.client import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.tools.repair_tool_message import RepairToolMessage
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -91,13 +91,11 @@ class GeometryIssue:
 class InspectResult:
     """Provides the result of the inspect geometry operation."""
 
-    def __init__(self, grpc_client: GrpcClient, body: "Body", issues: list[GeometryIssue]):
+    def __init__(self, body: "Body", issues: list[GeometryIssue]):
         """Initialize a new instance of the result of the inspect geometry operation.
 
         Parameters
         ----------
-        grpc_client: GrpcClient
-            gRPC client to communicate with the server.
         body: Body
             Body for which issues are found.
         issues: list[GeometryIssue]
@@ -105,7 +103,7 @@ class InspectResult:
         """
         self._body = body
         self._issues = issues
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @property
     def body(self) -> "Body":

--- a/src/ansys/geometry/core/tools/measurement_tools.py
+++ b/src/ansys/geometry/core/tools/measurement_tools.py
@@ -23,7 +23,7 @@
 
 from typing import TYPE_CHECKING, Union
 
-from ansys.geometry.core.connection import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.misc.checks import min_backend_version
 from ansys.geometry.core.misc.measurements import Distance
@@ -58,8 +58,6 @@ class MeasurementTools:
 
     Parameters
     ----------
-    grpc_client : GrpcClient
-        gRPC client to use for the measurement tools.
     _internal_use : bool, optional
         Internal flag to prevent direct instantiation by users.
         This parameter is for internal use only.
@@ -76,14 +74,14 @@ class MeasurementTools:
     ``modeler.measurement_tools`` instead.
     """
 
-    def __init__(self, grpc_client: GrpcClient, _internal_use: bool = False):
+    def __init__(self, _internal_use: bool = False):
         """Initialize measurement tools class."""
         if not _internal_use:
             raise GeometryRuntimeError(
                 "MeasurementTools should not be instantiated directly. "
                 "Use 'modeler.measurement_tools' to access measurement tools."
             )
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @min_backend_version(24, 2, 0)
     def min_distance_between_objects(

--- a/src/ansys/geometry/core/tools/prepare_tools.py
+++ b/src/ansys/geometry/core/tools/prepare_tools.py
@@ -435,7 +435,6 @@ class PrepareTools:
 
         return LogoProblemArea(
             id=response.get("id"),
-            grpc_client=self._grpc_client,
             face_ids=response.get("face_ids"),
         )
 

--- a/src/ansys/geometry/core/tools/prepare_tools.py
+++ b/src/ansys/geometry/core/tools/prepare_tools.py
@@ -27,8 +27,8 @@ from typing import TYPE_CHECKING
 from pint import Quantity
 
 import ansys.geometry.core as pyansys_geom
-from ansys.geometry.core.connection import GrpcClient
 from ansys.geometry.core.connection.backend import BackendType
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.logger import LOG
 from ansys.geometry.core.math.frame import Frame
@@ -87,8 +87,6 @@ class PrepareTools:
 
     Parameters
     ----------
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     _internal_use : bool, optional
         Internal flag to prevent direct instantiation by users.
         This parameter is for internal use only.
@@ -104,14 +102,14 @@ class PrepareTools:
     ``modeler.prepare_tools`` instead.
     """
 
-    def __init__(self, grpc_client: GrpcClient, _internal_use: bool = False):
+    def __init__(self, _internal_use: bool = False):
         """Initialize Prepare Tools class."""
         if not _internal_use:
             raise GeometryRuntimeError(
                 "PrepareTools should not be instantiated directly. "
                 "Use 'modeler.prepare_tools' to access prepare tools."
             )
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @min_backend_version(25, 1, 0)
     def extract_volume_from_faces(
@@ -565,14 +563,12 @@ class PrepareTools:
                         helix.get("trimmed_curve").get("end"),
                         helix.get("trimmed_curve").get("interval"),
                         helix.get("trimmed_curve").get("length"),
-                        grpc_client=self._grpc_client,
                     ),
                     "edges": [
                         Edge(
                             edge.get("id"),
                             CurveType(edge.get("curve_type")),
                             get_bodies_from_ids(parent_design, [edge.get("parent_id")])[0],
-                            self._grpc_client,
                             edge.get("is_reversed"),
                         )
                         for edge in helix.get("edges")

--- a/src/ansys/geometry/core/tools/problem_areas.py
+++ b/src/ansys/geometry/core/tools/problem_areas.py
@@ -25,7 +25,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 import ansys.geometry.core as pyansys_geom
-from ansys.geometry.core.connection import GrpcClient
+from ansys.geometry.core.connection import ClientProvider
 from ansys.geometry.core.misc.auxiliary import (
     get_design_from_body,
     get_design_from_edge,
@@ -50,14 +50,12 @@ class ProblemArea:
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient):
+    def __init__(self, id: str):
         """Initialize a new instance of a problem area class."""
         self._id = id
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     @property
     def id(self) -> str:
@@ -101,15 +99,13 @@ class DuplicateFaceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     faces : list[Face]
         List of faces associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, faces: list["Face"]):
+    def __init__(self, id: str, faces: list["Face"]):
         """Initialize a new instance of the duplicate face problem areaclass."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.face import Face
 
@@ -155,15 +151,13 @@ class MissingFaceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
+    def __init__(self, id: str, edges: list["Edge"]):
         """Initialize a new instance of the missing face problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.edge import Edge
 
@@ -209,15 +203,13 @@ class InexactEdgeProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
+    def __init__(self, id: str, edges: list["Edge"]):
         """Initialize a new instance of the inexact edge problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.edge import Edge
 
@@ -264,15 +256,13 @@ class ExtraEdgeProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
+    def __init__(self, id: str, edges: list["Edge"]):
         """Initialize a new instance of the extra edge problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.edge import Edge
 
@@ -318,15 +308,13 @@ class ShortEdgeProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
+    def __init__(self, id: str, edges: list["Edge"]):
         """Initialize a new instance of the ``ShortEdgeProblemAreas`` class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.edge import Edge
 
@@ -372,15 +360,13 @@ class SmallFaceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     faces : list[Face]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, faces: list["Face"]):
+    def __init__(self, id: str, faces: list["Face"]):
         """Initialize a new instance of the small face problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.face import Face
 
@@ -426,15 +412,13 @@ class SplitEdgeProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     edges : list[Edge]
         List of edges associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, edges: list["Edge"]):
+    def __init__(self, id: str, edges: list["Edge"]):
         """Initialize a new instance of the split edge problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.edge import Edge
 
@@ -480,15 +464,13 @@ class StitchFaceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     bodies : list[Body]
         List of bodies associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, bodies: list["Body"]):
+    def __init__(self, id: str, bodies: list["Body"]):
         """Initialize a new instance of the stitch face problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         from ansys.geometry.core.designer.body import Body
 
@@ -534,15 +516,13 @@ class UnsimplifiedFaceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     faces : list[Face]
         List of faces associated with the design.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, faces: list["Face"]):
+    def __init__(self, id: str, faces: list["Face"]):
         """Initialize a new instance of the unsimplified face problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         self._faces = faces
 
@@ -583,15 +563,13 @@ class InterferenceProblemAreas(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     bodies : list[Body]
         List of bodies in the problem area.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, bodies: list["Body"]):
+    def __init__(self, id: str, bodies: list["Body"]):
         """Initialize a new instance of the interference problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         self._bodies = bodies
 
@@ -639,15 +617,13 @@ class LogoProblemArea(ProblemArea):
     ----------
     id : str
         Server-defined ID for the problem area.
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     faces : list[str]
         List of faces defining the logo problem area.
     """
 
-    def __init__(self, id: str, grpc_client: GrpcClient, face_ids: list[str]):
+    def __init__(self, id: str, face_ids: list[str]):
         """Initialize a new instance of the logo problem area class."""
-        super().__init__(id, grpc_client)
+        super().__init__(id)
 
         self._face_ids = face_ids
 

--- a/src/ansys/geometry/core/tools/problem_areas.py
+++ b/src/ansys/geometry/core/tools/problem_areas.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 import ansys.geometry.core as pyansys_geom
-from ansys.geometry.core.connection import ClientProvider
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.misc.auxiliary import (
     get_design_from_body,
     get_design_from_edge,

--- a/src/ansys/geometry/core/tools/repair_tools.py
+++ b/src/ansys/geometry/core/tools/repair_tools.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 import pint
 
 import ansys.geometry.core as pyansys_geometry
-from ansys.geometry.core.connection import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.misc.auxiliary import (
     get_bodies_from_ids,
@@ -69,8 +69,6 @@ class RepairTools:
 
     Parameters
     ----------
-    grpc_client : GrpcClient
-        Active supporting geometry service instance for design modeling.
     modeler : Modeler
         The parent modeler instance.
     _internal_use : bool, optional
@@ -89,7 +87,7 @@ class RepairTools:
     ``modeler.repair_tools`` instead.
     """
 
-    def __init__(self, grpc_client: GrpcClient, modeler: "Modeler", _internal_use: bool = False):
+    def __init__(self, modeler: "Modeler", _internal_use: bool = False):
         """Initialize a new instance of the ``RepairTools`` class."""
         if not _internal_use:
             raise GeometryRuntimeError(
@@ -97,7 +95,7 @@ class RepairTools:
                 "Use 'modeler.repair_tools' to access repair tools."
             )
         self._modeler = modeler
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
 
     def find_split_edges(
         self,
@@ -147,7 +145,6 @@ class RepairTools:
         return [
             SplitEdgeProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_edges_from_ids(parent_design, res.get("edges")),
             )
             for res in response.get("problems")
@@ -179,7 +176,6 @@ class RepairTools:
         return [
             ExtraEdgeProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_edges_from_ids(parent_design, res.get("edges")),
             )
             for res in response.get("problems")
@@ -212,7 +208,6 @@ class RepairTools:
         return [
             InexactEdgeProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_edges_from_ids(parent_design, res.get("edges")),
             )
             for res in response.get("problems")
@@ -254,7 +249,6 @@ class RepairTools:
         return [
             ShortEdgeProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_edges_from_ids(parent_design, res.get("edges")),
             )
             for res in response.get("problems")
@@ -286,7 +280,6 @@ class RepairTools:
         return [
             DuplicateFaceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_faces_from_ids(parent_design, res.get("faces")),
             )
             for res in response.get("problems")
@@ -340,7 +333,6 @@ class RepairTools:
         return [
             MissingFaceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_edges_from_ids(parent_design, res.get("edges")),
             )
             for res in response.get("problems")
@@ -394,7 +386,6 @@ class RepairTools:
         return [
             SmallFaceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_faces_from_ids(parent_design, res.get("faces")),
             )
             for res in response.get("problems")
@@ -442,7 +433,6 @@ class RepairTools:
         return [
             StitchFaceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_bodies_from_ids(parent_design, res.get("bodies")),
             )
             for res in response.get("problems")
@@ -477,7 +467,6 @@ class RepairTools:
         return [
             UnsimplifiedFaceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_faces_from_ids(parent_design, res.get("bodies")),
             )
             for res in response.get("problems")
@@ -527,7 +516,6 @@ class RepairTools:
         return [
             InterferenceProblemAreas(
                 f"{res.get('id')}",
-                self._grpc_client,
                 get_bodies_from_ids(parent_design, res.get("bodies")),
             )
             for res in response.get("problems")
@@ -877,9 +865,7 @@ class RepairTools:
         for inspect_geometry_result in inspect_geometry_results:
             body = get_bodies_from_ids(design, [inspect_geometry_result["body"]["id"]])
             issues = self.__create_issues_from_response(inspect_geometry_result.get("issues"))
-            inspect_result = InspectResult(
-                grpc_client=self._grpc_client, body=body[0], issues=issues
-            )
+            inspect_result = InspectResult(body=body[0], issues=issues)
             inspect_results.append(inspect_result)
 
         return inspect_results

--- a/src/ansys/geometry/core/tools/unsupported.py
+++ b/src/ansys/geometry/core/tools/unsupported.py
@@ -26,7 +26,7 @@ from enum import Enum, unique
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ansys.geometry.core.connection import GrpcClient
+from ansys.geometry.core.connection.client import ClientProvider
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.misc.auxiliary import (
     get_all_bodies_from_design,
@@ -65,8 +65,6 @@ class UnsupportedCommands:
 
     Parameters
     ----------
-    grpc_client : GrpcClient
-        gRPC client to use for the geometry commands.
     modeler : Modeler
         Modeler instance to use for the geometry commands.
     _internal_use : bool, optional
@@ -85,14 +83,14 @@ class UnsupportedCommands:
 
     """
 
-    def __init__(self, grpc_client: GrpcClient, modeler: "Modeler", _internal_use: bool = False):
+    def __init__(self, modeler: "Modeler", _internal_use: bool = False):
         """Initialize an instance of the ``UnsupportedCommands`` class."""
         if not _internal_use:
             raise GeometryRuntimeError(
                 "UnsupportedCommands should not be instantiated directly. "
                 "Use 'modeler.unsupported' to access unsupported commands."
             )
-        self._grpc_client = grpc_client
+        self._grpc_client = ClientProvider.get()
         self.__id_map = {}
         self.__modeler = modeler
         self.__current_design = modeler.get_active_design()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -224,10 +224,10 @@ def session_modeler(docker_instance, proto_version, transport_mode):
 
 @pytest.fixture(scope="function")
 def modeler(session_modeler: Modeler):
-    # Ensure the session client is the active ClientProvider for this test.
+    # Ensure the session modeler is the active ClientProvider for this test.
     from ansys.geometry.core.connection.client import ClientProvider
 
-    ClientProvider.set(session_modeler.client)
+    ClientProvider.set(session_modeler)
 
     # Yield the modeler
     yield session_modeler

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -223,6 +223,11 @@ def session_modeler(docker_instance, proto_version, transport_mode):
 
 @pytest.fixture(scope="function")
 def modeler(session_modeler: Modeler):
+    # Ensure the session client is the active ClientProvider for this test.
+    from ansys.geometry.core.connection.client import ClientProvider
+
+    ClientProvider.set(session_modeler.client)
+
     # Yield the modeler
     yield session_modeler
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -75,6 +75,7 @@ def test_client_through_channel(modeler: Modeler):
     assert "Connection" in client_repr
     assert target == client.target().lstrip("dns:///")
     assert client.channel
+    client.close()
 
 
 def test_client_close(client: GrpcClient):

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -162,6 +162,12 @@ def test_design_close_handles_close_rpc_error(modeler: Modeler):
         warning_spy.assert_any_call(f"Design {design.name} could not be closed. Error: boom.")
         warning_spy.assert_any_call("Ignoring response and assuming the design is closed.")
 
+    # The patch prevented the real close from reaching the server. Reset _is_active so that
+    # the real close RPC is sent now, otherwise the server keeps a zombie open design that
+    # corrupts subsequent tests in the full suite.
+    design._is_active = True
+    design.close()
+
 
 def test_design_download_legacy_backend(modeler: Modeler, tmp_path):
     """Test download() legacy backend path."""
@@ -270,7 +276,7 @@ def test_insert_file_v0_uses_upload_and_insert(modeler: Modeler, tmp_path):
     """Cover v0 insert_file branch that uploads then inserts by server path."""
     design = modeler.create_design("insert_v0_branch")
     file_location = tmp_path / "to_insert.scdocx"
-    component = Component("mock_component", None, modeler.client)
+    component = Component("mock_component", None)
 
     with (
         patch.object(design._grpc_client.services, "version", GeometryApiProtos.V0),
@@ -972,8 +978,8 @@ def test_design_selection(modeler: Modeler):
 
 def test_design_part(modeler: Modeler):
     """Test to validate the designer part id, name, and setter for components and bodies."""
-    body1 = MasterBody(id="body1", name="First Only Body", grpc_client=modeler.client)
-    body2 = MasterBody(id="body2", name="Second Body in Component", grpc_client=modeler.client)
+    body1 = MasterBody(id="body1", name="First Only Body")
+    body2 = MasterBody(id="body2", name="Second Body in Component")
     bodies = [body1]
     part = Part(id="IDPart", name="NamePart", components=[], bodies=bodies)
     masterpart = MasterComponent(id="PartMaster", name="Part Master", part=part)
@@ -5286,21 +5292,20 @@ def test_updating_design_from_tracker(modeler: Modeler):
     }
     # Adding needed bodies and components that are modified
     design.bodies.append(
-        MasterBody("body100", "ExistingBody", design._grpc_client, is_surface=False)
+        MasterBody("body100", "ExistingBody", is_surface=False)
     )
     design.components[2].components.append(
-        Component("SubComponent", design.components[2], design._grpc_client, preexisting_id="sub1")
+        Component("SubComponent", design.components[2], preexisting_id="sub1")
     )
     design.components[2].components[0].components.append(
         Component(
             "SubComponent2",
             design.components[2].components[0],
-            design._grpc_client,
             preexisting_id="sub2",
         )
     )
     design.components[2].components[0].bodies.append(
-        MasterBody("test", "SubComponentBody", design._grpc_client, is_surface=True)
+        MasterBody("test", "SubComponentBody", is_surface=True)
     )
     # Changing the ids of the bodies to match those in the tracker response
     design.components[1].bodies[0]._id = "7"
@@ -5316,7 +5321,7 @@ def test_updating_design_from_tracker(modeler: Modeler):
         "parent_id": "sub1",
     }
     design._find_and_update_body(body_info, design.components[2])
-    top_component = Component("TopComponent", design, design._grpc_client, preexisting_id="top1")
+    top_component = Component("TopComponent", design, preexisting_id="top1")
     design.components.append(top_component)
     body_info = {
         "id": "body1",

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -5292,9 +5292,7 @@ def test_updating_design_from_tracker(modeler: Modeler):
         ],
     }
     # Adding needed bodies and components that are modified
-    design.bodies.append(
-        MasterBody("body100", "ExistingBody", is_surface=False)
-    )
+    design.bodies.append(MasterBody("body100", "ExistingBody", is_surface=False))
     design.components[2].components.append(
         Component("SubComponent", design.components[2], preexisting_id="sub1")
     )

--- a/tests/integration/test_geometry_commands.py
+++ b/tests/integration/test_geometry_commands.py
@@ -1604,7 +1604,7 @@ def test_failures_to_extrude(modeler: Modeler):
     design = modeler.create_design("SimpleFaceDesign")
     surface = design.create_surface("SimpleFace", sketch)
     grpc_client = modeler.client
-    geometry_commands = GeometryCommands(grpc_client, _internal_use=True)
+    geometry_commands = GeometryCommands(_internal_use=True)
 
     # Failing to extrude single face
     results = geometry_commands.extrude_faces(

--- a/tests/integration/test_geometry_commands.py
+++ b/tests/integration/test_geometry_commands.py
@@ -1603,7 +1603,7 @@ def test_failures_to_extrude(modeler: Modeler):
     sketch.segment(p4, p1)
     design = modeler.create_design("SimpleFaceDesign")
     surface = design.create_surface("SimpleFace", sketch)
-    grpc_client = modeler.client
+
     geometry_commands = GeometryCommands(_internal_use=True)
 
     # Failing to extrude single face

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -347,31 +347,31 @@ def test_issue_2184_prevent_raw_instantiation_of_tools_and_commands():
     with pytest.raises(
         GeometryRuntimeError, match="UnsupportedCommands should not be instantiated directly"
     ):
-        UnsupportedCommands(None, None)
+        UnsupportedCommands(None)
 
     # Test RepairTools
     with pytest.raises(
         GeometryRuntimeError, match="RepairTools should not be instantiated directly"
     ):
-        RepairTools(None, None)
+        RepairTools(None)
 
     # Test PrepareTools
     with pytest.raises(
         GeometryRuntimeError, match="PrepareTools should not be instantiated directly"
     ):
-        PrepareTools(None)
+        PrepareTools()
 
     # Test MeasurementTools
     with pytest.raises(
         GeometryRuntimeError, match="MeasurementTools should not be instantiated directly"
     ):
-        MeasurementTools(None)
+        MeasurementTools()
 
     # Test GeometryCommands
     with pytest.raises(
         GeometryRuntimeError, match="GeometryCommands should not be instantiated directly"
     ):
-        GeometryCommands(None)
+        GeometryCommands()
 
 
 def test_issue_2074_rounding_math_errors():

--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -712,7 +712,6 @@ def test_problem_area_fix_not_implemented(modeler: Modeler):
 )
 def test_problem_area_fix_no_data(modeler: Modeler, problem_area_class, kwargs):
     """Test the fix method for various ProblemArea subclasses when required attributes are empty."""
-    grpc_client = modeler.client
     problem_area = problem_area_class(id="123", **kwargs)
     repair_message = problem_area.fix()
     assert isinstance(repair_message, RepairToolMessage)

--- a/tests/integration/test_repair_tools.py
+++ b/tests/integration/test_repair_tools.py
@@ -674,9 +674,8 @@ def test_design_import_check_geometry(modeler: Modeler):
 
 def test_repair_no_body(modeler: Modeler):
     """Test the repair method when body is None."""
-    grpc_client = modeler.client
     # Create an instance of InspectResult with body set to None
-    inspect_result = InspectResult(grpc_client=grpc_client, body=None, issues=[])
+    inspect_result = InspectResult(body=None, issues=[])
     # Call the repair method
     repair_message = inspect_result.repair()
     # Assert the returned RepairToolMessage
@@ -688,9 +687,8 @@ def test_repair_no_body(modeler: Modeler):
 
 def test_problem_area_fix_not_implemented(modeler: Modeler):
     """Test that the fix method in the ProblemArea base class raises NotImplementedError."""
-    grpc_client = modeler.client
     # Create an instance of ProblemArea
-    problem_area = ProblemArea(id="123", grpc_client=grpc_client)
+    problem_area = ProblemArea(id="123")
     # Assert that calling fix raises NotImplementedError
     with pytest.raises(
         NotImplementedError, match="Fix method is not implemented in the base class."
@@ -715,7 +713,7 @@ def test_problem_area_fix_not_implemented(modeler: Modeler):
 def test_problem_area_fix_no_data(modeler: Modeler, problem_area_class, kwargs):
     """Test the fix method for various ProblemArea subclasses when required attributes are empty."""
     grpc_client = modeler.client
-    problem_area = problem_area_class(id="123", grpc_client=grpc_client, **kwargs)
+    problem_area = problem_area_class(id="123", **kwargs)
     repair_message = problem_area.fix()
     assert isinstance(repair_message, RepairToolMessage)
     assert repair_message.success is False

--- a/tests/integration/test_trimmed_geometry.py
+++ b/tests/integration/test_trimmed_geometry.py
@@ -312,7 +312,6 @@ def test_trimmed_curve(modeler: Modeler):
         end=body.edges[0].shape.end,
         interval=body.edges[0].shape.interval,
         length=body.edges[0].shape.length,
-        grpc_client=modeler.client,  # Pass the gRPC client here
     )
     edge1 = TrimmedCurve(
         geometry=body.edges[1].shape.geometry,
@@ -320,7 +319,6 @@ def test_trimmed_curve(modeler: Modeler):
         end=body.edges[1].shape.end,
         interval=body.edges[1].shape.interval,
         length=body.edges[1].shape.length,
-        grpc_client=modeler.client,  # Pass the gRPC client here
     )
 
     edge2 = TrimmedCurve(
@@ -329,7 +327,6 @@ def test_trimmed_curve(modeler: Modeler):
         end=body.edges[4].shape.end,
         interval=body.edges[4].shape.interval,
         length=body.edges[4].shape.length,
-        grpc_client=modeler.client,  # Pass the gRPC client here
     )
 
     # Perform assertions and call intersect_curve

--- a/tests/integration/test_trimmed_geometry.py
+++ b/tests/integration/test_trimmed_geometry.py
@@ -303,8 +303,7 @@ def test_trimmed_curve(modeler: Modeler):
     """Test Trimmed Curve class"""
     design = modeler.create_design("trimmed_curve_edges")
     body = design.extrude_sketch("box", Sketch().box(Point2D([0, 0]), 1, 1), 1)
-    with pytest.raises(ValueError):
-        design.bodies[0].edges[0].shape.intersect_curve(design.bodies[0].edges[1].shape)
+
     # Retrieve edges and initialize TrimmedCurve objects with the gRPC client
     edge0 = TrimmedCurve(
         geometry=body.edges[0].shape.geometry,


### PR DESCRIPTION
## Description
Rather than passing a common GrpcClient object around, have one ContextVar that all classes can access.
This also provides client access to class that weren't previously able to make gRPC communication on their own.

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
