### PR TITLE
feat: drop Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
         target: ['', 'all']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
@@ -538,7 +538,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -598,7 +598,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.14']
+        python-version: ['3.12', '3.14']
     steps:
       - name: Login in Github Container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
     rev: ca620e0df5ae9a02b7b81a6e4c954894f043ce42 # frozen: v2.24.1
     hooks:
       - id: pyproject-fmt
-        additional_dependencies: [toml-fmt-common<1.3.3]
         args: [--keep-full-version]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/doc/changelog.d/2871.added.md
+++ b/doc/changelog.d/2871.added.md
@@ -1,0 +1,1 @@
+Drop Python 3.10 and 3.11

--- a/doc/source/assets.rst
+++ b/doc/source/assets.rst
@@ -18,17 +18,17 @@ If you lack an internet connection on your installation machine, you should inst
 by downloading the wheelhouse archive.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PyAnsys Geometry from scratch on Windows,
-Linux, and MacOS from Python 3.10 to 3.14. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.12 to 3.14. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with:
+For example, on Linux with Python 3.12, unzip the wheelhouse archive and install it with:
 
 .. code:: bash
 
-    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-latest-3.10.zip wheelhouse
+    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-latest-3.12.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you are on Windows with Python 3.10, unzip to a wheelhouse directory by running ``-d wheelhouse``
+If you are on Windows with Python 3.12, unzip to a wheelhouse directory by running ``-d wheelhouse``
 (this is required for unzipping to a directory on Windows) and install using the preceding command.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ def get_wheelhouse_assets_dictionary():
     """Auxiliary method to build the wheelhouse assets dictionary."""
     assets_context_os = ["Linux", "Windows", "MacOS"]
     assets_context_runners = ["ubuntu-latest", "windows-latest", "macos-latest"]
-    assets_context_python_versions = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    assets_context_python_versions = ["3.12", "3.13", "3.14"]
     if get_version_match(__version__) == "dev":
         # Try to retrieve the content three times before failing
         content = None

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -13,7 +13,7 @@ or from the `PyAnsys Geometry repository <https://github.com/ansys/pyansys-geome
 Package dependencies
 --------------------
 
-PyAnsys Geometry is supported on Python version 3.10 and later. As indicated in the
+PyAnsys Geometry is supported on Python version 3.12 and later. As indicated in the
 `Moving to require Python 3 <https://python3statement.github.io/>`_ statement,
 previous versions of Python are no longer supported.
 
@@ -87,17 +87,17 @@ archive for your corresponding machine architecture from the repository's `Relea
 <https://github.com/ansys/pyansys-geometry/releases>`_.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PyAnsys Geometry from scratch on Windows,
-Linux, and MacOS from Python 3.10 to 3.14. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.12 to 3.14. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with these commands:
+For example, on Linux with Python 3.12, unzip the wheelhouse archive and install it with these commands:
 
 .. code:: bash
 
-    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-3.10.zip wheelhouse
+    unzip ansys_geometry_core-v0.16.dev0-all-wheelhouse-ubuntu-3.12.zip wheelhouse
     pip install ansys-geometry-core -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you are on Windows with Python 3.10, unzip the wheelhouse archive to a wheelhouse directory
+If you are on Windows with Python 3.12, unzip the wheelhouse archive to a wheelhouse directory
 and then install using the same ``pip install`` command as in the preceding example.
 
 Consider installing using a virtual environment. For more information, see `Creation of virtual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,12 @@ license = "MIT"
 license-files = [ "LICENSE" ]
 maintainers = [ { name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" } ]
 authors = [ { name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" } ]
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -99,15 +97,13 @@ general-all = [
   "grpcio==1.78.1",
   "grpcio-health-checking==1.78.1",
   "matplotlib==3.10.9",
-  "numpy==2.2.6; python_version<'3.11'",
-  "numpy==2.4.0; python_version>='3.11'",
+  "numpy==2.4.0",
   "pint==0.25.2",
   "protobuf==6.33.6",
   "pygltflib==1.16.5",
   "pyvista[jupyter]==0.48.4",
   "requests==2.34.2",
-  "scipy==1.15.3; python_version<'3.11'",
-  "scipy==1.16.3; python_version>='3.11'",
+  "scipy==1.16.3",
   "semver==3.0.4",
   "six==1.17.0",
   "trame-vtk==2.10.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{tests310,tests311,tests312,tests313}{,-coverage},doc
+    style,{tests312,tests313,tests314}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -9,8 +9,6 @@ isolated_build_env = build
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    tests310: python3.10
-    tests311: python3.11
     tests312: python3.12
     tests313: python3.13
     tests314: python3.14


### PR DESCRIPTION
## Description
Dropping Python 3.10 and 3.11 as not required anymore
