### PR TITLE
fix: fill_edge_loops bug on deleted edge reference

### DIFF
--- a/doc/changelog.d/2974.fixed.md
+++ b/doc/changelog.d/2974.fixed.md
@@ -1,0 +1,1 @@
+Fill_edge_loops bug on deleted edge reference

--- a/src/ansys/geometry/core/designer/geometry_commands.py
+++ b/src/ansys/geometry/core/designer/geometry_commands.py
@@ -625,6 +625,11 @@ class GeometryCommands:
         """
         from ansys.geometry.core.designer.face import FaceLoop
 
+        design = (
+            get_design_from_edge(loops[0].edges[0])
+            if isinstance(loops, list)
+            else get_design_from_edge(loops.edges[0])
+        )
         loops: list[FaceLoop] = loops if isinstance(loops, list) else [loops]
         check_type_all_elements_in_iterable(loops, FaceLoop)
 
@@ -637,7 +642,6 @@ class GeometryCommands:
         )
 
         if result.get("success"):
-            design = get_design_from_edge(loops[0].edges[0])
             if pyansys_geo.USE_TRACKER_TO_UPDATE_DESIGN:
                 design._update_from_tracker(result.get("tracked_response"))
             else:

--- a/src/ansys/geometry/core/designer/geometry_commands.py
+++ b/src/ansys/geometry/core/designer/geometry_commands.py
@@ -625,12 +625,8 @@ class GeometryCommands:
         """
         from ansys.geometry.core.designer.face import FaceLoop
 
-        design = (
-            get_design_from_edge(loops[0].edges[0])
-            if isinstance(loops, list)
-            else get_design_from_edge(loops.edges[0])
-        )
         loops: list[FaceLoop] = loops if isinstance(loops, list) else [loops]
+        design = get_design_from_edge(loops[0].edges[0])
         check_type_all_elements_in_iterable(loops, FaceLoop)
 
         for loop in loops:


### PR DESCRIPTION
## Description
Changed to get design reference before the referenced edge gets deleted.

## Issue linked
Reported on TFS.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
