### PR TITLE
fix: Discovery add-in manifest path

### DIFF
--- a/doc/changelog.d/3052.fixed.md
+++ b/doc/changelog.d/3052.fixed.md
@@ -1,1 +1,1 @@
-Discovery addin path
+Discovery add-in manifest path

--- a/doc/changelog.d/3052.fixed.md
+++ b/doc/changelog.d/3052.fixed.md
@@ -1,0 +1,1 @@
+Discovery addin path

--- a/src/ansys/geometry/core/connection/product_instance.py
+++ b/src/ansys/geometry/core/connection/product_instance.py
@@ -681,9 +681,12 @@ def _manifest_path_provider(
                 "Specified manifest file's path does not exist. Taking install default path."
             )
 
-    # Default manifest path
+    # Starting with 2027 R1, Discovery's add-ins are installed under its product folder.
+    def_addins_folder = (
+        Path(DISCOVERY_FOLDER, ADDINS_SUBFOLDER) if version >= 271 else Path(ADDINS_SUBFOLDER)
+    )
     def_manifest_path = Path(
-        available_installations[version], ADDINS_SUBFOLDER, BACKEND_SUBFOLDER, MANIFEST_FILENAME
+        available_installations[version], def_addins_folder, BACKEND_SUBFOLDER, MANIFEST_FILENAME
     )
 
     if def_manifest_path.exists():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -184,6 +184,24 @@ def test_manifest_path_exists(tmp_path):
     assert result == str(manifest_path)
 
 
+@pytest.mark.parametrize(
+    ("version", "relative_manifest_path"),
+    [
+        (261, ("Addins", "ApiServer", "Presentation.ApiServerAddIn.Manifest.xml")),
+        (271, ("Discovery", "Addins", "ApiServer", "Presentation.ApiServerAddIn.Manifest.xml")),
+    ],
+)
+def test_default_manifest_path(version, relative_manifest_path, tmp_path):
+    """Test default manifests use the version-specific installation layout."""
+    manifest_path = tmp_path.joinpath(*relative_manifest_path)
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.touch()
+
+    result = _manifest_path_provider(version, {version: str(tmp_path)})
+
+    assert result == manifest_path.as_posix()
+
+
 def test_manifest_path_does_not_exist(tmp_path, caplog):
     """Test when the manifest path does not exist and handle RuntimeError."""
 


### PR DESCRIPTION
## Description
The ApiServer addin was moved in 271

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate unit tests.
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved to the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
