### PR TITLE
fix: reset root part fields on design update

### DIFF
--- a/doc/changelog.d/2945.fixed.md
+++ b/doc/changelog.d/2945.fixed.md
@@ -1,0 +1,1 @@
+Reset root part fields on design update

--- a/src/ansys/geometry/core/designer/design.py
+++ b/src/ansys/geometry/core/designer/design.py
@@ -1594,7 +1594,11 @@ class Design(Component):
         self._clear_cached_bodies()
         self._materials = []
         self._named_selections = {}
-        self._coordinate_systems = {}
+        self._coordinate_systems = []
+        self._datum_planes = []
+        self._design_curves = []
+        self._design_points = []
+        self._beam_profiles = {}
 
         # Read the existing design
         self.__read_existing_design()

--- a/tests/_incompatible_tests.yml
+++ b/tests/_incompatible_tests.yml
@@ -154,6 +154,8 @@ backends:
       - tests/integration/test_unsupported.py::test_import_lightweight_and_convert
       # SC color tones import added in 27.1
       - tests/integration/test_design_import.py::test_importing_with_sc_colors
+      # Root part CS not loaded until 27.1
+      - tests/integration/test_design.py::test_coordinate_systems_on_design_refresh
 
   - version: "24.2"
     incompatible_tests:
@@ -303,6 +305,8 @@ backends:
       - tests/integration/test_design.py::test_design_download_v1_api
       # SC color tones import added in 27.1
       - tests/integration/test_design_import.py::test_importing_with_sc_colors
+      # Root part CS not loaded until 27.1
+      - tests/integration/test_design.py::test_coordinate_systems_on_design_refresh
 
   - version: "25.1"
     incompatible_tests:
@@ -420,6 +424,8 @@ backends:
       - tests/integration/test_design.py::test_design_download_v1_api
       # SC color tones import added in 27.1
       - tests/integration/test_design_import.py::test_importing_with_sc_colors
+      # Root part CS not loaded until 27.1
+      - tests/integration/test_design.py::test_coordinate_systems_on_design_refresh
 
   - version: "25.2"
     incompatible_tests:
@@ -488,6 +494,8 @@ backends:
       - tests/integration/test_design.py::test_set_component_name
       # SC color tones import added in 27.1
       - tests/integration/test_design_import.py::test_importing_with_sc_colors
+      # Root part CS not loaded until 27.1
+      - tests/integration/test_design.py::test_coordinate_systems_on_design_refresh
 
   - version: "26.1"
     incompatible_tests:
@@ -511,3 +519,5 @@ backends:
       - tests/integration/test_design.py::test_set_component_name
       # SC color tones import added in 27.1
       - tests/integration/test_design_import.py::test_importing_with_sc_colors
+      # Root part CS not loaded until 27.1
+      - tests/integration/test_design.py::test_coordinate_systems_on_design_refresh

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1587,10 +1587,6 @@ def test_coordinate_system_creation(modeler: Modeler):
     nested_comp.create_coordinate_system("CompCS1", frame1)
     nested_comp.create_coordinate_system("CompCS2", frame2)
 
-    # Call design.update_design_inplace() to ensure that the coordinate systems are reset/updated
-    assert len(design.coordinate_systems) == 1
-    design._update_design_inplace()
-
     # Check that the coordinate systems are available
     assert len(design.coordinate_systems) == 1
     assert all(entry.id is not None for entry in design.coordinate_systems)
@@ -1648,6 +1644,23 @@ def test_coordinate_system_creation(modeler: Modeler):
     assert "  Frame X-direction    : " in nested_comp_cs1_str
     assert "  Frame Y-direction    : " in nested_comp_cs1_str
     assert "  Frame Z-direction    : " in nested_comp_cs1_str
+
+
+def test_coordinate_systems_on_design_refresh(modeler: Modeler):
+    """Test for verifying the correct behavior of ``CoordinateSystem`` after a design refresh."""
+    # Create your design on the server side
+    design = modeler.create_design("CoordinateSystem_Test")
+    frame1 = Frame(
+        Point3D([10, 200, 3000], UNITS.mm), UnitVector3D([1, 1, 0]), UnitVector3D([1, -1, 0])
+    )
+
+    # Create the CoordinateSystem
+    design.create_coordinate_system("DesignCS1", frame1)
+    assert len(design.coordinate_systems) == 1
+
+    # Call the refresh method on the design and check that the coordinate system is still there
+    design._update_design_inplace()
+    assert len(design.coordinate_systems) == 1
 
 
 def test_search_component_by_name(modeler: Modeler):

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -1587,7 +1587,11 @@ def test_coordinate_system_creation(modeler: Modeler):
     nested_comp.create_coordinate_system("CompCS1", frame1)
     nested_comp.create_coordinate_system("CompCS2", frame2)
 
-    # Check that the named selections are available
+    # Call design.update_design_inplace() to ensure that the coordinate systems are reset/updated
+    assert len(design.coordinate_systems) == 1
+    design._update_design_inplace()
+
+    # Check that the coordinate systems are available
     assert len(design.coordinate_systems) == 1
     assert all(entry.id is not None for entry in design.coordinate_systems)
     design_cs = design.coordinate_systems[0]


### PR DESCRIPTION
## Description
Some fields were not being reset correctly on design._update_design_inplace().

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
