### PR TITLE
fix: leverage test group dependency on releasing with ``build-linux-container`` stage

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -928,6 +928,7 @@ jobs:
           pytest-extra-args: "--use-existing-service=yes"
           checkout: false
           randomize: true
+          group-dependencies-name: "tests"
           skip-install: true
 
       - name: "Compressing Linux Dockerfile"

--- a/doc/changelog.d/3049.fixed.md
+++ b/doc/changelog.d/3049.fixed.md
@@ -1,0 +1,1 @@
+Leverage test grooup dependency on releasing with \`\`build-linux-container\`\` stage

--- a/doc/changelog.d/3049.fixed.md
+++ b/doc/changelog.d/3049.fixed.md
@@ -1,1 +1,1 @@
-Leverage test group dependency on releasing with \`\`build-linux-container\`\` stage
+Leverage test grooup dependency on releasing with \`\`build-linux-container\`\` stage

--- a/doc/changelog.d/3049.fixed.md
+++ b/doc/changelog.d/3049.fixed.md
@@ -1,1 +1,1 @@
-Leverage test grooup dependency on releasing with \`\`build-linux-container\`\` stage
+Leverage test group dependency on releasing with \`\`build-linux-container\`\` stage


### PR DESCRIPTION
Coming from a  hotfix on v0.17.0 release

https://github.com/ansys/pyansys-geometry/commit/17e47b8ed720a33c4ea5c170bb4a19ef5a3efa9f