### PR TITLE
fix: improve repair tool performance

### DIFF
--- a/doc/changelog.d/2885.fixed.md
+++ b/doc/changelog.d/2885.fixed.md
@@ -1,0 +1,1 @@
+Improve repair tool performance

--- a/src/ansys/geometry/core/misc/auxiliary.py
+++ b/src/ansys/geometry/core/misc/auxiliary.py
@@ -270,6 +270,33 @@ def get_edges_from_ids(design: "Design", edge_ids: list[str]) -> list["Edge"]:
     ]  # noqa: E501
 
 
+def build_edge_id_map(design: "Design") -> "dict[str, Edge]":
+    """Build a mapping of edge id to ``Edge`` object for all edges in a ``Design``.
+
+    Parameters
+    ----------
+    design : Design
+        Parent design to traverse.
+
+    Returns
+    -------
+    dict[str, Edge]
+        Dictionary mapping each edge id to its corresponding ``Edge`` object.
+
+    Notes
+    -----
+    This method traverses the design tree once and issues one gRPC call per body
+    (``body.edges``). Use this instead of repeated calls to ``get_edges_from_ids``
+    when you need to resolve multiple sets of edge ids from the same design, so that
+    the full traversal is paid only once.
+    """
+    return {
+        edge.id: edge
+        for body in __traverse_all_bodies(design)
+        for edge in body.edges
+    }
+
+
 def get_vertices_from_ids(design: "Design", vertex_ids: list[str]) -> list["Vertex"]:
     """Find the ``Vertex`` objects inside a ``Design`` from its ids.
 

--- a/src/ansys/geometry/core/misc/auxiliary.py
+++ b/src/ansys/geometry/core/misc/auxiliary.py
@@ -290,11 +290,7 @@ def build_edge_id_map(design: "Design") -> "dict[str, Edge]":
     when you need to resolve multiple sets of edge ids from the same design, so that
     the full traversal is paid only once.
     """
-    return {
-        edge.id: edge
-        for body in __traverse_all_bodies(design)
-        for edge in body.edges
-    }
+    return {edge.id: edge for body in __traverse_all_bodies(design) for edge in body.edges}
 
 
 def get_vertices_from_ids(design: "Design", vertex_ids: list[str]) -> list["Vertex"]:

--- a/src/ansys/geometry/core/tools/repair_tools.py
+++ b/src/ansys/geometry/core/tools/repair_tools.py
@@ -33,7 +33,6 @@ from ansys.geometry.core.misc.auxiliary import (
     build_edge_id_map,
     get_bodies_from_ids,
     get_design_from_body,
-    get_edges_from_ids,
     get_faces_from_ids,
 )
 from ansys.geometry.core.misc.checks import (
@@ -146,11 +145,12 @@ class RepairTools:
         )
 
         parent_design = get_design_from_body(bodies[0])
+        edge_map = build_edge_id_map(parent_design)
         return [
             SplitEdgeProblemAreas(
                 f"{res.get('id')}",
                 self._grpc_client,
-                get_edges_from_ids(parent_design, res.get("edges")),
+                [edge_map[eid] for eid in res.get("edges", []) if eid in edge_map],
             )
             for res in response.get("problems")
         ]
@@ -177,12 +177,13 @@ class RepairTools:
         body_ids = [body.id for body in bodies]
         response = self._grpc_client.services.repair_tools.find_extra_edges(selection=body_ids)
         parent_design = get_design_from_body(bodies[0])
+        edge_map = build_edge_id_map(parent_design)
 
         return [
             ExtraEdgeProblemAreas(
                 f"{res.get('id')}",
                 self._grpc_client,
-                get_edges_from_ids(parent_design, res.get("edges")),
+                [edge_map[eid] for eid in res.get("edges", []) if eid in edge_map],
             )
             for res in response.get("problems")
         ]
@@ -210,12 +211,13 @@ class RepairTools:
         response = self._grpc_client.services.repair_tools.find_inexact_edges(selection=body_ids)
 
         parent_design = get_design_from_body(bodies[0])
+        edge_map = build_edge_id_map(parent_design)
 
         return [
             InexactEdgeProblemAreas(
                 f"{res.get('id')}",
                 self._grpc_client,
-                get_edges_from_ids(parent_design, res.get("edges")),
+                [edge_map[eid] for eid in res.get("edges", []) if eid in edge_map],
             )
             for res in response.get("problems")
         ]
@@ -339,12 +341,13 @@ class RepairTools:
             backend_version=self._grpc_client.backend_version,
         )
         parent_design = get_design_from_body(bodies[0])
+        edge_map = build_edge_id_map(parent_design)
 
         return [
             MissingFaceProblemAreas(
                 f"{res.get('id')}",
                 self._grpc_client,
-                get_edges_from_ids(parent_design, res.get("edges")),
+                [edge_map[eid] for eid in res.get("edges", []) if eid in edge_map],
             )
             for res in response.get("problems")
         ]

--- a/src/ansys/geometry/core/tools/repair_tools.py
+++ b/src/ansys/geometry/core/tools/repair_tools.py
@@ -30,6 +30,7 @@ import ansys.geometry.core as pyansys_geometry
 from ansys.geometry.core.connection import GrpcClient
 from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.misc.auxiliary import (
+    build_edge_id_map,
     get_bodies_from_ids,
     get_design_from_body,
     get_edges_from_ids,
@@ -252,11 +253,12 @@ class RepairTools:
         )
 
         parent_design = get_design_from_body(bodies[0])
+        edge_map = build_edge_id_map(parent_design)
         return [
             ShortEdgeProblemAreas(
                 f"{res.get('id')}",
                 self._grpc_client,
-                get_edges_from_ids(parent_design, res.get("edges")),
+                [edge_map[eid] for eid in res.get("edges", []) if eid in edge_map],
             )
             for res in response.get("problems")
         ]


### PR DESCRIPTION
## Description
- use an edge map to improve search speed for get_edge_by_id
- improves all repair tools that need to fetch edges from response data

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
