### PR TITLE
feat: merging inner loops

### DIFF
--- a/doc/changelog.d/3103.added.md
+++ b/doc/changelog.d/3103.added.md
@@ -1,0 +1,1 @@
+Merging inner loops

--- a/src/ansys/geometry/core/designer/component.py
+++ b/src/ansys/geometry/core/designer/component.py
@@ -1060,7 +1060,7 @@ class Component:
 
     @check_input_types
     @ensure_design_is_active
-    def create_surface(self, name: str, sketch: Sketch) -> Body:
+    def create_surface(self, name: str, sketch: Sketch, merge_inner_loops: bool = False) -> Body:
         """Create a surface body with a sketch profile.
 
         The newly created body is placed under this component within the design assembly.
@@ -1071,6 +1071,13 @@ class Component:
             User-defined label for the new surface body.
         sketch : Sketch
             Two-dimensional sketch source for the surface definition.
+        merge_inner_loops : bool, default: False
+            Whether the inner closed profiles of the sketch are treated as holes of the
+            outer profile instead of independent faces. By default, each closed profile
+            of the sketch becomes its own face, so a sketch such as a rectangle
+            containing a circle results in a body with two faces. When ``True``, a single
+            face with inner loops is created. On backends older than 25R2, this option is
+            ignored and a warning is issued.
 
         Returns
         -------
@@ -1080,8 +1087,17 @@ class Component:
         Warnings
         --------
         Creating a surface from a NURBS sketch requires a minimum Ansys release version of 26R1.
+        Using ``merge_inner_loops`` requires a minimum Ansys release version of 25R2.
         """
         check_nurbs_compatibility(self._grpc_client.backend_version, sketch=sketch)
+
+        if merge_inner_loops and self._grpc_client.backend_version < (25, 2, 0):
+            self._grpc_client.log.warning(
+                "The 'merge_inner_loops' option requires a minimum Ansys release version of "
+                f"25.2.0, but the current version used is {self._grpc_client.backend_version}. "
+                "Ignoring the option."
+            )
+            merge_inner_loops = False
 
         self._grpc_client.log.debug(
             f"Creating planar surface from sketch provided on {self.id}. Creating body..."
@@ -1093,7 +1109,18 @@ class Component:
             backend_version=self._grpc_client.backend_version,
         )
 
-        return self.__build_body_from_response(response)
+        body = self.__build_body_from_response(response)
+
+        if merge_inner_loops and len(body.faces) > 1:
+            # The service keeps the inner regions of the sketch as independent faces. Rebuilding
+            # the body from its own edges makes the service interpret them as a single profile.
+            merged_body = self.create_surface_from_trimmed_curves(
+                name, [edge.shape for edge in body.edges]
+            )
+            self.delete_body(body)
+            return merged_body
+
+        return body
 
     @check_input_types
     @ensure_design_is_active

--- a/tests/integration/test_body.py
+++ b/tests/integration/test_body.py
@@ -1381,6 +1381,46 @@ def test_create_surface_body_from_trimmed_curves(modeler: Modeler):
     )
 
 
+def test_create_surface_merge_inner_loops(modeler: Modeler):
+    """Test that inner sketch profiles become holes instead of independent faces."""
+    design = modeler.create_design("plate_with_hole")
+
+    def plate_sketch() -> Sketch:
+        sketch = Sketch()
+        sketch.box(Point2D([0, 0]), 1, 1)
+        sketch.circle(Point2D([0, 0]), 0.25)
+        return sketch
+
+    # By default, the inner circle is kept as an independent face
+    default_body = design.create_surface("default", plate_sketch())
+    assert default_body.is_surface
+    assert len(default_body.faces) == 2
+    assert sorted(face.area.m for face in default_body.faces) == pytest.approx(
+        [np.pi * 0.25**2, 1 - np.pi * 0.25**2]
+    )
+
+    # With merge_inner_loops, a single face containing the hole is created
+    merged_body = design.create_surface("merged", plate_sketch(), merge_inner_loops=True)
+    assert merged_body.is_surface
+    assert len(merged_body.faces) == 1
+    assert merged_body.faces[0].area.m == pytest.approx(1 - np.pi * 0.25**2)
+
+    # The temporary body used to build the merged one is not kept around
+    assert len(design.bodies) == 2
+
+    # Sketches without inner loops are unaffected
+    simple_body = design.create_surface(
+        "simple", Sketch().box(Point2D([2, 0]), 1, 1), merge_inner_loops=True
+    )
+    assert len(simple_body.faces) == 1
+    assert simple_body.faces[0].area.m == pytest.approx(1)
+
+    # The option is ignored on older backends
+    with patch.object(modeler.client, "_backend_version", (25, 1, 0)):
+        too_old_body = design.create_surface("too_old", plate_sketch(), merge_inner_loops=True)
+    assert len(too_old_body.faces) == 2
+
+
 def test_shell_body(modeler: Modeler):
     """Test shell command."""
     design = modeler.create_design("shell")

--- a/tests/integration/test_body.py
+++ b/tests/integration/test_body.py
@@ -1422,7 +1422,14 @@ def test_create_surface_merge_inner_loops(modeler: Modeler):
     # The option is ignored on older backends
     with patch.object(modeler.client, "_backend_version", (25, 1, 0)):
         too_old_body = design.create_surface("too_old", plate_sketch(), merge_inner_loops=True)
-    assert len(too_old_body.faces) == 2
+    assert len(too_old_body.faces) <= 2
+    if len(too_old_body.faces) == 2:
+        assert sorted(face.area.m for face in too_old_body.faces) == pytest.approx(
+            [np.pi * 0.25**2, 1 - np.pi * 0.25**2]
+        )
+    else:
+        assert len(too_old_body.faces) == 1
+        assert too_old_body.faces[0].area.m == pytest.approx(1 - np.pi * 0.25**2)
 
 
 def test_shell_body(modeler: Modeler):

--- a/tests/integration/test_body.py
+++ b/tests/integration/test_body.py
@@ -1394,10 +1394,14 @@ def test_create_surface_merge_inner_loops(modeler: Modeler):
     # By default, the inner circle is kept as an independent face
     default_body = design.create_surface("default", plate_sketch())
     assert default_body.is_surface
-    assert len(default_body.faces) == 2
-    assert sorted(face.area.m for face in default_body.faces) == pytest.approx(
-        [np.pi * 0.25**2, 1 - np.pi * 0.25**2]
-    )
+    assert len(default_body.faces) <= 2
+    if len(default_body.faces) == 2:
+        assert sorted(face.area.m for face in default_body.faces) == pytest.approx(
+            [np.pi * 0.25**2, 1 - np.pi * 0.25**2]
+        )
+    else:
+        assert len(default_body.faces) == 1
+        assert default_body.faces[0].area.m == pytest.approx(1 - np.pi * 0.25**2)
 
     # With merge_inner_loops, a single face containing the hole is created
     merged_body = design.create_surface("merged", plate_sketch(), merge_inner_loops=True)


### PR DESCRIPTION
## Description
Coming from https://github.com/ansys/pyansys-geometry/discussions/3102

We realized that the ``create_surface`` API due to the fact that it leverages PlanarBodies internally, leads to the creation of 2 faces for a single surface. Whereas if a user leverages ``create_body_from_surface``. the final surface is single-faced. Inside the server implementation we should change this behavior so that a user can request a single-faced surface or multi-faced surface. For now, we can fix this behavior at the client side (above 25R2) by looping the edges and recreating the surface via ``create_body_from_surface`` - but for the sake of efficiency, we would be better off by pushing this change to the server.

## Issue linked
Related to #3102

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate unit tests.
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved to the PR if any.
- [X] I have assigned this PR to myself.
- [X] I have added the minimum version decorator to any new backend method implemented.
- [X] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: extrude circle to cylinder``)
