### PR TITLE
docs: add port warning when connecting to existing session

### DIFF
--- a/doc/changelog.d/2983.documentation.md
+++ b/doc/changelog.d/2983.documentation.md
@@ -1,0 +1,1 @@
+Add port warning when connecting to existing session

--- a/doc/source/getting_started/existing/index.rst
+++ b/doc/source/getting_started/existing/index.rst
@@ -37,7 +37,7 @@ Note that your local port number might differ from the one shown in the precedin
     to lower values. You should change the value of ``ANSRV_GEO_PORT``
     to use a port such as ``700``, instead of ``50051``.
 
-    You can check the restricted port ranges with ``netsh int ipv4 show excludedportrange protocol=tcp`` 
+    You can check the restricted port ranges with ``netsh int ipv4 show excludedportrange protocol=tcp``
     in a Windows command prompt.
 
 .. note::

--- a/doc/source/getting_started/existing/index.rst
+++ b/doc/source/getting_started/existing/index.rst
@@ -31,6 +31,15 @@ From Python, establish a connection to the existing client session by creating a
 If no error messages are received, your connection is established successfully.
 Note that your local port number might differ from the one shown in the preceding code.
 
+.. warning::
+    When running a Windows Docker container, certain high-value ports might be restricted
+    from its use. This means that the port exposed by the container has to be set
+    to lower values. You should change the value of ``ANSRV_GEO_PORT``
+    to use a port such as ``700``, instead of ``50051``.
+
+    You can check the restricted port ranges with ``netsh int ipv4 show excludedportrange protocol=tcp`` 
+    in a Windows command prompt.
+
 .. note::
 
     Starting from PyAnsys Geometry 0.14, the ``transport_mode`` parameter is required.


### PR DESCRIPTION
## Description
As title says. In response to an issue I had with Docker Desktop installed with Windows Container support blocking the usual ports.

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
