### PR TITLE
feat: license error messaging improvements

### DIFF
--- a/doc/changelog.d/2886.added.md
+++ b/doc/changelog.d/2886.added.md
@@ -1,0 +1,1 @@
+License error messaging improvements

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -337,7 +337,7 @@ class GrpcClient:
         # Retrieve the backend information
         try:
             response = self._services.admin.get_backend()
-        except (GeometryExitedError, grpc.RpcError) as exc:
+        except GeometryExitedError as exc:
             raise GeometryRuntimeError(
                 "Failed to retrieve backend information. Check server logs for licensing and "
                 "connectivity.\nDefault server logs path is "

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -38,7 +38,7 @@ from ansys.geometry.core.connection.backend import BackendType
 import ansys.geometry.core.connection.defaults as pygeom_defaults
 from ansys.geometry.core.connection.docker_instance import LocalDockerInstance
 from ansys.geometry.core.connection.product_instance import ProductInstance
-from ansys.geometry.core.errors import GeometryRuntimeError
+from ansys.geometry.core.errors import GeometryExitedError, GeometryRuntimeError
 from ansys.geometry.core.logger import LOG, PyGeometryCustomAdapter
 from ansys.geometry.core.misc.checks import check_input_types
 from ansys.geometry.core.typing import Real
@@ -337,13 +337,15 @@ class GrpcClient:
         # Retrieve the backend information
         try:
             response = self._services.admin.get_backend()
-        except Exception:  # pragma: no cover
+        except GeometryExitedError:
+            raise
+        except grpc.RpcError as exc:
             raise GeometryRuntimeError(
                 "Failed to retrieve backend information. Check server logs for licensing and "
                 "connectivity.\nDefault server logs path is "
                 "%PUBLIC%/Documents/Ansys/GeometryService (Windows) or "
                 "/tmp/Ansys/GeometryService (Linux). "
-            )
+            ) from exc
 
         # Store the backend type and version
         self._backend_type = response.get("backend")

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -38,6 +38,7 @@ from ansys.geometry.core.connection.backend import BackendType
 import ansys.geometry.core.connection.defaults as pygeom_defaults
 from ansys.geometry.core.connection.docker_instance import LocalDockerInstance
 from ansys.geometry.core.connection.product_instance import ProductInstance
+from ansys.geometry.core.errors import GeometryRuntimeError
 from ansys.geometry.core.logger import LOG, PyGeometryCustomAdapter
 from ansys.geometry.core.misc.checks import check_input_types
 from ansys.geometry.core.typing import Real
@@ -334,7 +335,15 @@ class GrpcClient:
             self._log.log_to_file(filename=logging_file, level=logging_level)
 
         # Retrieve the backend information
-        response = self._services.admin.get_backend()
+        try:
+            response = self._services.admin.get_backend()
+        except Exception:  # pragma: no cover
+            raise GeometryRuntimeError(
+                "Failed to retrieve backend information. Check server logs for licensing and "
+                "connectivity.\nDefault server logs path is "
+                "%PUBLIC%/Documents/Ansys/GeometryService (Windows) or "
+                "/tmp/Ansys/GeometryService (Linux). "
+            )
 
         # Store the backend type and version
         self._backend_type = response.get("backend")

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -337,9 +337,7 @@ class GrpcClient:
         # Retrieve the backend information
         try:
             response = self._services.admin.get_backend()
-        except GeometryExitedError:
-            raise
-        except grpc.RpcError as exc:
+        except (GeometryExitedError, grpc.RpcError) as exc:
             raise GeometryRuntimeError(
                 "Failed to retrieve backend information. Check server logs for licensing and "
                 "connectivity.\nDefault server logs path is "

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -1102,6 +1102,11 @@ def launch_modeler_with_core_service(
         # Writing to the "Public" folder by default - no write permissions specifically required.
         server_logs_folder = Path(os.getenv("PUBLIC"), "Documents", "Ansys", "GeometryService")
         LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
+    elif server_logs_folder is None:
+        # Writing to the "/tmp/Ansys/GeometryService" folder by default - no write
+        # permissions specifically required.
+        server_logs_folder = Path("/tmp", "Ansys", "GeometryService")
+        LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
 
     return prepare_and_start_backend(
         BackendType.LINUX_SERVICE,

--- a/src/ansys/geometry/core/connection/launcher.py
+++ b/src/ansys/geometry/core/connection/launcher.py
@@ -25,6 +25,7 @@
 import logging
 import os
 from pathlib import Path
+import tempfile
 from typing import TYPE_CHECKING
 
 from ansys.geometry.core.connection.backend import ApiVersions, BackendType
@@ -1103,9 +1104,8 @@ def launch_modeler_with_core_service(
         server_logs_folder = Path(os.getenv("PUBLIC"), "Documents", "Ansys", "GeometryService")
         LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
     elif server_logs_folder is None:
-        # Writing to the "/tmp/Ansys/GeometryService" folder by default - no write
-        # permissions specifically required.
-        server_logs_folder = Path("/tmp", "Ansys", "GeometryService")
+        # Writing to the system temp folder by default - no write permissions specifically required.
+        server_logs_folder = Path(tempfile.gettempdir(), "Ansys", "GeometryService")
         LOG.info(f"Writing server logs to the default folder at {server_logs_folder}.")
 
     return prepare_and_start_backend(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -23,6 +23,7 @@
 import os
 import socket
 import tempfile
+from unittest.mock import MagicMock, patch
 
 from beartype.roar import BeartypeCallHintParamViolation
 import grpc
@@ -39,6 +40,7 @@ from ansys.geometry.core.connection.product_instance import (
     _manifest_path_provider,
     prepare_and_start_backend,
 )
+from ansys.geometry.core.errors import GeometryExitedError, GeometryRuntimeError
 
 
 def test_wait_until_healthy():
@@ -339,3 +341,64 @@ def test_get_common_env(
         # Assert environment variables are correctly set
         for key, value in expected_env.items():
             assert env[key] == value
+
+
+def test_grpc_client_get_backend_failure():
+    """Test that GrpcClient raises GeometryRuntimeError when get_backend() raises grpc.RpcError.
+
+    Mocks wait_until_healthy and _GRPCServices so that the admin.get_backend()
+    call raises a grpc.RpcError, verifying it is wrapped in GeometryRuntimeError with chaining.
+    """
+    mock_channel = MagicMock()
+
+    mock_admin = MagicMock()
+    mock_admin.get_backend.side_effect = grpc.RpcError("connection refused")
+
+    mock_services = MagicMock()
+    mock_services.admin = mock_admin
+
+    with (
+        patch(
+            "ansys.geometry.core.connection.client.wait_until_healthy",
+            return_value=mock_channel,
+        ),
+        patch(
+            "ansys.geometry.core.connection.client._GRPCServices",
+            return_value=mock_services,
+        ),
+        pytest.raises(GeometryRuntimeError, match="Failed to retrieve backend information") as exc,
+    ):
+        GrpcClient(host="localhost", port=50051)
+
+    assert exc.value.__cause__ is not None
+
+
+def test_grpc_client_get_backend_geometry_exited_error():
+    """Test that GeometryExitedError from get_backend() propagates unchanged.
+
+    Verifies that a GeometryExitedError raised by the @protect_grpc wrapper
+    is not masked by the get_backend() exception handler.
+    """
+    mock_channel = MagicMock()
+    original_error = GeometryExitedError("Geometry service has exited.")
+
+    mock_admin = MagicMock()
+    mock_admin.get_backend.side_effect = original_error
+
+    mock_services = MagicMock()
+    mock_services.admin = mock_admin
+
+    with (
+        patch(
+            "ansys.geometry.core.connection.client.wait_until_healthy",
+            return_value=mock_channel,
+        ),
+        patch(
+            "ansys.geometry.core.connection.client._GRPCServices",
+            return_value=mock_services,
+        ),
+        pytest.raises(GeometryExitedError) as exc,
+    ):
+        GrpcClient(host="localhost", port=50051)
+
+    assert exc.value is original_error

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -344,15 +344,16 @@ def test_get_common_env(
 
 
 def test_grpc_client_get_backend_failure():
-    """Test that GrpcClient raises GeometryRuntimeError when get_backend() raises grpc.RpcError.
+    """Test that GrpcClient raises GeometryRuntimeError when get_backend() fails.
 
     Mocks wait_until_healthy and _GRPCServices so that the admin.get_backend()
     call raises a grpc.RpcError, verifying it is wrapped in GeometryRuntimeError with chaining.
+    Both grpc.RpcError and GeometryExitedError are caught by the same handler.
     """
     mock_channel = MagicMock()
 
     mock_admin = MagicMock()
-    mock_admin.get_backend.side_effect = grpc.RpcError("connection refused")
+    mock_admin.get_backend.side_effect = GeometryExitedError("connection refused")
 
     mock_services = MagicMock()
     mock_services.admin = mock_admin
@@ -371,34 +372,3 @@ def test_grpc_client_get_backend_failure():
         GrpcClient(host="localhost", port=50051)
 
     assert exc.value.__cause__ is not None
-
-
-def test_grpc_client_get_backend_geometry_exited_error():
-    """Test that GeometryExitedError from get_backend() propagates unchanged.
-
-    Verifies that a GeometryExitedError raised by the @protect_grpc wrapper
-    is not masked by the get_backend() exception handler.
-    """
-    mock_channel = MagicMock()
-    original_error = GeometryExitedError("Geometry service has exited.")
-
-    mock_admin = MagicMock()
-    mock_admin.get_backend.side_effect = original_error
-
-    mock_services = MagicMock()
-    mock_services.admin = mock_admin
-
-    with (
-        patch(
-            "ansys.geometry.core.connection.client.wait_until_healthy",
-            return_value=mock_channel,
-        ),
-        patch(
-            "ansys.geometry.core.connection.client._GRPCServices",
-            return_value=mock_services,
-        ),
-        pytest.raises(GeometryExitedError) as exc,
-    ):
-        GrpcClient(host="localhost", port=50051)
-
-    assert exc.value is original_error


### PR DESCRIPTION
## Description
- added linux default server logs location
- direct users to server logs folder and to check licensing on failure to get_backend

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
