### PR TITLE
fix: clean up temp files on process close

### DIFF
--- a/doc/changelog.d/3050.fixed.md
+++ b/doc/changelog.d/3050.fixed.md
@@ -1,0 +1,1 @@
+Clean up temp files on process close

--- a/src/ansys/geometry/core/connection/client.py
+++ b/src/ansys/geometry/core/connection/client.py
@@ -481,7 +481,6 @@ class GrpcClient:
                 self.services.admin.close()
             except Exception as err:
                 self.log.debug(f"Shutdown call failed. Temporary files may be stranded: {err}")
-            finally:
                 self._product_instance.close()
 
         self._closed = True


### PR DESCRIPTION
## Description
Only do force shutdown if the graceful shutdown fails. We need the graceful shutdown to do tempfile cleanup.

## Issue linked
Various 27R1 TFS defects

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate unit tests.
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved to the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
